### PR TITLE
Move css processing outside of systemjs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ jspm_packages
 .sass-cache
 
 src/**/*.tpl.js
-src/**/*.css
-src/**/*.css.map

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -33,11 +33,11 @@ gulp.task('html', function () {
 gulp.task('scss', function () {
   return gulp.src(paths.scss)
     .pipe($.plumber())
-    .pipe($.changed(paths.srcDir, {extension: '.css'}))
     .pipe($.sourcemaps.init())
     .pipe($.systemjsResolver({systemConfig: './system.config.js'}))
     .pipe($.sass())
+    .pipe($.concat('give.css'))
     .pipe($.sourcemaps.write("."))
-    .pipe(gulp.dest(paths.srcDir))
+    .pipe(gulp.dest(paths.output))
     .pipe($.browserSync.reload({ stream: true }));
 });

--- a/build/tasks/release.js
+++ b/build/tasks/release.js
@@ -5,11 +5,11 @@ var $ = require('gulp-load-plugins')({
 
 var paths = require('../paths');
 
-gulp.task('cache-bust', function () {
-  var cacheBust = "var systemLocate = System.locate; System.locate = function(load) { var cacheBust = '?bust=' + " + Math.round(new Date() / 1000) +"; return Promise.resolve(systemLocate.call(this, load)).then(function(address) { if (address.indexOf('bust') > -1 || address.indexOf('css') > -1 || address.indexOf('json') > -1) return address; return address + cacheBust; });}\n"
-  return gulp.src('dist/app/app.js')
-    .pipe($.insert.prepend(cacheBust))
-    .pipe(gulp.dest('dist/app'));
+gulp.task('minify-css', function () {
+  return gulp.src(paths.outputCss)
+    .pipe($.cleanCss())
+    .pipe($.concat('give.min.css'))
+    .pipe(gulp.dest(paths.output));
 });
 
 gulp.task('inline-systemjs', function () {
@@ -39,11 +39,8 @@ gulp.task('release', function (callback) {
   return $.runSequence(
     'clean',
     'build',
-    'bundle',
-    'cache-bust',
-    'replace',
+    ['bundle', 'minify-css', 'replace', 'move'],
     'inline-systemjs',
-    'move',
     callback
   );
 });

--- a/build/tasks/replace.js
+++ b/build/tasks/replace.js
@@ -4,21 +4,14 @@ var paths = require('../paths');
 
 gulp.task('replace', function(){
   return gulp.src('./index.html')
+    .pipe($.preprocess({
+      context: {
+        ENV: 'prod'
+      }
+    }))
     .pipe($.replaceTask({
       usePrefix: false,
       patterns: [
-        {
-          match: '<script src="jspm_packages/system.js"></script>',
-          replacement: '<!-- <script src="jspm_packages/system.js"></script> -->'
-        },
-        {
-          match: '<script src="system.config.js"></script>',
-          replacement: '<!-- <script src="system.config.js"></script> -->'
-        },
-        {
-          match: '<!-- <script src="main.js?bust={{date}}"></script> -->',
-          replacement: '<script src="main.js?bust={{date}}"></script>'
-        },
         {
           match: '{{date}}',
           replacement: Math.round(new Date() / 1000)

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
       <meta name="apple-mobile-web-app-title" content="Demo App">
       <title>Cru | Give</title>
       <base href="/">
+      <!-- @if ENV='dev' -->
+      <link rel="stylesheet" href="dist/give.css" type="text/css">
+      <!-- @endif -->
+
+      <!-- @if ENV='prod' !>
+      <link rel="stylesheet" href="give.min.css" type="text/css">
+      <!-- @endif -->
   </head>
   <body ng-cloak ng-app="main">
 
@@ -22,14 +29,14 @@
 
     <main></main>
 
-    <!-- build:dev -->
+    <!-- @if ENV='dev' -->
     <script src="jspm_packages/system.js"></script>
     <script src="system.config.js"></script>
-    <!-- endbuild -->
+    <!-- @endif -->
 
-    <!-- build:prod -->
-    <!-- <script src="main.js?bust={{date}}"></script> -->
-    <!-- endbuild -->
+    <!-- @if ENV='prod' !>
+    <script src="main.js?bust={{date}}"></script>
+    <!-- @endif -->
 
     <script>
       System.import('app/main/main.component')

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-jasmine": "^1.8.1",
     "gulp": "^3.9.1",
     "gulp-changed": "^1.3.0",
+    "gulp-clean-css": "^2.0.12",
     "gulp-concat": "^2.6.0",
     "gulp-css-url-adjuster": "^0.2.3",
     "gulp-eslint": "^3.0.1",
@@ -25,6 +26,7 @@
     "gulp-ng-annotate": "^2.0.0",
     "gulp-ng-html2js": "^0.2.2",
     "gulp-plumber": "^1.1.0",
+    "gulp-preprocess": "^2.0.0",
     "gulp-protractor": "^3.0.0",
     "gulp-replace-task": "^0.11.0",
     "gulp-sass": "^2.3.2",
@@ -68,14 +70,12 @@
       "angular-gettext": "github:rubenv/angular-gettext@^2.3.4",
       "angular-messages": "github:angular/bower-angular-messages@^1.5.8",
       "angular-ui-router": "github:angular-ui/ui-router@^0.3.1",
-      "css": "github:systemjs/plugin-css@^0.1.26",
       "jsencrypt": "npm:jsencrypt@^2.3.1",
       "json": "github:systemjs/plugin-json@^0.1.2",
       "jsonpath": "npm:jsonpath@^0.2.6",
       "jwt-decode": "github:auth0/jwt-decode@^2.1.0",
       "lodash": "npm:lodash@^4.14.2",
-      "rxjs": "npm:rxjs@^5.0.0-beta.11",
-      "scss": "github:KevCJones/plugin-scss@^0.2.11"
+      "rxjs": "npm:rxjs@^5.0.0-beta.11"
     },
     "devDependencies": {
       "angular-mocks": "github:angular/bower-angular-mocks@^1.5.8",

--- a/src/app/main/main.component.js
+++ b/src/app/main/main.component.js
@@ -14,7 +14,6 @@ import signInComponent from '../signIn/signIn.component';
 import cartService from 'common/services/api/cart.service';
 
 import template from './main.tpl';
-import './main.css!';
 
 let componentName = 'main';
 

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -5,7 +5,6 @@ import includes from 'lodash/includes';
 import sessionService from 'common/services/session.service';
 
 import template from './signInForm.tpl';
-import './signInForm.css!';
 
 let componentName = 'signInForm';
 

--- a/system.config.js
+++ b/system.config.js
@@ -13,20 +13,10 @@ System.config({
     "app/*": "src/app/*",
     "common/*": "src/common/*",
     "assets/*": "dist/assets/*",
-    "bundles/*": "dist/bundles/*",
     "lib/*": "lib/*",
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*",
     "jspm_packages/*": "jspm_packages/*"
-  },
-  buildCSS: true,
-  separateCSS: false,
-  packages: {
-    'src/': {
-      meta: {
-        '*.css': { loader: 'css' }
-      }
-    }
   },
 
   map: {
@@ -42,7 +32,6 @@ System.config({
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@1.2.7",
-    "css": "github:systemjs/plugin-css@0.1.26",
     "jsencrypt": "npm:jsencrypt@2.3.1",
     "json": "github:systemjs/plugin-json@0.1.2",
     "jsonpath": "npm:jsonpath@0.2.6",
@@ -51,18 +40,7 @@ System.config({
     "plugin-babel": "npm:systemjs-plugin-babel@0.0.13",
     "plugin-babel-runtime": "npm:babel-runtime@5.8.38",
     "rxjs": "npm:rxjs@5.0.0-beta.11",
-    "scss": "github:KevCJones/plugin-scss@0.2.11",
     "systemjs-babel-build": "npm:systemjs-plugin-babel@0.0.13/systemjs-babel-browser.js",
-    "github:KevCJones/plugin-scss@0.2.11": {
-      "autoprefixer": "npm:autoprefixer@6.4.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "lodash": "npm:lodash@4.15.0",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "postcss": "npm:postcss@5.1.2",
-      "reqwest": "github:ded/reqwest@2.0.5",
-      "sass.js": "npm:sass.js@0.9.12",
-      "url": "github:jspm/nodelibs-url@0.1.0"
-    },
     "github:angular/bower-angular-cookies@1.5.8": {
       "angular": "github:angular/bower-angular@1.5.8"
     },
@@ -81,9 +59,6 @@ System.config({
     "github:jspm/nodelibs-constants@0.1.0": {
       "constants-browserify": "npm:constants-browserify@0.0.1"
     },
-    "github:jspm/nodelibs-crypto@0.1.0": {
-      "crypto-browserify": "npm:crypto-browserify@3.11.0"
-    },
     "github:jspm/nodelibs-events@0.1.1": {
       "events": "npm:events@1.0.2"
     },
@@ -95,9 +70,6 @@ System.config({
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
-    },
-    "github:jspm/nodelibs-string_decoder@0.1.0": {
-      "string_decoder": "npm:string_decoder@0.10.31"
     },
     "github:jspm/nodelibs-tty@0.1.0": {
       "tty-browserify": "npm:tty-browserify@0.0.0"
@@ -123,15 +95,6 @@ System.config({
       "longest": "npm:longest@1.0.1",
       "repeat-string": "npm:repeat-string@1.5.4"
     },
-    "npm:asn1.js@4.8.0": {
-      "assert": "github:jspm/nodelibs-assert@0.1.0",
-      "bn.js": "npm:bn.js@4.11.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
-      "minimalistic-assert": "npm:minimalistic-assert@1.0.0",
-      "vm": "github:jspm/nodelibs-vm@0.1.0"
-    },
     "npm:assert@1.4.1": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -141,79 +104,11 @@ System.config({
     "npm:async@0.2.10": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:autoprefixer@6.4.0": {
-      "browserslist": "npm:browserslist@1.3.5",
-      "caniuse-db": "npm:caniuse-db@1.0.30000524",
-      "normalize-range": "npm:normalize-range@0.1.2",
-      "num2fraction": "npm:num2fraction@1.2.2",
-      "postcss": "npm:postcss@5.1.2",
-      "postcss-value-parser": "npm:postcss-value-parser@3.3.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:beeper@1.1.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:bn.js@4.11.6": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
-    },
-    "npm:browserify-aes@1.0.6": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "buffer-xor": "npm:buffer-xor@1.0.3",
-      "cipher-base": "npm:cipher-base@1.0.2",
-      "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
-    "npm:browserify-cipher@1.0.0": {
-      "browserify-aes": "npm:browserify-aes@1.0.6",
-      "browserify-des": "npm:browserify-des@1.0.0",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "evp_bytestokey": "npm:evp_bytestokey@1.0.0"
-    },
-    "npm:browserify-des@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "cipher-base": "npm:cipher-base@1.0.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "des.js": "npm:des.js@1.0.0",
-      "inherits": "npm:inherits@2.0.1"
-    },
-    "npm:browserify-rsa@4.0.1": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "constants": "github:jspm/nodelibs-constants@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "randombytes": "npm:randombytes@2.0.3"
-    },
-    "npm:browserify-sign@4.0.0": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "browserify-rsa": "npm:browserify-rsa@4.0.1",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "create-hmac": "npm:create-hmac@1.1.4",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "elliptic": "npm:elliptic@6.3.1",
-      "inherits": "npm:inherits@2.0.1",
-      "parse-asn1": "npm:parse-asn1@5.0.0",
-      "stream": "github:jspm/nodelibs-stream@0.1.0"
-    },
-    "npm:browserslist@1.3.5": {
-      "caniuse-db": "npm:caniuse-db@1.0.30000524",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
-    "npm:buffer-xor@1.0.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:buffer@3.6.0": {
       "base64-js": "npm:base64-js@0.0.8",
@@ -243,12 +138,6 @@ System.config({
       "strip-ansi": "npm:strip-ansi@3.0.1",
       "supports-color": "npm:supports-color@2.0.0"
     },
-    "npm:cipher-base@1.0.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "inherits": "npm:inherits@2.0.1",
-      "stream": "github:jspm/nodelibs-stream@0.1.0",
-      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
-    },
     "npm:cjson@0.2.1": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0"
@@ -259,10 +148,12 @@ System.config({
       "wordwrap": "npm:wordwrap@0.0.2"
     },
     "npm:clone-stats@0.0.1": {
-      "fs": "github:jspm/nodelibs-fs@0.1.2"
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:clone@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:colors@0.5.1": {
@@ -280,40 +171,6 @@ System.config({
     "npm:core-util-is@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
-    "npm:create-ecdh@4.0.0": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "elliptic": "npm:elliptic@6.3.1"
-    },
-    "npm:create-hash@1.1.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "cipher-base": "npm:cipher-base@1.0.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
-      "ripemd160": "npm:ripemd160@1.0.1",
-      "sha.js": "npm:sha.js@2.4.5"
-    },
-    "npm:create-hmac@1.1.4": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "inherits": "npm:inherits@2.0.1",
-      "stream": "github:jspm/nodelibs-stream@0.1.0"
-    },
-    "npm:crypto-browserify@3.11.0": {
-      "browserify-cipher": "npm:browserify-cipher@1.0.0",
-      "browserify-sign": "npm:browserify-sign@4.0.0",
-      "create-ecdh": "npm:create-ecdh@4.0.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "create-hmac": "npm:create-hmac@1.1.4",
-      "diffie-hellman": "npm:diffie-hellman@5.0.2",
-      "inherits": "npm:inherits@2.0.1",
-      "pbkdf2": "npm:pbkdf2@3.0.4",
-      "public-encrypt": "npm:public-encrypt@4.0.0",
-      "randombytes": "npm:randombytes@2.0.3"
-    },
     "npm:currently-unhandled@0.4.1": {
       "array-find-index": "npm:array-find-index@1.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -322,33 +179,14 @@ System.config({
       "get-stdin": "npm:get-stdin@4.0.1",
       "meow": "npm:meow@3.7.0"
     },
-    "npm:des.js@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "inherits": "npm:inherits@2.0.1",
-      "minimalistic-assert": "npm:minimalistic-assert@1.0.0"
-    },
-    "npm:diffie-hellman@5.0.2": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "miller-rabin": "npm:miller-rabin@4.0.0",
-      "randombytes": "npm:randombytes@2.0.3",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
     "npm:duplexer2@0.0.2": {
-      "readable-stream": "npm:readable-stream@1.1.14"
+      "readable-stream": "npm:readable-stream@1.1.14",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:ebnf-parser@0.1.10": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:elliptic@6.3.1": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "brorand": "npm:brorand@1.0.5",
-      "hash.js": "npm:hash.js@1.0.3",
-      "inherits": "npm:inherits@2.0.1",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:error-ex@1.3.0": {
       "is-arrayish": "npm:is-arrayish@0.2.1",
@@ -379,11 +217,6 @@ System.config({
     "npm:esprima@1.2.2": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:evp_bytestokey@1.0.0": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0"
     },
     "npm:fancy-log@1.2.0": {
       "chalk": "npm:chalk@1.1.3",
@@ -456,14 +289,8 @@ System.config({
     "npm:has-ansi@2.0.0": {
       "ansi-regex": "npm:ansi-regex@2.0.0"
     },
-    "npm:has-flag@1.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
     "npm:has-gulplog@0.1.0": {
       "sparkles": "npm:sparkles@1.0.0"
-    },
-    "npm:hash.js@1.0.3": {
-      "inherits": "npm:inherits@2.0.1"
     },
     "npm:hosted-git-info@2.1.5": {
       "url": "github:jspm/nodelibs-url@0.1.0"
@@ -482,6 +309,9 @@ System.config({
     },
     "npm:is-finite@1.0.1": {
       "number-is-nan": "npm:number-is-nan@1.0.0"
+    },
+    "npm:isarray@1.0.0": {
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:isobject@2.1.0": {
       "isarray": "npm:isarray@1.0.0"
@@ -507,9 +337,6 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
-    "npm:js-base64@2.1.9": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:jsencrypt@2.3.1": {
       "gulp-rename": "npm:gulp-rename@1.2.2",
@@ -583,6 +410,7 @@ System.config({
       "currently-unhandled": "npm:currently-unhandled@0.4.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "signal-exit": "npm:signal-exit@3.0.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:meow@3.7.0": {
@@ -598,10 +426,6 @@ System.config({
       "read-pkg-up": "npm:read-pkg-up@1.0.1",
       "redent": "npm:redent@1.0.0",
       "trim-newlines": "npm:trim-newlines@1.0.0"
-    },
-    "npm:miller-rabin@4.0.0": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "brorand": "npm:brorand@1.0.5"
     },
     "npm:multipipe@0.1.2": {
       "duplexer2": "npm:duplexer2@0.0.2",
@@ -622,15 +446,6 @@ System.config({
       "util": "github:jspm/nodelibs-util@0.1.0",
       "validate-npm-package-license": "npm:validate-npm-package-license@3.0.1"
     },
-    "npm:parse-asn1@5.0.0": {
-      "asn1.js": "npm:asn1.js@4.8.0",
-      "browserify-aes": "npm:browserify-aes@1.0.6",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
-      "pbkdf2": "npm:pbkdf2@3.0.4",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
     "npm:parse-json@2.2.0": {
       "error-ex": "npm:error-ex@1.3.0"
     },
@@ -646,53 +461,22 @@ System.config({
       "pify": "npm:pify@2.3.0",
       "pinkie-promise": "npm:pinkie-promise@2.0.1"
     },
-    "npm:pbkdf2@3.0.4": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
-      "create-hmac": "npm:create-hmac@1.1.4",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
-    },
     "npm:pify@2.3.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:pinkie-promise@2.0.1": {
       "pinkie": "npm:pinkie@2.0.4"
     },
-    "npm:postcss@5.1.2": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "js-base64": "npm:js-base64@2.1.9",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "source-map": "npm:source-map@0.5.6",
-      "supports-color": "npm:supports-color@3.1.2"
-    },
     "npm:process-nextick-args@1.0.7": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:process@0.11.8": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
-    "npm:public-encrypt@4.0.0": {
-      "bn.js": "npm:bn.js@4.11.6",
-      "browserify-rsa": "npm:browserify-rsa@4.0.1",
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "create-hash": "npm:create-hash@1.1.2",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "parse-asn1": "npm:parse-asn1@5.0.0",
-      "randombytes": "npm:randombytes@2.0.3"
-    },
     "npm:punycode@1.3.2": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:randombytes@2.0.3": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:read-pkg-up@1.0.1": {
@@ -739,29 +523,12 @@ System.config({
     "npm:right-align@0.1.3": {
       "align-text": "npm:align-text@0.1.4"
     },
-    "npm:ripemd160@1.0.1": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
     "npm:rxjs@5.0.0-beta.11": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "symbol-observable": "npm:symbol-observable@1.0.2"
     },
-    "npm:sass.js@0.9.12": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
     "npm:semver@5.3.0": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:sha.js@2.4.5": {
-      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "inherits": "npm:inherits@2.0.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:signal-exit@3.0.0": {
@@ -810,10 +577,6 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:supports-color@2.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
-    },
-    "npm:supports-color@3.1.2": {
-      "has-flag": "npm:has-flag@1.0.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:through2@2.0.1": {
@@ -870,6 +633,9 @@ System.config({
     "npm:window-size@0.1.0": {
       "process": "github:jspm/nodelibs-process@0.1.2",
       "tty": "github:jspm/nodelibs-tty@0.1.0"
+    },
+    "npm:xtend@4.0.1": {
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:yargs@3.10.0": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",


### PR DESCRIPTION
- Create dist/give.css and dist/give.min.css
- Use gulp-preprocess to replace dev imports in index.html with production ones
- Remove systems-plugin-css and systems-plugin-scss
- Output css to dist/ instead of src/
- Remove cache-bust task
- Remove css imports in js
- Remove src/\*\*/\*.css and src/\*\*/\*.css.map from .gitignore (@adammeyer @Omicron7 means you guys need to remove your css files after you pull this commit)