### PR TITLE
Add tests to paymentValidationService

### DIFF
--- a/src/common/services/paymentValidation.service.js
+++ b/src/common/services/paymentValidation.service.js
@@ -12,7 +12,13 @@ class PaymentValidation {
 
   /*@ngInject*/
   constructor(envService){
-    if(envService.is('production')){
+    this.envService = envService;
+
+    this.initializeCcp();
+  }
+
+  initializeCcp(){
+    if(this.envService.is('production')){
       ccp.initialize(ccpKey);
     }else{
       ccp.initialize(ccpStagingKey);

--- a/src/common/services/paymentValidation.spec.js
+++ b/src/common/services/paymentValidation.spec.js
@@ -1,27 +1,40 @@
 import angular from 'angular';
 import 'angular-mocks';
 import module from './paymentValidation.service.js';
+import 'angular-environment';
 
 describe('payment validation service', () => {
   beforeEach(angular.mock.module(module.name));
   var self = {};
 
-  beforeEach(inject(function(paymentValidationService) {
+  beforeEach(inject((envService, paymentValidationService) => {
+    self.envService = envService;
     self.paymentValidationService = paymentValidationService;
   }));
 
-  it('to be defined', () => {
-    expect(self.paymentValidationService).toBeDefined();
+  describe('ccp initialization', () => {
+    it('should be initialized correctly in staging', () => {
+      self.envService.set('staging');
+      self.paymentValidationService.initializeCcp();
+      // Test that ccp doesn't throw a key undefined error
+      expect(self.paymentValidationService.validateCardNumber()('4111 1111 1111 1111')).toEqual(true);
+    });
+    it('should be initialized correctly in production', () => {
+      self.envService.set('production');
+      self.paymentValidationService.initializeCcp();
+      // Test that ccp doesn't throw a key undefined error
+      expect(self.paymentValidationService.validateCardNumber()('4111 1111 1111 1111')).toEqual(true);
+    });
   });
 
   describe('validateRoutingNumber', () => {
-    it('to return true for valid routing numbers', () => {
+    it('should return true for valid routing numbers', () => {
       expect(self.paymentValidationService.validateRoutingNumber()(267084131)).toEqual(true);
       expect(self.paymentValidationService.validateRoutingNumber()('021300420')).toEqual(true);
       expect(self.paymentValidationService.validateRoutingNumber()('043318092')).toEqual(true);
       expect(self.paymentValidationService.validateRoutingNumber()(122038251)).toEqual(true);
     });
-    it('to return false for invalid routing numbers', () => {
+    it('should return false for invalid routing numbers', () => {
       expect(self.paymentValidationService.validateRoutingNumber()(267084132)).toEqual(false);
       expect(self.paymentValidationService.validateRoutingNumber()(121300420)).toEqual(false);
       expect(self.paymentValidationService.validateRoutingNumber()(943318092)).toEqual(false);
@@ -38,27 +51,66 @@ describe('payment validation service', () => {
   });
 
   describe('validateCardNumber', () => {
-    it('to return false for an invalid number', () => {
+    it('should return false for an invalid number', () => {
       expect(self.paymentValidationService.validateCardNumber()('5800000000000000')).toEqual(false);
-    });
-    it('to return true for a valid VISA number', () => {
+      expect(self.paymentValidationService.validateCardNumber()(null)).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()(undefined)).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('abcdabcdabcdabcd')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('4111111')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('411')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('4111111111111111111111')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('5800000000000000')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('411111111111111')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('4111111111111112')).toEqual(false);
+      expect(self.paymentValidationService.validateCardNumber()('5111111111111111')).toEqual(false);
       expect(self.paymentValidationService.validateCardNumber()('4111 1111 1111 1111')).toEqual(true);
     });
   });
 
+  describe('getCardNumberErrorMessage', () => {
+    it('should return an error for an empty card number', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage(null)).toEqual('Card number is blank');
+      expect(self.paymentValidationService.getCardNumberErrorMessage(undefined)).toEqual('Card number is blank');
+      expect(self.paymentValidationService.getCardNumberErrorMessage('')).toEqual('Card number is blank');
+      //Non-digits are stripped
+      expect(self.paymentValidationService.getCardNumberErrorMessage('abcdabcdabcdabcd')).toEqual('Card number is blank');
+    });
+    it('should return an error if the card number is too short', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('4111111')).toEqual('Card number is too short');
+      expect(self.paymentValidationService.getCardNumberErrorMessage('411')).toEqual('Card number is too short');
+    });
+    it('should return an error if the card number is too long', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('4111111111111111111111')).toEqual('Card number is too long');
+    });
+    it('should return an error for a valid number that doesn\'t match a card issuer', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('5800000000000000')).toEqual('5800000000000000 has not been issued by a card issuer this system accepts');
+    });
+    it('should return an error if the card number is the wrong length for a card issuer', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('411111111111111')).toEqual('411111111111111 is an invalid visa number; it should have 13 or 16 digits (this number has 15)');
+    });
+    it('should return an error if the card number is invalid', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('4111111111111112')).toEqual('Card number is invalid; at least one digit is wrong');
+      expect(self.paymentValidationService.getCardNumberErrorMessage('5111111111111111')).toEqual('Card number is invalid; at least one digit is wrong');
+    });
+    it('should return an empty string for a valid number with no errors', () => {
+      expect(self.paymentValidationService.getCardNumberErrorMessage('4111 1111 1111 1111')).toEqual('');
+    });
+  });
+
   describe('validateCardSecurityCode', () => {
-    it('to return false for a code of invalid length', () => {
+    it('should return false for a code of invalid length', () => {
       expect(self.paymentValidationService.validateCardSecurityCode()('12')).toEqual(false);
       expect(self.paymentValidationService.validateCardSecurityCode()('12345')).toEqual(false);
     });
-    it('to return true for a code of valid length', () => {
+    it('should return true for a code of valid length', () => {
       expect(self.paymentValidationService.validateCardSecurityCode()('123')).toEqual(true);
       expect(self.paymentValidationService.validateCardSecurityCode()('1234')).toEqual(true);
     });
   });
 
   describe('stripNonDigits', () => {
-    it('to remove all non digits from a string', () => {
+    it('should remove all non digits from a string', () => {
       expect(self.paymentValidationService.stripNonDigits('12')).toEqual('12');
       expect(self.paymentValidationService.stripNonDigits('12345')).toEqual('12345');
       expect(self.paymentValidationService.stripNonDigits('&1a23-4 5')).toEqual('12345');


### PR DESCRIPTION
- Move CCP initialization to function
- Test CCP initialization with different keys
- Test getCardNumberErrorMessage