### PR TITLE
Validate bank account number for min digits

### DIFF
--- a/src/app/checkout/step-2/bank-account/bank-account.component.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.component.js
@@ -44,7 +44,8 @@ class BankAccountController{
     this.bankPaymentForm.routingNumber.$validators.routingNumber = this.paymentValidationService.validateRoutingNumber();
 
     this.bankPaymentForm.accountNumber.$parsers.push(this.paymentValidationService.stripNonDigits);
-    this.bankPaymentForm.accountNumber.$validators.length = number => toString(number).length <= 17;
+    this.bankPaymentForm.accountNumber.$validators.minlength = number => toString(number).length >= 2;
+    this.bankPaymentForm.accountNumber.$validators.maxlength = number => toString(number).length <= 17;
     this.bankPaymentForm.accountNumber.$viewChangeListeners.push(() => {
       // Revalidate verifyAccountNumber after accountNumber changes
       this.bankPaymentForm.verifyAccountNumber.$validate();

--- a/src/app/checkout/step-2/bank-account/bank-account.spec.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.spec.js
@@ -78,7 +78,7 @@ describe('checkout', () => {
           expect(size(self.controller.bankPaymentForm.routingNumber.$validators)).toEqual(2);
 
           expect(size(self.controller.bankPaymentForm.accountNumber.$parsers)).toEqual(1);
-          expect(size(self.controller.bankPaymentForm.accountNumber.$validators)).toEqual(1);
+          expect(size(self.controller.bankPaymentForm.accountNumber.$validators)).toEqual(2);
           expect(size(self.controller.bankPaymentForm.accountNumber.$viewChangeListeners)).toEqual(1);
 
           expect(size(self.controller.bankPaymentForm.verifyAccountNumber.$parsers)).toEqual(1);

--- a/src/app/checkout/step-2/bank-account/bank-account.tpl.html
+++ b/src/app/checkout/step-2/bank-account/bank-account.tpl.html
@@ -50,7 +50,8 @@
           <input type="text" class="form-control  form-control-subtle" name="accountNumber" ng-model="$ctrl.bankPayment.accountNumber" required>
           <div role="alert" ng-messages="$ctrl.bankPaymentForm.accountNumber.$error" ng-if="($ctrl.bankPaymentForm.accountNumber | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter an account number</div>
-            <div class="help-block" ng-message="length" translate>This account number must contain 17 or fewer digits</div>
+            <div class="help-block" ng-message="minlength" translate>This account number must contain 2 or more digits</div>
+            <div class="help-block" ng-message="maxlength" translate>This account number must contain 17 or fewer digits</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The user may have only entered spaces or dashes or something else.