### PR TITLE
Use enhancedpurchaseform for all checkout flows

### DIFF
--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -45,7 +45,7 @@ class Step3Controller{
       submitRequest = this.orderService.submit();
     }else if(this.creditCardPaymentDetails){
       let encryptedCcv = this.orderService.retrieveCardSecurityCode();
-      submitRequest = encryptedCcv ? this.orderService.submitWithCcv(encryptedCcv) : Observable.throw('Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly');
+      submitRequest = encryptedCcv ? this.orderService.submit(encryptedCcv) : Observable.throw('Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly');
     }else{
       submitRequest = Observable.throw('Current payment type is unknown');
     }

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -89,8 +89,7 @@ describe('checkout', () => {
         self.controller.creditCardPaymentDetails = {};
         self.storedCcv = '1234';
         self.controller.submitOrder();
-        expect(self.controller.orderService.submit).not.toHaveBeenCalled();
-        expect(self.controller.orderService.submitWithCcv).toHaveBeenCalledWith('1234');
+        expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234');
         expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
       });
       it('should throw an error if paying with a credit card and the CCV is missing', () => {

--- a/src/common/services/api/fixtures/cortex-purchaseform.fixture.js
+++ b/src/common/services/api/fixtures/cortex-purchaseform.fixture.js
@@ -51,18 +51,6 @@ export default {
         "href": "https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu="
       }],
       "security-code": ""
-    }],
-    "_purchaseform": [{
-      "self": {
-        "type": "elasticpath.purchases.purchase",
-        "uri": "/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=/form"
-      },
-      "links": [{
-        "rel": "submitorderaction",
-        "uri": "/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/purchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu="
-      }]
     }]
   }],
   "total-quantity": 1

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -69,38 +69,23 @@ class Order{
       });
   }
 
-  getPurchaseForms(){
-    if(this.purchaseForms){
-      return Observable.of(this.purchaseForms);
-    }else{
-      return this.cortexApiService.get({
-          path: ['carts', this.cortexApiService.scope, 'default'],
-          zoom: {
-            purchaseform: 'order:purchaseform',
-            enhancedpurchaseform: 'order:enhancedpurchaseform'
-          }
-        })
-        .do((data) => {
-          this.purchaseForms = data;
-        });
-    }
+  getPurchaseForm(){
+    return this.cortexApiService.get({
+      path: ['carts', this.cortexApiService.scope, 'default'],
+      zoom: {
+        enhancedpurchaseform: 'order:enhancedpurchaseform'
+      },
+      cache: true
+    });
   }
 
-  submit(){
-    return this.getPurchaseForms()
+  submit(ccv){
+    return this.getPurchaseForm()
       .mergeMap((data) => {
-        return this.cortexApiService.post({
-          path: this.hateoasHelperService.getLink(data.purchaseform, 'submitorderaction')
-        });
-      });
-  }
-
-  submitWithCcv(ccv){
-    return this.getPurchaseForms()
-      .mergeMap((data) => {
+        let postData = ccv ? {"security-code": ccv} : undefined;
         return this.cortexApiService.post({
           path: this.hateoasHelperService.getLink(data.enhancedpurchaseform, 'createenhancedpurchaseaction'),
-          data: {"security-code": ccv}
+          data: postData
         });
       });
   }


### PR DESCRIPTION
Still need to evaluate whether the app should to check for `needinfo` errors. Some of the time I wasn't seeing `enhancedpurchaseform` return those errors like `purchaseform` does. I guess I'll do that in another PR if I need to.