### PR TITLE
Session expiry

### DIFF
--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -18,8 +18,8 @@ let componentName = 'cart';
 class CartController{
 
   /* @ngInject */
-  constructor($location, $uibModal, cartService, sessionService) {
-    this.$location = $location;
+  constructor($window, $uibModal, cartService, sessionService) {
+    this.$window = $window;
     this.$uibModal = $uibModal;
     this.cartService = cartService;
     this.sessionService = sessionService;
@@ -66,7 +66,7 @@ class CartController{
   }
 
   checkout() {
-    this.$location.url(this.sessionService.getRole() === 'REGISTERED' ? 'checkout.html' : 'sign-in.html');
+    this.$window.location.href = this.sessionService.getRole() === 'REGISTERED' ? 'checkout.html' : 'sign-in.html';
   }
 }
 

--- a/src/app/signIn/signIn.component.js
+++ b/src/app/signIn/signIn.component.js
@@ -10,12 +10,12 @@ let componentName = 'signIn';
 class SignInController {
 
   /* @ngInject */
-  constructor( $location ) {
-    this.$location = $location;
+  constructor( $window ) {
+    this.$window = $window;
   }
 
   signInSuccess() {
-    this.$location.url( 'checkout.html' );
+    this.$window.location.href = 'checkout.html';
   }
 }
 

--- a/src/common/services/session.service.js
+++ b/src/common/services/session.service.js
@@ -18,6 +18,7 @@ function session( $cookies, $rootScope, $http, envService ) {
   updateCurrentSession( $cookies.get( 'cortex-session' ) );
 
   // Watch cortex-session cookie for changes and update existing session variable
+  // This only detects changes made by $http or other angular services, not the browser expiring the cookie.
   // eslint-disable-next-line angular/on-watch
   $rootScope.$watch( () => $cookies.get( 'cortex-session' ), updateCurrentSession );
 
@@ -57,8 +58,14 @@ function session( $cookies, $rootScope, $http, envService ) {
   }
 
   function currentRole() {
-    // @todo Check session expiration
     if ( angular.isDefined( session.token_hash ) ) {
+      if ( session.token_hash.role === 'PUBLIC' ) {
+        return 'PUBLIC';
+      }
+      // Expired cookies are undefined
+      if ( angular.isUndefined( $cookies.get( 'give-session' ) ) ) {
+        return 'IDENTIFIED';
+      }
       return session.token_hash.role;
     }
     return 'PUBLIC';


### PR DESCRIPTION
Updates sessionService.getRole() to check current 'give-session' cookie before returning the 'cortex-session' role. This accounts for users who are idle more than give-session expiration.

Fixes $location.url() issues by using $window.location.href instead.