### PR TITLE
Rename apiService to cortexApiService.

### DIFF
--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -17,13 +17,13 @@ function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProv
     },
     vars: {
       development: {
-        apiUrl: 'https://cortex-gateway-stage.cru.org/cortex'
+        apiUrl: 'https://cortex-gateway-stage.cru.org'
       },
       staging: {
-        apiUrl: 'https://cortex-gateway-stage.cru.org/cortex'
+        apiUrl: 'https://cortex-gateway-stage.cru.org'
       },
       production: {
-        apiUrl: 'https://cortex-gateway.cru.org/cortex'
+        apiUrl: 'https://cortex-gateway.cru.org'
       }
     }
   });

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -2,12 +2,12 @@ import angular from 'angular';
 import JSONPath from 'jsonpath';
 import 'rxjs/add/operator/map';
 
-import apiService from '../api.service';
+import cortexApiService from '../cortexApi.service';
 
 let serviceName = 'cartService';
 
 /*@ngInject*/
-function cart(apiService){
+function cart(cortexApiService){
   return {
     get: get,
     addItem: addItem,
@@ -23,8 +23,8 @@ function cart(apiService){
   };
 
   function get() {
-    return apiService.get({
-      path: ['carts', apiService.scope, 'default'],
+    return cortexApiService.get({
+      path: ['carts', cortexApiService.scope, 'default'],
       params: {
         zoom: 'lineitems:element:availability,lineitems:element:item:code,lineitems:element:item:definition,lineitems:element:rate,lineitems:element:total,ratetotals:element,total,lineitems:element:itemfields'
       }
@@ -121,14 +121,14 @@ function cart(apiService){
   function addItem(id, data){
     data.quantity = 1;
 
-    return apiService.post({
-      path: ['itemfieldlineitems', 'items', apiService.scope, id],
+    return cortexApiService.post({
+      path: ['itemfieldlineitems', 'items', cortexApiService.scope, id],
       data: data
     });
   }
 
   function updateItem(uri){
-    return apiService.post({
+    return cortexApiService.post({
       path: uri,
       data: {
         quantity: 1
@@ -137,14 +137,14 @@ function cart(apiService){
   }
 
   function deleteItem(uri){
-    return apiService.delete({
+    return cortexApiService.delete({
       path: uri
     });
   }
 
   function getDonorDetails(){
-    return apiService.get({
-        path: ['carts', apiService.scope, 'default'],
+    return cortexApiService.get({
+        path: ['carts', cortexApiService.scope, 'default'],
         params: {
           zoom: 'order:donordetails,order:emailinfo:email'
         }
@@ -181,22 +181,22 @@ function cart(apiService){
       details['mailing-address']['region'] = '';
     }
 
-    return apiService.put({
+    return cortexApiService.put({
       path: uri,
       data: details
     });
   }
 
   function addEmail(email){
-    return apiService.post({
-      path: ['emails', apiService.scope],
+    return cortexApiService.post({
+      path: ['emails', cortexApiService.scope],
       data: {email: email}
     });
   }
 
   function getGeographiesCountries(){
-    return apiService.get({
-        path: ['geographies', apiService.scope, 'countries'],
+    return cortexApiService.get({
+        path: ['geographies', cortexApiService.scope, 'countries'],
         params: {
           zoom: 'element'
         },
@@ -208,7 +208,7 @@ function cart(apiService){
   }
 
   function getGeographiesRegions(uri){
-    return apiService.get({
+    return cortexApiService.get({
         path: uri,
         params: {
           zoom: 'element'
@@ -223,6 +223,6 @@ function cart(apiService){
 
 export default angular
   .module(serviceName, [
-    apiService.name
+    cortexApiService.name
   ])
   .factory(serviceName, cart);

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -3,12 +3,12 @@ import JSONPath from 'jsonpath';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/toPromise';
 
-import apiService from '../api.service';
+import cortexApiService from '../cortexApi.service';
 
 let serviceName = 'designationsService';
 
 /*@ngInject*/
-function designations(apiService){
+function designations(cortexApiService){
 
   return {
     createSearch: createSearch,
@@ -17,8 +17,8 @@ function designations(apiService){
   };
 
   function createSearch(keywords){
-    return apiService.post({
-        path: ['searches', apiService.scope, 'keywords', 'items'],
+    return cortexApiService.post({
+        path: ['searches', cortexApiService.scope, 'keywords', 'items'],
         params: {
           FollowLocation: true
         },
@@ -33,8 +33,8 @@ function designations(apiService){
   }
 
   function getSearchResults(id, page){
-    return apiService.get({
-      path: ['searches', apiService.scope, 'keywords', 'items', id, 'pages', page],
+    return cortexApiService.get({
+      path: ['searches', cortexApiService.scope, 'keywords', 'items', id, 'pages', page],
       params: {
         zoom: 'element:definition'
       }
@@ -42,15 +42,15 @@ function designations(apiService){
   }
 
   function productLookup(query, selectQuery){
-    var httpRequest = selectQuery ? apiService.post({
+    var httpRequest = selectQuery ? cortexApiService.post({
       path: query,
       data: { },
       followLocation: true,
       params: {
         zoom: 'code,definition,definition:options:element:selector:choice:description,definition:options:element:selector:chosen:description,definition:options:element:selector:choice:selectaction'
       }
-    }) : apiService.post({
-      path: ['lookups', apiService.scope, 'items'],
+    }) : cortexApiService.post({
+      path: ['lookups', cortexApiService.scope, 'items'],
       followLocation: true,
       data: {
         code: query
@@ -90,6 +90,6 @@ function designations(apiService){
 
 export default angular
   .module(serviceName, [
-    apiService.name
+    cortexApiService.name
   ])
   .factory(serviceName, designations);

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -3,7 +3,7 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/observable/of';
 
-import apiService from '../api.service';
+import cortexApiService from '../cortexApi.service';
 import hateoasHelperService from 'common/services/hateoasHelper.service';
 
 let serviceName = 'orderService';
@@ -11,8 +11,8 @@ let serviceName = 'orderService';
 class Order{
 
   /*@ngInject*/
-  constructor(apiService, hateoasHelperService){
-    this.apiService = apiService;
+  constructor(cortexApiService, hateoasHelperService){
+    this.cortexApiService = cortexApiService;
     this.hateoasHelperService = hateoasHelperService;
   }
 
@@ -20,8 +20,8 @@ class Order{
     if(this.paymentTypes){
       return Observable.of(this.paymentTypes);
     }else{
-      return this.apiService.get({
-          path: ['carts', this.apiService.scope, 'default'],
+      return this.cortexApiService.get({
+          path: ['carts', this.cortexApiService.scope, 'default'],
           zoom: {
             bankAccount: 'order:paymentmethodinfo:bankaccountform',
             creditCard: 'order:paymentmethodinfo:creditcardform'
@@ -36,7 +36,7 @@ class Order{
   addBankAccountPayment(paymentInfo){
     return this.getCurrentPayments()
       .mergeMap((data) => {
-        return this.apiService.post({
+        return this.cortexApiService.post({
             path: this.hateoasHelperService.getLink(data.bankAccount, 'createbankaccountfororderaction'),
             data: paymentInfo,
             followLocation: true
@@ -52,7 +52,7 @@ class Order{
 
 export default angular
   .module(serviceName, [
-    apiService.name,
+    cortexApiService.name,
     hateoasHelperService.name
   ])
   .service(serviceName, Order);

--- a/src/common/services/cortexApi.service.js
+++ b/src/common/services/cortexApi.service.js
@@ -10,9 +10,9 @@ import { cortexScope } from 'common/app.constants';
 import appConfig from 'common/app.config';
 import hateoasHelperService from 'common/services/hateoasHelper.service';
 
-let serviceName = 'apiService';
+let serviceName = 'cortexApiService';
 
-class Api {
+class CortexApi {
 
   /*@ngInject*/
   constructor($http, envService, hateoasHelperService){
@@ -33,7 +33,7 @@ class Api {
 
     return Observable.from(this.$http({
         method: config.method,
-        url: this.envService.read('apiUrl') + this.serializePath(config.path),
+        url: this.envService.read('apiUrl') + '/cortex' + this.serializePath(config.path),
         params: config.params,
         data: config.data,
         withCredentials: true
@@ -81,4 +81,4 @@ export default angular
     appConfig.name,
     hateoasHelperService.name
   ])
-  .service(serviceName, Api);
+  .service(serviceName, CortexApi);

--- a/src/common/services/cortexApi.spec.js
+++ b/src/common/services/cortexApi.spec.js
@@ -1,20 +1,20 @@
 import angular from 'angular';
 import 'angular-mocks';
-import module from './api.service';
+import module from './cortexApi.service';
 
-describe('api service', function() {
+describe('cortex api service', function() {
   beforeEach(angular.mock.module(module.name));
   var self = {};
 
-  beforeEach(inject(function(apiService, $httpBackend) {
-    self.apiService = apiService;
+  beforeEach(inject(function(cortexApiService, $httpBackend) {
+    self.cortexApiService = cortexApiService;
     self.$httpBackend = $httpBackend;
   }));
 
   describe('http', function() {
     it('should send a simple request', function() {
       self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/test').respond(200, 'success');
-      self.apiService.http({
+      self.cortexApiService.http({
         method: 'GET',
         path: 'test'
       }).subscribe((data) => {


### PR DESCRIPTION
This PR drops the cortex namespace from the default apiUrl and adds it to the cortex specific API calls.

Login process requires issuing api calls to the apiUrl + '/cas/' + path. A casApiService will be added to facilitate this.