### PR TITLE
Implement storing CCV in sessionStorage and submitting the purchase form on step 3

### DIFF
--- a/build/tasks/test.js
+++ b/build/tasks/test.js
@@ -3,7 +3,7 @@ var karma = require('karma');
 var gulp_protractor = require("gulp-protractor");
 var paths = require('../paths');
 
-gulp.task('test', ['build'], function(done) {
+gulp.task('test', ['html'], function(done) {
   new karma.Server({
     configFile: __dirname + '/../../karma.conf.js',
     singleRun: true

--- a/src/app/checkout/step-2/bank-account/bank-account.spec.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.spec.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import 'angular-mocks';
-import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import size from 'lodash/size';
 import module from './bank-account.component';
@@ -89,7 +88,7 @@ describe('checkout', () => {
           let expectedPostData = {"account-type":"checking","bank-name":"First Bank", "encrypted-account-number": '***encrypted***',"routing-number":"123456789"};
           function dataValidator(data){
             data = angular.fromJson(data);
-            return isEqual(omit(data, 'encrypted-account-number'), omit(expectedPostData, 'encrypted-account-number')) && data['encrypted-account-number'].length >= 100;
+            return angular.equals(omit(data, 'encrypted-account-number'), omit(expectedPostData, 'encrypted-account-number')) && data['encrypted-account-number'].length >= 100;
           }
           dataValidator.toString = () => 'encrypted-account-number must be at least 100 chars and rest of object must match: ' + angular.toJson(expectedPostData);
 
@@ -160,7 +159,7 @@ describe('checkout', () => {
           it('should not be valid if the field is empty',  () => {
             self.formController.bankName.$setViewValue('');
             expect(self.formController.bankName.$valid).toEqual(false);
-            expect(self.formController.routingNumber.$error.required).toEqual(true);
+            expect(self.formController.bankName.$error.required).toEqual(true);
           });
           it('should be valid if there is something in the input',  () => {
             self.formController.bankName.$setViewValue('Some Bank');

--- a/src/app/checkout/step-2/credit-card/credit-card.component.js
+++ b/src/app/checkout/step-2/credit-card/credit-card.component.js
@@ -63,7 +63,7 @@ class CreditCardController {
         })
         .subscribe((data) => {
             this.$log.info('added credit card', data);
-            ccpSecurityCode.encrypt(); //TODO: save this in session storage and submit it on confirmation of order
+            this.orderService.storeCardSecurityCode(ccpSecurityCode.encrypt());
             this.onSave({success: true});
           },
           (error) => {

--- a/src/app/checkout/step-2/credit-card/credit-card.spec.js
+++ b/src/app/checkout/step-2/credit-card/credit-card.spec.js
@@ -1,23 +1,277 @@
 import angular from 'angular';
 import 'angular-mocks';
+import omit from 'lodash/omit';
+import size from 'lodash/size';
 import module from './credit-card.component';
 
-describe('checkout', function() {
-  describe('step 2', function() {
-    describe('credit card', function() {
+import cartResponse from 'common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js';
+
+describe('checkout', () => {
+  describe('step 2', () => {
+    describe('credit card', () => {
       beforeEach(angular.mock.module(module.name));
       var self = {};
 
-      beforeEach(inject(function($rootScope, $componentController) {
-        var $scope = $rootScope.$new();
+      beforeEach(inject(($rootScope, $componentController, $httpBackend, $compile) => {
+        self.outerScope = $rootScope.$new();
+        self.$httpBackend = $httpBackend;
 
-        self.controller = $componentController(module.name, {
-          $scope: $scope
-        });
+        self.outerScope.submitted = false;
+        self.outerScope.onSave = () => {};
+        let compiledElement = $compile(angular.element('<checkout-credit-card submitted="submitted" on-save="onSave(success)"></checkout-credit-card>'))(self.outerScope);
+        self.outerScope.$apply();
+        self.controller = compiledElement.controller(module.name);
+        self.formController = self.controller.creditCardPaymentForm;
       }));
 
-      it('to be defined', function() {
-        expect(self.controller).toBeDefined();
+      describe('$onChanges', () => {
+        it('should call savePayment when called directly with a mock change object', () => {
+          spyOn(self.controller, 'savePayment');
+          self.controller.$onChanges({
+            submitted: {
+              currentValue: true
+            }
+          });
+          expect(self.controller.savePayment).toHaveBeenCalled();
+        });
+        it('should call savePayment when submitted changes to true', () => {
+          spyOn(self.controller, 'savePayment');
+          self.outerScope.submitted = true;
+          self.outerScope.$apply();
+          expect(self.controller.savePayment).toHaveBeenCalled();
+        });
+      });
+
+      describe('waitForFormInitialization', () => {
+        it('should call addCustomValidators when the form is initialized', () => {
+          spyOn(self.controller, 'addCustomValidators');
+          self.controller.waitForFormInitialization();
+          self.controller.creditCardPaymentForm = {};
+          self.controller.$scope.$apply();
+          expect(self.controller.addCustomValidators).toHaveBeenCalled();
+        });
+      });
+
+      describe('addCustomValidators', () => {
+        it('should add parser and validator functions to ngModelControllers ', () => {
+          self.controller.addCustomValidators();
+          expect(size(self.formController.cardNumber.$parsers)).toEqual(2);
+          expect(size(self.formController.cardNumber.$validators)).toEqual(4);
+
+          expect(size(self.formController.expiryYear.$validators)).toEqual(2);
+
+          expect(size(self.formController.securityCode.$parsers)).toEqual(2);
+          expect(size(self.formController.securityCode.$validators)).toEqual(3);
+        });
+      });
+
+      describe('savePayment', () => {
+        afterEach(function() {
+          self.$httpBackend.verifyNoOutstandingExpectation();
+          self.$httpBackend.verifyNoOutstandingRequest();
+        });
+
+        it('should call onSave with success false when form is invalid', () => {
+          spyOn(self.controller, 'onSave').and.callThrough();
+          spyOn(self.outerScope, 'onSave');
+          self.controller.savePayment();
+          expect(self.controller.onSave).toHaveBeenCalledWith({success: false});
+          expect(self.outerScope.onSave).toHaveBeenCalledWith(false);
+        });
+        it('should send a request to save the credit card payment info', () => {
+          //Request to get form link
+          self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform').respond(200, cartResponse);
+
+          //Custom post data validator to check match on everything except encrypted-account-number which changes on each run
+          let expectedPostData ={
+            'card-number': '***encrypted***',
+            'card-type': 'VISA',
+            'cardholder-name': 'Person Name',
+            'expiry-month': 12,
+            'expiry-year': 19
+          };
+          function dataValidator(data){
+            data = angular.fromJson(data);
+            return angular.equals(omit(data, 'card-number'), omit(expectedPostData, 'card-number')) && data['card-number'].length >= 100;
+          }
+          dataValidator.toString = () => 'card-number must be at least 100 chars (because it should be encrypted) and rest of object must match: ' + angular.toJson(expectedPostData);
+
+          //Request to save credit card info
+          self.$httpBackend.expectPOST(
+            'https://cortex-gateway-stage.cru.org/cortex/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=?followLocation=true',
+            dataValidator
+          ).respond(200, 'success');
+
+          spyOn(self.formController, '$setSubmitted');
+          spyOn(self.controller, 'onSave').and.callThrough();
+          spyOn(self.outerScope, 'onSave');
+
+          self.controller.creditCardPayment = {
+            cardNumber: '4111111111111111',
+            cardholderName: 'Person Name',
+            expiryMonth: 12,
+            expiryYear: 19,
+            securityCode: '123'
+          };
+          self.formController.$valid = true;
+          self.controller.savePayment();
+          expect(self.formController.$setSubmitted).toHaveBeenCalled();
+
+          self.$httpBackend.flush();
+          self.$httpBackend.flush();
+          expect(self.controller.onSave).toHaveBeenCalledWith({success: true});
+          expect(self.outerScope.onSave).toHaveBeenCalledWith(true);
+        });
+        it('should handle an error saving to cortex', () => {
+          //Request to get form link
+          self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform').respond(400, 'error');
+
+          spyOn(self.formController, '$setSubmitted');
+          spyOn(self.controller, 'onSave').and.callThrough();
+          spyOn(self.outerScope, 'onSave');
+
+          self.controller.creditCardPayment = {
+            cardNumber: '4111111111111111',
+            cardholderName: 'Person Name',
+            expiryMonth: 12,
+            expiryYear: 19,
+            securityCode: '123'
+          };
+          self.formController.$valid = true;
+          self.controller.savePayment();
+          expect(self.formController.$setSubmitted).toHaveBeenCalled();
+
+          self.$httpBackend.flush();
+          expect(self.controller.onSave).toHaveBeenCalledWith({success: false});
+          expect(self.outerScope.onSave).toHaveBeenCalledWith(false);
+        });
+      });
+
+      describe('form controller', () => {
+        it('should be invalid if any of the inputs are invalid', () => {
+          self.formController.cardNumber.$setViewValue('');
+          expect(self.formController.$valid).toEqual(false);
+        });
+        it('should be valid if all of the inputs are valid', () => {
+          self.formController.cardNumber.$setViewValue('4111111111111111');
+          self.formController.cardholderName.$setViewValue('Person Name');
+          self.formController.expiryMonth.$setViewValue('12');
+          self.formController.expiryYear.$setViewValue('19');
+          self.formController.securityCode.$setViewValue('1234');
+          expect(self.formController.$valid).toEqual(true);
+        });
+        describe('cardNumber input', () => {
+          it('should not be valid if the field is empty',  () => {
+            expect(self.formController.cardNumber.$valid).toEqual(false);
+            expect(self.formController.cardNumber.$error.required).toEqual(true);
+          });
+          it('should not be valid if the input is too short',  () => {
+            self.formController.cardNumber.$setViewValue('123456789012');
+            expect(self.formController.cardNumber.$valid).toEqual(false);
+            expect(self.formController.cardNumber.$error.required).toBeUndefined();
+            expect(self.formController.cardNumber.$error.minlength).toEqual(true);
+          });
+          it('should not be valid if the input is too lond',  () => {
+            self.formController.cardNumber.$setViewValue('12345678901234567');
+            expect(self.formController.cardNumber.$valid).toEqual(false);
+            expect(self.formController.cardNumber.$error.required).toBeUndefined();
+            expect(self.formController.cardNumber.$error.maxlength).toEqual(true);
+          });
+          it('should be valid if it contains a valid card number',  () => {
+            self.formController.cardNumber.$setViewValue('4111111111111111');
+            expect(self.formController.cardNumber.$valid).toEqual(true);
+          });
+        });
+        describe('cardholderName input', () => {
+          it('should not be valid if the field is empty',  () => {
+            expect(self.formController.cardholderName.$valid).toEqual(false);
+            expect(self.formController.cardholderName.$error.required).toEqual(true);
+          });
+          it('should be valid if it contains text',  () => {
+            self.formController.cardholderName.$setViewValue('Person Name');
+            expect(self.formController.cardholderName.$valid).toEqual(true);
+          });
+        });
+        describe('expiryMonth input', () => {
+          it('should not be valid if the field is empty',  () => {
+            expect(self.formController.expiryMonth.$valid).toEqual(false);
+            expect(self.formController.expiryMonth.$error.required).toEqual(true);
+          });
+          it('should not be valid if it is less than 1',  () => {
+            self.formController.expiryMonth.$setViewValue('0');
+            expect(self.formController.expiryMonth.$valid).toEqual(false);
+            expect(self.formController.expiryMonth.$error.required).toBeUndefined();
+            expect(self.formController.expiryMonth.$error.min).toEqual(true);
+          });
+          it('should not be valid if it is greater than 12',  () => {
+            self.formController.expiryMonth.$setViewValue('13');
+            expect(self.formController.expiryMonth.$valid).toEqual(false);
+            expect(self.formController.expiryMonth.$error.required).toBeUndefined();
+            expect(self.formController.expiryMonth.$error.max).toEqual(true);
+          });
+          it('should be valid if it is between 1 and 12',  () => {
+            self.formController.expiryMonth.$setViewValue('1');
+            expect(self.formController.expiryMonth.$valid).toEqual(true);
+            self.formController.expiryMonth.$setViewValue('6');
+            expect(self.formController.expiryMonth.$valid).toEqual(true);
+            self.formController.expiryMonth.$setViewValue('12');
+            expect(self.formController.expiryMonth.$valid).toEqual(true);
+          });
+        });
+        describe('expiryYear input', () => {
+          it('should not be valid if the field is empty',  () => {
+            expect(self.formController.expiryYear.$valid).toEqual(false);
+            expect(self.formController.expiryYear.$error.required).toEqual(true);
+          });
+          it('should not be valid if it is not 2 or 4 digits',  () => {
+            self.formController.expiryYear.$setViewValue('1');
+            expect(self.formController.expiryYear.$valid).toEqual(false);
+            expect(self.formController.expiryYear.$error.required).toBeUndefined();
+            expect(self.formController.expiryYear.$error.length).toEqual(true);
+            self.formController.expiryMonth.$setViewValue('123');
+            expect(self.formController.expiryYear.$valid).toEqual(false);
+            expect(self.formController.expiryYear.$error.required).toBeUndefined();
+            expect(self.formController.expiryYear.$error.length).toEqual(true);
+            self.formController.expiryYear.$setViewValue('12345');
+            expect(self.formController.expiryYear.$valid).toEqual(false);
+            expect(self.formController.expiryYear.$error.required).toBeUndefined();
+            expect(self.formController.expiryYear.$error.length).toEqual(true);
+          });
+          it('should be valid if it is 4 digits',  () => {
+            self.formController.expiryYear.$setViewValue('12');
+            expect(self.formController.expiryYear.$valid).toEqual(true);
+          });
+          it('should be valid if it is 2 digits',  () => {
+            self.formController.expiryYear.$setViewValue('2012');
+            expect(self.formController.expiryYear.$valid).toEqual(true);
+          });
+        });
+        describe('securityCode input', () => {
+          it('should not be valid if the field is empty',  () => {
+            expect(self.formController.securityCode.$valid).toEqual(false);
+            expect(self.formController.securityCode.$error.required).toEqual(true);
+          });
+          it('should not be valid if it is less than 3 digits',  () => {
+            self.formController.securityCode.$setViewValue('12');
+            expect(self.formController.securityCode.$valid).toEqual(false);
+            expect(self.formController.securityCode.$error.required).toBeUndefined();
+            expect(self.formController.securityCode.$error.minlength).toEqual(true);
+          });
+          it('should not be valid if it is greater than 4 digits',  () => {
+            self.formController.securityCode.$setViewValue('12345');
+            expect(self.formController.securityCode.$valid).toEqual(false);
+            expect(self.formController.securityCode.$error.required).toBeUndefined();
+            expect(self.formController.securityCode.$error.maxlength).toEqual(true);
+          });
+          it('should be valid if it is 3 digits',  () => {
+            self.formController.securityCode.$setViewValue('123');
+            expect(self.formController.securityCode.$valid).toEqual(true);
+          });
+          it('should be valid if it is 4 digits',  () => {
+            self.formController.securityCode.$setViewValue('1234');
+            expect(self.formController.securityCode.$valid).toEqual(true);
+          });
+        });
       });
     });
   });

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -5,8 +5,8 @@ import module from './step-3.component';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
-describe('checkout', function() {
-  describe('step 3', function() {
+describe('checkout', () => {
+  describe('step 3', () => {
     beforeEach(angular.mock.module(module.name));
     var self = {};
 
@@ -17,6 +17,7 @@ describe('checkout', function() {
           type: null
         }
       };
+      self.storedCcv = null;
 
       self.controller = $componentController(module.name, {
         $scope: $scope,
@@ -25,38 +26,87 @@ describe('checkout', function() {
           getDonorDetails: () => Observable.of('donor details')
         },
         orderService: {
-          getCurrentPayment: () => Observable.of(self.loadedPayment)
+          getCurrentPayment: () => Observable.of(self.loadedPayment),
+          submit: () => Observable.of('called submit'),
+          submitWithCcv: (ccv) => Observable.of('called submit with a CCV of' + ccv),
+          retrieveCardSecurityCode: () => self.storedCcv,
+          clearCardSecurityCode: () => {}
         }
       });
     }));
 
     describe('$onInit', () => {
-      it('should load donor details', function() {
+      it('should load donor details', () => {
         self.loadedPayment.self.type = 'elasticpath.bankaccounts.bank-account';
         self.controller.$onInit();
         expect(self.controller.donorDetails).toEqual('donor details');
         self.controller.$log.assertEmpty();
       });
-      it('should load bank account payment details', function() {
+      it('should load bank account payment details', () => {
         self.loadedPayment.self.type = 'elasticpath.bankaccounts.bank-account';
         self.controller.$onInit();
         expect(self.controller.bankAccountPaymentDetails).toEqual(self.loadedPayment);
         expect(self.controller.creditCardPaymentDetails).toBeUndefined();
         self.controller.$log.assertEmpty();
       });
-      it('should load credit card payment details', function() {
+      it('should load credit card payment details', () => {
         self.loadedPayment.self.type = 'cru.creditcards.named-credit-card';
         self.controller.$onInit();
         expect(self.controller.bankAccountPaymentDetails).toBeUndefined();
         expect(self.controller.creditCardPaymentDetails).toEqual(self.loadedPayment);
         self.controller.$log.assertEmpty();
       });
-      it('should throw an error if the type is unknown', function() {
+      it('should throw an error if the payments aren\'t loaded', () => {
+        self.loadedPayment = undefined;
+        self.controller.$onInit();
+        expect(self.controller.bankAccountPaymentDetails).toBeUndefined();
+        expect(self.controller.creditCardPaymentDetails).toBeUndefined();
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error loading current payment info: current payment doesn\'t seem to exist']);
+      });
+      it('should throw an error if the type is unknown', () => {
         self.loadedPayment.self.type = 'some other type';
         self.controller.$onInit();
         expect(self.controller.bankAccountPaymentDetails).toBeUndefined();
         expect(self.controller.creditCardPaymentDetails).toBeUndefined();
         expect(self.controller.$log.error.logs[0]).toEqual(['Error loading current payment info: current payment type is unknown']);
+      });
+    });
+
+    describe('submitOrder', () => {
+      beforeEach(() => {
+        spyOn(self.controller.orderService, 'submit').and.callThrough();
+        spyOn(self.controller.orderService, 'submitWithCcv').and.callThrough();
+        spyOn(self.controller.orderService, 'clearCardSecurityCode');
+      });
+
+      it('should submit the order normally if paying with a bank account', () => {
+        self.controller.bankAccountPaymentDetails = {};
+        self.controller.submitOrder();
+        expect(self.controller.orderService.submit).toHaveBeenCalled();
+        expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+      });
+      it('should submit the order with a CCV if paying with a credit card', () => {
+        self.controller.creditCardPaymentDetails = {};
+        self.storedCcv = '1234';
+        self.controller.submitOrder();
+        expect(self.controller.orderService.submit).not.toHaveBeenCalled();
+        expect(self.controller.orderService.submitWithCcv).toHaveBeenCalledWith('1234');
+        expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+      });
+      it('should throw an error if paying with a credit card and the CCV is missing', () => {
+        self.controller.creditCardPaymentDetails = {};
+        self.controller.submitOrder();
+        expect(self.controller.orderService.submit).not.toHaveBeenCalled();
+        expect(self.controller.orderService.submitWithCcv).not.toHaveBeenCalled();
+        expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', 'Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly']);
+      });
+      it('should throw an error if neither bank account or credit card details are loaded', () => {
+        self.controller.submitOrder();
+        expect(self.controller.orderService.submit).not.toHaveBeenCalled();
+        expect(self.controller.orderService.submitWithCcv).not.toHaveBeenCalled();
+        expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', 'Current payment type is unknown']);
       });
     });
   });

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -137,7 +137,7 @@
         <tr>
           <td colspan="3" class="text-right">
             <div class="checkout-cta pull-right">
-              <button type="submit" class="btn btn-primary btn-lg btn-block" ng-disabled="!($ctrl.donorDetails && $ctrl.paymentDetails && $ctrl.cartData)">
+              <button type="submit" class="btn btn-primary btn-lg btn-block" ng-click="$ctrl.submitOrder()" ng-disabled="!($ctrl.donorDetails && ($ctrl.bankAccountPaymentDetails || $ctrl.creditCardPaymentDetails) && $ctrl.cartData)">
                 Submit Your Gift
               </button>
             </div>

--- a/src/common/services/api/fixtures/cortex-purchaseform.fixture.js
+++ b/src/common/services/api/fixtures/cortex-purchaseform.fixture.js
@@ -1,0 +1,70 @@
+export default {
+  "self": {
+    "type": "elasticpath.carts.cart",
+    "uri": "/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=?zoom=order:enhancedpurchaseform,order:purchaseform",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=?zoom=order:enhancedpurchaseform,order:purchaseform"
+  },
+  "links": [{
+    "rel": "lineitems",
+    "rev": "cart",
+    "type": "elasticpath.collections.links",
+    "uri": "/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=/lineitems",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=/lineitems"
+  }, {
+    "rel": "discount",
+    "type": "elasticpath.discounts.discount",
+    "uri": "/discounts/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/discounts/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge="
+  }, {
+    "rel": "order",
+    "rev": "cart",
+    "type": "elasticpath.orders.order",
+    "uri": "/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu="
+  }, {
+    "rel": "appliedpromotions",
+    "type": "elasticpath.collections.links",
+    "uri": "/promotions/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=/applied",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=/applied"
+  }, {
+    "rel": "ratetotals",
+    "type": "elasticpath.ratetotals.rate-total",
+    "uri": "/ratetotals/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/ratetotals/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge="
+  }, {
+    "rel": "total",
+    "rev": "cart",
+    "type": "elasticpath.totals.total",
+    "uri": "/totals/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/totals/carts/crugive/gzsdqmrrgbrtkljygbqtoljumm2giljzhfrtcllcmiygmmbsgm4ggnzrge="
+  }],
+  "_order": [{
+    "_enhancedpurchaseform": [{
+      "self": {
+        "type": "elasticpath.enhancedpurchases.enhancedpurchase",
+        "uri": "/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form"
+      },
+      "links": [{
+        "rel": "createenhancedpurchaseaction",
+        "uri": "/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu="
+      }],
+      "security-code": ""
+    }],
+    "_purchaseform": [{
+      "self": {
+        "type": "elasticpath.purchases.purchase",
+        "uri": "/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form"
+      },
+      "links": [{
+        "rel": "submitorderaction",
+        "uri": "/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu="
+      }]
+    }]
+  }],
+  "total-quantity": 1
+};
+

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -4,14 +4,16 @@ import module from './order.service';
 
 import cartResponse from 'common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js';
 import paymentMethodResponse from 'common/services/api/fixtures/cortex-paymentmethod.fixture.js';
+import purchaseFormResponse from 'common/services/api/fixtures/cortex-purchaseform.fixture.js';
 
 describe('order service', () => {
   beforeEach(angular.mock.module(module.name));
   var self = {};
 
-  beforeEach(inject((orderService, $httpBackend) => {
+  beforeEach(inject((orderService, $httpBackend, $window) => {
     self.orderService = orderService;
     self.$httpBackend = $httpBackend;
+    self.$window = $window;
   }));
 
   afterEach(function() {
@@ -25,13 +27,19 @@ describe('order service', () => {
     rawData: cartResponse
   };
 
-  describe('getPaymentForms', () => {
+  let purchaseFormResponseZoomMapped = {
+    purchaseform: purchaseFormResponse._order[0]._purchaseform[0],
+    enhancedpurchaseform: purchaseFormResponse._order[0]._enhancedpurchaseform[0],
+    rawData: purchaseFormResponse
+  };
+
+  describe('getPaymentMethodForms', () => {
     function setupRequest() {
       self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform').respond(200, cartResponse);
     }
 
     function initiateRequest(){
-      self.orderService.getPaymentForms()
+      self.orderService.getPaymentMethodForms()
         .subscribe((data) => {
           expect(data).toEqual(cartResponseZoomMapped);
         });
@@ -67,7 +75,7 @@ describe('order service', () => {
       ).respond(200, 'success');
 
       // cache getPaymentForms response to avoid another http request while testing
-      self.orderService.paymentTypes = cartResponseZoomMapped;
+      self.orderService.paymentMethodForms = cartResponseZoomMapped;
 
       self.orderService.addBankAccountPayment(paymentInfo)
         .subscribe((data) => {
@@ -94,7 +102,7 @@ describe('order service', () => {
       ).respond(200, 'success');
 
       // cache getPaymentForms response to avoid another http request while testing
-      self.orderService.paymentTypes = cartResponseZoomMapped;
+      self.orderService.paymentMethodForms = cartResponseZoomMapped;
 
       self.orderService.addCreditCardPayment(paymentInfo)
         .subscribe((data) => {
@@ -116,6 +124,97 @@ describe('order service', () => {
 
         self.$httpBackend.flush();
       });
+    });
+  });
+
+  describe('getPurchaseForms', () => {
+    function setupRequest() {
+      self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:purchaseform,order:enhancedpurchaseform').respond(200, purchaseFormResponse);
+    }
+
+    function initiateRequest(){
+      self.orderService.getPurchaseForms()
+        .subscribe((data) => {
+          expect(data).toEqual(purchaseFormResponseZoomMapped);
+        });
+    }
+
+    it('should send a request to get the payment form links', () => {
+      setupRequest();
+      initiateRequest();
+      self.$httpBackend.flush();
+    });
+
+    it('should use the cached response if called a second time', () => {
+      setupRequest();
+      initiateRequest();
+      self.$httpBackend.flush();
+      initiateRequest();
+    });
+  });
+
+  describe('submit', () => {
+    it('should send a request to finalize the purchase', () => {
+      self.$httpBackend.expectPOST(
+        'https://cortex-gateway-stage.cru.org/cortex/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=',
+      ).respond(200, 'success');
+
+      // cache getPaymentForms response to avoid another http request while testing
+      self.orderService.purchaseForms = purchaseFormResponseZoomMapped;
+
+      self.orderService.submit()
+        .subscribe((data) => {
+          expect(data).toEqual('success');
+        });
+
+      self.$httpBackend.flush();
+    });
+  });
+
+  describe('submitWithCcv', () => {
+    it('should send a request to finalize the purchase and send the saved CCV', () => {
+      self.$httpBackend.expectPOST(
+        'https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=',
+        {"security-code": '123'}
+      ).respond(200, 'success');
+
+      // cache getPaymentForms response to avoid another http request while testing
+      self.orderService.purchaseForms = purchaseFormResponseZoomMapped;
+
+      self.orderService.submitWithCcv('123')
+        .subscribe((data) => {
+          expect(data).toEqual('success');
+        });
+
+      self.$httpBackend.flush();
+    });
+  });
+
+  describe('storeCardSecurityCode', () => {
+    it('should store the encrypted ccv', () => {
+      let encryptedCcv = 'g43wj7sevtiusehiuhrv3478wehr783awhsuircahneyisuhwaf7eysu';
+      self.orderService.storeCardSecurityCode(encryptedCcv);
+      expect(self.$window.sessionStorage.getItem('ccv')).toEqual(encryptedCcv);
+    });
+    it('should throw an error when it looks like the security code is unencrypted (has less than 50 chars)', () => {
+      expect(() => self.orderService.storeCardSecurityCode('1234')).toThrowError('The CCV should be encrypted and the provided CCV looks like it is too short to be encrypted correctly');
+    });
+  });
+
+  describe('retrieveCardSecurityCode', () => {
+    it('should return the stored the encrypted ccv', () => {
+      let encryptedCcv = 'g43wj7sevtiusehiuhrv3478wehr783awhsuircahneyisuhwaf7eysu';
+      self.$window.sessionStorage.setItem('ccv', encryptedCcv);
+      expect(self.orderService.retrieveCardSecurityCode()).toEqual(encryptedCcv);
+    });
+  });
+
+  describe('clearCardSecurityCode', () => {
+    it('should clear the stored the encrypted ccv', () => {
+      let encryptedCcv = 'g43wj7sevtiusehiuhrv3478wehr783awhsuircahneyisuhwaf7eysu';
+      self.$window.sessionStorage.setItem('ccv', encryptedCcv);
+      self.orderService.clearCardSecurityCode();
+      expect(self.$window.sessionStorage.getItem('ccv')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
- Store encrypted CCV into session storage after step 2 credit card payment is submitted
- Add methods to order service to store, retrieve, and clear CCV to/from sessionStorage
- Add getPurchaseForms, submit, and submitWithCcv methods to order service
- Add check for no current payments when loading them in step 3
- In step 3, write submitOrder function to choose and submit the purchase form depending on current payment type
- Fix ng-disabled on Submit your Gift button to check if at least one payment is loaded
- gulp test only needs to run html
- Fix wrong input name in bank account spec

#### Notes:
- Submitting the bank account form will most likely fail as it check for a billing address. Sending a billing address to cortex hasn't been implemented yet. (The `enhancedpurchaseaction` for credit cards doesn't seem to have that kind of validation which is probably a bug)
- From a previous PR: the credit card number on the review page is showing the encrypted version. The api is sending the wrong data back in that field. The backend guys should know about it.