### PR TITLE
Add devpub.cru.org to list of staging domains

### DIFF
--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -12,7 +12,7 @@ function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProv
   envServiceProvider.config({
     domains: {
       development: ['localhost'],
-      staging: ['stage.give.cru.org', 'devpub.cru.org'],
+      staging: ['stage.give.cru.org', 'devpub.cru.org', 'uatpub.cru.org'],
       production: ['give.cru.org']
     },
     vars: {

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -12,7 +12,7 @@ function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProv
   envServiceProvider.config({
     domains: {
       development: ['localhost'],
-      staging: ['stage.give.cru.org'],
+      staging: ['stage.give.cru.org', 'devpub.cru.org'],
       production: ['give.cru.org']
     },
     vars: {


### PR DESCRIPTION
@adammeyer Should this point at the staging apiUrl? I guess at this point it doesn't matter much as the development and staging urls are the same. If it is not listed, it will default to development.