### PR TITLE
Add Rx.js and hateoas helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "json": "github:systemjs/plugin-json@^0.1.2",
       "jsonpath": "npm:jsonpath@^0.2.6",
       "lodash": "npm:lodash@^4.13.1",
+      "rxjs": "npm:rxjs@^5.0.0-beta.10",
       "scss": "github:KevCJones/plugin-scss@^0.2.11",
       "ui-router-extras": "npm:ui-router-extras@^0.0.14"
     },

--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -21,7 +21,7 @@ class CartController{
 
   loadCart(){
     this.cartService.get()
-      .then((data) => {
+      .subscribe((data) => {
         this.$log.info('cart', data);
       });
   }

--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -31,10 +31,10 @@ class CheckoutController{
 
   testRequests(){
     this.designationsService.createSearch('a')
-      .then((id) => {
+      .subscribe((id) => {
         this.$log.info('search id', id);
         this.designationsService.getSearchResults(id, 1)
-          .then((response) => {
+          .subscribe((response) => {
             this.$log.info('search page', response.data);
           });
       });

--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -1,5 +1,6 @@
 import 'babel/external-helpers';
 import angular from 'angular';
+import 'rxjs/add/operator/mergeMap';
 
 import appConfig from 'common/app.config';
 
@@ -31,12 +32,12 @@ class CheckoutController{
 
   testRequests(){
     this.designationsService.createSearch('a')
-      .subscribe((id) => {
+      .mergeMap((id) => {
         this.$log.info('search id', id);
-        this.designationsService.getSearchResults(id, 1)
-          .subscribe((response) => {
-            this.$log.info('search page', response.data);
-          });
+        return this.designationsService.getSearchResults(id, 1);
+      })
+      .subscribe((data) => {
+        this.$log.info('search page', data);
       });
   }
 

--- a/src/app/checkout/step-1/step-1.component.js
+++ b/src/app/checkout/step-1/step-1.component.js
@@ -1,4 +1,6 @@
 import angular from 'angular';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/forkJoin';
 import find from 'lodash/find';
 
 import cartService from 'common/services/api/cart.service';
@@ -10,9 +12,8 @@ let componentName = 'checkoutStep1';
 class Step1Controller{
 
   /* @ngInject */
-  constructor($q, cartService){
+  constructor(cartService){
     this.cartService = cartService;
-    this.$q = $q;
 
     this.init();
   }
@@ -25,32 +26,35 @@ class Step1Controller{
     if(details.email){
       requests.push(this.cartService.addEmail(details.email));
     }
-    this.$q.all(requests).then(() => {
-      //go to Step 2
-    });
+    Observable.forkJoin(requests)
+      .subscribe(() => {
+        //go to Step 2
+      });
   }
 
   refreshRegions(country){
     country = find(this.countries, function(v){ return v['display-name'].toUpperCase() === country; });
     if(!country){ return; }
 
-    this.cartService.getGeographies.regions(country.links[0].uri).then((response) => {
-      this.regions = response;
-    });
+    this.cartService.getGeographies.regions(country.links[0].uri)
+      .subscribe((data) => {
+        this.regions = data;
+      });
   }
 
   init(){
     this.cartService.getDonorDetails()
-      .then((data) => {
+      .subscribe((data) => {
         if(data['donor-type'] === ''){
           data['donor-type'] = 'individual';
         }
         this.donorDetails = data;
       });
 
-    this.cartService.getGeographies.countries().then((response) => {
-      this.countries = response;
-    });
+    this.cartService.getGeographies.countries()
+      .subscribe((data) => {
+        this.countries = data;
+      });
   }
 }
 

--- a/src/app/main/main.component.js
+++ b/src/app/main/main.component.js
@@ -26,7 +26,7 @@ class MainController{
 
   addItemToCart(id){
     this.cartService.addItem(id)
-      .then((response) => {
+      .subscribe((response) => {
         this.$log.info('Added new item', response.data);
       });
   }

--- a/src/common/services/api.spec.js
+++ b/src/common/services/api.spec.js
@@ -17,8 +17,8 @@ describe('api service', function() {
       self.apiService.http({
         method: 'GET',
         path: 'test'
-      }).then((response) => {
-        expect(response.data).toEqual('success');
+      }).subscribe((data) => {
+        expect(data).toEqual('success');
       });
       self.$httpBackend.flush();
     });

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import JSONPath from 'jsonpath';
 import keyBy from 'lodash/keyBy';
 import map from 'lodash/map';
+import 'rxjs/add/operator/map';
 
 import apiService from '../api.service';
 
@@ -27,28 +28,29 @@ function cart(apiService){
 
   function get() {
     return apiService.get({
-      path: ['carts', apiService.scope, 'default'],
-      params: {
-        zoom: 'total,' +
-        'lineitems:element:item:price,' +
-        'lineitems:element:item:amount,' +
-        'lineitems:element:item:definition,' +
-        'lineitems:element:total,' +
-        'lineitems:element:item:definition'
-      }
-    }).then((response) => {
-      let lineItems = JSONPath.query(response.data, '$.._lineitems.._element.*');
-      return {
-        items: map(lineItems, (item) => {
-          return {
-            name: JSONPath.query(item, '$.._item.._definition.*["display-name"]')[0],
-            details: keyBy(JSONPath.query(item, '$.._item.._definition..details')[0], 'name'),
-            listPrice: JSONPath.query(item, '$.._item.._price..["list-price"].*')[0],
-            purchasePrice: JSONPath.query(item, '$.._item.._price..["purchase-price"].*')[0]
-          };
-        })
-      };
-    });
+        path: ['carts', apiService.scope, 'default'],
+        params: {
+          zoom: 'total,' +
+          'lineitems:element:item:price,' +
+          'lineitems:element:item:amount,' +
+          'lineitems:element:item:definition,' +
+          'lineitems:element:total,' +
+          'lineitems:element:item:definition'
+        }
+      })
+      .map((data) => {
+        let lineItems = JSONPath.query(data, '$.._lineitems.._element.*');
+        return {
+          items: map(lineItems, (item) => {
+            return {
+              name: JSONPath.query(item, '$.._item.._definition.*["display-name"]')[0],
+              details: keyBy(JSONPath.query(item, '$.._item.._definition..details')[0], 'name'),
+              listPrice: JSONPath.query(item, '$.._item.._price..["list-price"].*')[0],
+              purchasePrice: JSONPath.query(item, '$.._item.._price..["purchase-price"].*')[0]
+            };
+          })
+        };
+      });
   }
 
   function addItem(itemId){
@@ -82,9 +84,9 @@ function cart(apiService){
           zoom: 'order:donordetails,order:emailinfo:email'
         }
       })
-      .then((response) => {
-        let details = JSONPath.query(response.data, '$.._order.._donordetails.*')[0];
-        let email = JSONPath.query(response.data, '$.._order.._emailinfo.*')[0];
+      .map((data) => {
+        let details = JSONPath.query(data, '$.._order.._donordetails.*')[0];
+        let email = JSONPath.query(data, '$.._order.._emailinfo.*')[0];
         details.email = email ? email['_email'][0]['email'] : '';
         return details;
       });
@@ -106,28 +108,28 @@ function cart(apiService){
 
   function getGeographiesCountries(){
     return apiService.get({
-      path: ['geographies', apiService.scope, 'countries'],
-      params: {
-        zoom: 'element'
-      },
-      cache: true
-    })
-    .then((response) => {
-      return response.data._element;
-    });
+        path: ['geographies', apiService.scope, 'countries'],
+        params: {
+          zoom: 'element'
+        },
+        cache: true
+      })
+      .map((data) => {
+        return data._element;
+      });
   }
 
   function getGeographiesRegions(uri){
     return apiService.get({
-      path: uri,
-      params: {
-        zoom: 'element'
-      },
-      cache: true
-    })
-    .then((response) => {
-      return response.data._element;
-    });
+        path: uri,
+        params: {
+          zoom: 'element'
+        },
+        cache: true
+      })
+      .map((data) => {
+        return data._element;
+      });
   }
 }
 

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -14,16 +14,16 @@ function designations(apiService){
 
   function createSearch(keywords){
     return apiService.post({
-      path: ['searches', apiService.scope, 'keywords', 'items'],
-      params: {
-        FollowLocation: true
-      },
-      data: {
-        keywords: keywords,
-        'page-size': 1
-      }
-    })
-      .then((response) => {
+        path: ['searches', apiService.scope, 'keywords', 'items'],
+        params: {
+          FollowLocation: true
+        },
+        data: {
+          keywords: keywords,
+          'page-size': 1
+        }
+      })
+      .subscribe((response) => {
         return response.data.self.uri.split('/').pop();
       });
   }

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import 'rxjs/add/operator/map';
 
 import apiService from '../api.service';
 
@@ -23,8 +24,8 @@ function designations(apiService){
           'page-size': 1
         }
       })
-      .subscribe((response) => {
-        return response.data.self.uri.split('/').pop();
+      .map((data) => {
+        return data.self.uri.split('/').pop();
       });
   }
 

--- a/src/common/services/hateoasHelper.service.js
+++ b/src/common/services/hateoasHelper.service.js
@@ -1,0 +1,43 @@
+import angular from 'angular';
+import find from 'lodash/find';
+import get from 'lodash/get';
+import isArray from 'lodash/isArray';
+import mapValues from 'lodash/mapValues';
+import values from 'lodash/values';
+
+let serviceName = 'hateoasHelperService';
+
+class HateoasHelper {
+
+  getLink(response, relationshipName){
+    let linkObj = find(response.links, {rel: relationshipName});
+    return linkObj ? linkObj.uri : undefined;
+  }
+
+  getElement(response, path){
+    if(isArray(path)){
+      path = path.join('[0]._');
+    }
+    let objectPath = '_' + path + '[0]';
+    return get(response, objectPath);
+  }
+
+  serializeZoom(zoom){
+    return values(zoom).join();
+  }
+
+  mapZoomElements(data, zoom){
+    let dataObj = mapValues(zoom, (zoomString) => {
+      return this.getElement(data, zoomString.split(':'));
+    });
+    dataObj.rawData = data;
+    return dataObj;
+  }
+
+}
+
+export default angular
+  .module(serviceName, [
+
+  ])
+  .service(serviceName, HateoasHelper);

--- a/src/common/services/hateoasHelper.spec.js
+++ b/src/common/services/hateoasHelper.spec.js
@@ -1,0 +1,162 @@
+import angular from 'angular';
+import 'angular-mocks';
+import module from './hateoasHelper.service';
+
+describe('HATEOAS helper service', function() {
+  beforeEach(angular.mock.module(module.name));
+  let self = {};
+
+  beforeEach(inject(function(hateoasHelperService) {
+    self.hateoasHelperService = hateoasHelperService;
+
+    self.cartResponse = {
+      "self": {
+        "type": "elasticpath.carts.cart",
+        "uri": "/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform",
+        "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform"
+      },
+      "links": [
+        {
+          "rel": "lineitems",
+          "rev": "cart",
+          "type": "elasticpath.collections.links",
+          "uri": "/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=/lineitems",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=/lineitems"
+        },
+        {
+          "rel": "discount",
+          "type": "elasticpath.discounts.discount",
+          "uri": "/discounts/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/discounts/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga="
+        },
+        {
+          "rel": "order",
+          "rev": "cart",
+          "type": "elasticpath.orders.order",
+          "uri": "/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq="
+        },
+        {
+          "rel": "appliedpromotions",
+          "type": "elasticpath.collections.links",
+          "uri": "/promotions/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=/applied",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/promotions/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=/applied"
+        },
+        {
+          "rel": "ratetotals",
+          "type": "elasticpath.ratetotals.rate-total",
+          "uri": "/ratetotals/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/ratetotals/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga="
+        },
+        {
+          "rel": "total",
+          "rev": "cart",
+          "type": "elasticpath.totals.total",
+          "uri": "/totals/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=",
+          "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/totals/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga="
+        }
+      ],
+      "_order": [
+        {
+          "_paymentmethodinfo": [
+            {
+              "_bankaccountform": [
+                {
+                  "self": {
+                    "type": "training.bankaccounts.bank-account",
+                    "uri": "/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form",
+                    "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form"
+                  },
+                  "links": [
+                    {
+                      "rel": "createbankaccountfororderaction",
+                      "uri": "/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=",
+                      "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq="
+                    }
+                  ],
+                  "account-type": "",
+                  "bank-name": "",
+                  "display-account-number": "",
+                  "encrypted-account-number": "",
+                  "routing-number": ""
+                }
+              ],
+              "_creditcardform": [
+                {
+                  "self": {
+                    "type": "cru.creditcards.named-credit-card",
+                    "uri": "/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form",
+                    "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form"
+                  },
+                  "links": [
+                    {
+                      "rel": "createcreditcardfororderaction",
+                      "uri": "/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=",
+                      "href": "http://give-ep-cortex-uat.aws.cru.org/cortex/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq="
+                    }
+                  ],
+                  "card-number": "",
+                  "card-type": "",
+                  "cardholder-name": "",
+                  "expiry-month": "",
+                  "expiry-year": "",
+                  "issue-number": 0,
+                  "start-month": "",
+                  "start-year": ""
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "total-quantity": 0
+    };
+
+    self.zoom = {
+      bankaccountform: 'order:paymentmethodinfo:bankaccountform',
+      creditcardform: 'order:paymentmethodinfo:creditcardform'
+    };
+
+  }));
+
+  it('to be defined', () => {
+    expect(self.hateoasHelperService).toBeDefined();
+  });
+
+  describe('getLink', () => {
+    it('should find the uri for a relationship', () => {
+      expect(self.hateoasHelperService.getLink(self.cartResponse, 'order')).toEqual('/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=');
+    });
+    it('should return undefined for an unknown relationship', () => {
+      expect(self.hateoasHelperService.getLink(self.cartResponse, 'nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getElement', () => {
+    it('should get the object specified by a path array', () => {
+      expect(self.hateoasHelperService.getElement(self.cartResponse, ['order', 'paymentmethodinfo', 'bankaccountform'])).toEqual(self.cartResponse._order[0]._paymentmethodinfo[0]._bankaccountform[0]);
+    });
+    it('should get the object specified by a path string', () => {
+      expect(self.hateoasHelperService.getElement(self.cartResponse, 'order')).toEqual(self.cartResponse._order[0]);
+    });
+    it('should return undefined for an unknown element', () => {
+      expect(self.hateoasHelperService.getElement(self.cartResponse, ['order', 'nonexistent'])).toBeUndefined();
+    });
+  });
+
+  describe('serializeZoom', () => {
+    it('should join all zoom strings with a comma', () => {
+      expect(self.hateoasHelperService.serializeZoom(self.zoom)).toEqual('order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform');
+    });
+  });
+
+  describe('mapZoomElements', () => {
+    it('should use the zoom keys as keys and find the corresponding objects', () => {
+      expect(self.hateoasHelperService.mapZoomElements(self.cartResponse, self.zoom)).toEqual({
+        bankaccountform: self.cartResponse._order[0]._paymentmethodinfo[0]._bankaccountform[0],
+        creditcardform: self.cartResponse._order[0]._paymentmethodinfo[0]._creditcardform[0],
+        rawData: self.cartResponse
+      });
+    });
+  });
+});

--- a/system.config.js
+++ b/system.config.js
@@ -71,6 +71,7 @@ System.config({
     "json": "github:systemjs/plugin-json@0.1.2",
     "jsonpath": "npm:jsonpath@0.2.6",
     "lodash": "npm:lodash@4.13.1",
+    "rxjs": "npm:rxjs@5.0.0-beta.10",
     "scss": "github:KevCJones/plugin-scss@0.2.11",
     "systemjs/plugin-css": "github:systemjs/plugin-css@0.1.21",
     "ui-router-extras": "npm:ui-router-extras@0.0.14",
@@ -810,6 +811,11 @@ System.config({
     "npm:ripemd160@1.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:rxjs@5.0.0-beta.10": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "symbol-observable": "npm:symbol-observable@1.0.1"
     },
     "npm:sass.js@0.9.10": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",


### PR DESCRIPTION
@adammeyer let me know your thoughts. I was trying to make it easier to grab and follow links through the hateoas API. Let me know if you think we should use JSONPath more. Maybe we should make some wrappers/shortcuts for it so we don't have to add the `[0]` everywhere and make it easier to grab links. I've also added a little bit to `payment` branch but not a whole lot yet.
- Add Rx.js
- Use Observable map() and subscribe() instead of promise then()
- Use forkJoin() instead of $q.all()
- Change apiService to class
- Have http helper methods change the method and pass the object on
- Add zoom and followLocation options to api config
- Map response object to zoom object
- Add hateoasHelpers service to pull links and  data out of response object using paths and zoom