### PR TITLE
Display credit card payment info on review page

### DIFF
--- a/src/app/checkout/step-2/bank-account/bank-account.component.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.component.js
@@ -65,7 +65,6 @@ class BankAccountController{
       this.orderService.addBankAccountPayment({
           'account-type': this.bankPayment.accountType,
           'bank-name': this.bankPayment.bankName,
-          'display-account-number': ccpAccountNumber.mask(),
           'encrypted-account-number': ccpAccountNumber.encrypt(),
           'routing-number': this.bankPayment.routingNumber
         })

--- a/src/app/checkout/step-2/bank-account/bank-account.spec.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.spec.js
@@ -86,7 +86,7 @@ describe('checkout', () => {
           self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform').respond(200, cartResponse);
 
           //Custom post data validator to check match on everything except encrypted-account-number which changes on each run
-          let expectedPostData = {"account-type":"checking","bank-name":"First Bank","display-account-number":"************9012", "encrypted-account-number": '***encrypted***',"routing-number":"123456789"};
+          let expectedPostData = {"account-type":"checking","bank-name":"First Bank", "encrypted-account-number": '***encrypted***',"routing-number":"123456789"};
           function dataValidator(data){
             data = angular.fromJson(data);
             return isEqual(omit(data, 'encrypted-account-number'), omit(expectedPostData, 'encrypted-account-number')) && data['encrypted-account-number'].length >= 100;

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -11,14 +11,13 @@ let componentName = 'checkoutStep3';
 class Step3Controller{
 
   /* @ngInject */
-  constructor(cartService, orderService){
+  constructor(cartService, orderService, $log){
     this.cartService = cartService;
     this.orderService = orderService;
-
-    this.init();
+    this.$log = $log;
   }
 
-  init(){
+  $onInit(){
     this.cartService.getDonorDetails()
       .subscribe((data) => {
         this.donorDetails = data;
@@ -26,7 +25,13 @@ class Step3Controller{
 
     this.orderService.getCurrentPayment()
       .subscribe((data) => {
-        this.paymentDetails = data;
+        if(data.self.type === 'elasticpath.bankaccounts.bank-account') {
+          this.bankAccountPaymentDetails = data;
+        }else if(data.self.type === 'cru.creditcards.named-credit-card'){
+          this.creditCardPaymentDetails = data;
+        }else{
+          this.$log.error('Error loading current payment info: current payment type is unknown');
+        }
       });
   }
 }

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -12,6 +12,11 @@ describe('checkout', function() {
 
     beforeEach(inject(function($rootScope, $componentController) {
       var $scope = $rootScope.$new();
+      self.loadedPayment = {
+        self: {
+          type: null
+        }
+      };
 
       self.controller = $componentController(module.name, {
         $scope: $scope,
@@ -20,16 +25,38 @@ describe('checkout', function() {
           getDonorDetails: () => Observable.of('donor details')
         },
         orderService: {
-          getCurrentPayment: () => Observable.of('payment details')
+          getCurrentPayment: () => Observable.of(self.loadedPayment)
         }
       });
     }));
 
-    describe('init', () => {
-      it('should load donor and payment details', function() {
-        self.controller.init();
+    describe('$onInit', () => {
+      it('should load donor details', function() {
+        self.loadedPayment.self.type = 'elasticpath.bankaccounts.bank-account';
+        self.controller.$onInit();
         expect(self.controller.donorDetails).toEqual('donor details');
-        expect(self.controller.paymentDetails).toEqual('payment details');
+        self.controller.$log.assertEmpty();
+      });
+      it('should load bank account payment details', function() {
+        self.loadedPayment.self.type = 'elasticpath.bankaccounts.bank-account';
+        self.controller.$onInit();
+        expect(self.controller.bankAccountPaymentDetails).toEqual(self.loadedPayment);
+        expect(self.controller.creditCardPaymentDetails).toBeUndefined();
+        self.controller.$log.assertEmpty();
+      });
+      it('should load credit card payment details', function() {
+        self.loadedPayment.self.type = 'cru.creditcards.named-credit-card';
+        self.controller.$onInit();
+        expect(self.controller.bankAccountPaymentDetails).toBeUndefined();
+        expect(self.controller.creditCardPaymentDetails).toEqual(self.loadedPayment);
+        self.controller.$log.assertEmpty();
+      });
+      it('should throw an error if the type is unknown', function() {
+        self.loadedPayment.self.type = 'some other type';
+        self.controller.$onInit();
+        expect(self.controller.bankAccountPaymentDetails).toBeUndefined();
+        expect(self.controller.creditCardPaymentDetails).toBeUndefined();
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error loading current payment info: current payment type is unknown']);
       });
     });
   });

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -37,25 +37,47 @@
     <div class="panel-body">
       <div class="row">
         <div class="col-md-8">
-          <div class="row" ng-if="$ctrl.paymentDetails">
+          <div class="row" ng-if="$ctrl.bankAccountPaymentDetails">
             <div class="col-md-6">
               <div class="form-group">
                 <label class="">Bank Name</label>
-                <p>{{$ctrl.paymentDetails['bank-name']}}</p>
+                <p>{{$ctrl.bankAccountPaymentDetails['bank-name']}}</p>
               </div>
               <div class="form-group">
                 <label class="">Account Number</label>
-                <p class="number">************{{$ctrl.paymentDetails['display-account-number']}}</p>
+                <p class="number">************{{$ctrl.bankAccountPaymentDetails['display-account-number']}}</p>
               </div>
             </div>
             <div class="col-md-6">
               <div class="form-group">
                 <label class="">Account Type</label>
-                <p class="number">{{$ctrl.paymentDetails['account-type'] | capitalize}}</p>
+                <p class="number">{{$ctrl.bankAccountPaymentDetails['account-type'] | capitalize}}</p>
               </div>
               <div class="form-group">
                 <label class="">Routing Number</label>
-                <p class="number">{{$ctrl.paymentDetails['routing-number']}}</p>
+                <p class="number">{{$ctrl.bankAccountPaymentDetails['routing-number']}}</p>
+              </div>
+            </div>
+          </div>
+          <div class="row" ng-if="$ctrl.creditCardPaymentDetails">
+            <div class="col-md-6">
+              <div class="form-group">
+                <label class="">Name on card</label>
+                <p>{{$ctrl.creditCardPaymentDetails['cardholder-name']}}</p>
+              </div>
+              <div class="form-group">
+                <label class="">Card Number</label>
+                <p class="number">************{{$ctrl.creditCardPaymentDetails['card-number']}}</p><!-- TODO: this is undefined -->
+              </div>
+            </div>
+            <div class="col-md-6">
+              <div class="form-group">
+                <label class="">Card Type</label>
+                <p class="number">{{$ctrl.creditCardPaymentDetails['card-type']}}</p>
+              </div>
+              <div class="form-group">
+                <label class="">Expires</label>
+                <p class="number">{{$ctrl.creditCardPaymentDetails['expiry-month']}}/{{$ctrl.creditCardPaymentDetails['expiry-year']}}</p><!-- TODO: deal with localization -->
               </div>
             </div>
             <div class="col-md-12">
@@ -65,7 +87,7 @@
               </div>
             </div>
           </div>
-          <div class="loading-wrap" ng-if="!$ctrl.paymentDetails">
+          <div class="loading-wrap" ng-if="!$ctrl.bankAccountPaymentDetails && !$ctrl.creditCardPaymentDetails">
             <span class="loading loading1"></span>
             <span class="loading loading2"></span>
             <span class="loading loading3"></span>


### PR DESCRIPTION
- Also remove sending the bank account display-account-number as the server generates that

Cortex seems to be returning the encrypted card number in the `card-number` field instead of the masked one. I think they are working on fixing that.