### PR TITLE
Donation config corrections

### DIFF
--- a/src/app/productConfig/productConfig.modal.js
+++ b/src/app/productConfig/productConfig.modal.js
@@ -11,6 +11,11 @@ class ModalInstanceCtrl{
     this.productData = productData;
 
     this.itemConfig = itemConfig;
+
+    this.selectableAmounts = [50, 100, 250, 500, 1000, 5000];
+    if(this.selectableAmounts.indexOf(itemConfig.amount) === -1){
+      this.customAmount = this.itemConfig.amount;
+    }
   }
 
   frequencyOrder(f){
@@ -22,6 +27,11 @@ class ModalInstanceCtrl{
     this.designationsService.productLookup(productId, true).subscribe((data) => {
       this.productData = data;
     });
+  }
+
+  changeAmount(amount){
+    this.itemConfig.amount = amount;
+    this.customAmount = '';
   }
 
   addToCart(){

--- a/src/app/productConfig/productConfig.modal.js
+++ b/src/app/productConfig/productConfig.modal.js
@@ -23,10 +23,11 @@ class ModalInstanceCtrl{
     return indexOf(order, f.name);
   }
 
-  changeFrequency(productId){
-    this.designationsService.productLookup(productId, true).subscribe((data) => {
+  changeFrequency(product){
+    this.designationsService.productLookup(product.selectAction, true).subscribe((data) => {
       this.productData = data;
     });
+    this.productData.frequency = product.name;
   }
 
   changeAmount(amount){

--- a/src/app/productConfig/productConfigModal.tpl.html
+++ b/src/app/productConfig/productConfigModal.tpl.html
@@ -48,8 +48,7 @@
                 </div>
               </label>
               <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error" ng-if="($ctrl.itemConfigForm.amount | showErrors)">
-                <div class="help-block" ng-message="required" translate>Amount must be at least $1</div>
-                <div class="help-block" ng-message="pattern" translate>Amount must be at least $1</div>
+                <div class="help-block" ng-message="pattern" translate>Amount must be a valid amount and at least $1</div>
               </div>
             </div>
           </div><!-- // panel-body -->

--- a/src/app/productConfig/productConfigModal.tpl.html
+++ b/src/app/productConfig/productConfigModal.tpl.html
@@ -47,7 +47,7 @@
                 </div>
               </label>
               <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error" ng-if="($ctrl.itemConfigForm.amount | showErrors)">
-                <div class="help-block" ng-message="required" translate>You must enter an amount</div>
+                <div class="help-block" ng-message="required" translate>Amount must be at least $1</div>
                 <div class="help-block" ng-message="min" translate>Amount must be at least $1</div>
               </div>
             </div>

--- a/src/app/productConfig/productConfigModal.tpl.html
+++ b/src/app/productConfig/productConfigModal.tpl.html
@@ -61,8 +61,8 @@
             <div data-toggle="buttons">
               <label class="btn btn-radio btn-wide"
                      ng-repeat-start="f in $ctrl.productData.frequencies | orderBy: $ctrl.frequencyOrder"
-                     ng-class="{'active': !f.selectAction}"
-                     ng-click="$ctrl.changeFrequency(f.selectAction)">
+                     ng-class="{'active': f.name === $ctrl.productData.frequency}"
+                     ng-click="$ctrl.changeFrequency(f)">
                 <span class="giftsum-about giftsum-title" ng-switch="f.name">
                   <span ng-switch-when="NA" translate>Single Gift</span>
                   <span ng-switch-default>{{f.display}}</span>
@@ -83,7 +83,7 @@
                   <div class="form-group">
                     <label translate>Month</label>
                     <div class="form-group">
-                      <select class="form-control form-control-subtle" ng-model="$ctrl.itemConfig.month">
+                      <select class="form-control form-control-subtle" ng-model="$ctrl.itemConfig['start-month']">
                         <option value="01" translate>January</option>
                         <option value="02" translate>February</option>
                         <option value="03" translate>March</option>
@@ -104,7 +104,7 @@
                   <div class="form-group">
                     <label translate>Day</label>
                     <div class="form-group">
-                      <select class="form-control form-control-subtle" ng-model="$ctrl.itemConfig.day" ng-options="o as o for o in $ctrl.daysInMonth($ctrl.itemConfig.month)">
+                      <select class="form-control form-control-subtle" ng-model="$ctrl.itemConfig['start-day']" ng-options="o as o for o in $ctrl.daysInMonth($ctrl.itemConfig['start-month'])">
                       </select>
                     </div>
                   </div>

--- a/src/app/productConfig/productConfigModal.tpl.html
+++ b/src/app/productConfig/productConfigModal.tpl.html
@@ -35,20 +35,21 @@
             <!--</div>-->
 
             <div data-toggle="buttons" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 50" ng-class="{'active': $ctrl.itemConfig.amount === 50}"><span class="number">$50</span></label>
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 100" ng-class="{'active': $ctrl.itemConfig.amount === 100}"><span class="number">$100</span></label>
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 250" ng-class="{'active': $ctrl.itemConfig.amount === 250}"><span class="number">$250</span></label>
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 500" ng-class="{'active': $ctrl.itemConfig.amount === 500}"><span class="number">$500</span></label>
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 1000" ng-class="{'active': $ctrl.itemConfig.amount === 1000}"><span class="number">$1000</span></label>
-              <label class="btn btn-radio" ng-click="$ctrl.itemConfig.amount = 5000" ng-class="{'active': $ctrl.itemConfig.amount === 5000}"><span class="number">$5000</span></label>
+              <label class="btn btn-radio" ng-click="$ctrl.changeAmount(a)" ng-class="{'active': $ctrl.itemConfig.amount === a}" ng-repeat-start="a in $ctrl.selectableAmounts">
+                <span class="number">${{a}}</span>
+              </label>
+              <span ng-repeat-end></span>
               <label class="btn btn-default-form u-textLeft custom-amount">
                 <div class="form-group form-group-default u-inline">
-                  <input class="form-control form-control-subtle number" min="1" type="number" name="amount" ng-model="$ctrl.itemConfig.amount" required>
+                  <input class="form-control form-control-subtle number" type="text" name="amount"
+                         ng-model="$ctrl.customAmount"
+                         ng-change="$ctrl.itemConfig.amount = $ctrl.customAmount"
+                         ng-pattern="/^[1-9]\d*(\.\d+)?$/">
                 </div>
               </label>
               <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error" ng-if="($ctrl.itemConfigForm.amount | showErrors)">
                 <div class="help-block" ng-message="required" translate>Amount must be at least $1</div>
-                <div class="help-block" ng-message="min" translate>Amount must be at least $1</div>
+                <div class="help-block" ng-message="pattern" translate>Amount must be at least $1</div>
               </div>
             </div>
           </div><!-- // panel-body -->
@@ -63,7 +64,10 @@
                      ng-repeat-start="f in $ctrl.productData.frequencies | orderBy: $ctrl.frequencyOrder"
                      ng-class="{'active': !f.selectAction}"
                      ng-click="$ctrl.changeFrequency(f.selectAction)">
-                <span class="giftsum-about giftsum-title">{{f.display}}</span>
+                <span class="giftsum-about giftsum-title" ng-switch="f.name">
+                  <span ng-switch-when="NA" translate>Single Gift</span>
+                  <span ng-switch-default>{{f.display}}</span>
+                </span>
               </label>
               <span ng-repeat-end></span>
             </div>
@@ -112,7 +116,7 @@
         </div>
         <div class="panel panel-default give-modal-panel">
           <h4 class="panel-title border-bottom-small mt" translate>
-            Optional Comments
+            Optional
           </h4>
           <div class="panel-body pt0">
             <ul class="list-unstyled">
@@ -126,7 +130,7 @@
                         style="display:block;"></textarea>
               </li>
               <li>
-                <a class="commentLink" href="" ng-click="showDSComments = !showDSComments" translate>Special Handling Instructions for Processing the Gift</a>
+                <a class="commentLink" href="" ng-click="showDSComments = !showDSComments" translate>Special Handling Instructions for Processing This Gift</a>
                 <textarea class="cru-comments give-modal-comments"
                         rows="3"
                         maxlength="250"


### PR DESCRIPTION
This are corrections from QA.

1) In the AMOUNT section – the last option is for "other amount" – for some reason it is getting pre-populated with whichever amount is being selected (for example "50"). If you try to change it, weird up/down arrows show up and make it feel like you have to click one at a time to increase the amount. See how United Way handles their amounts: https://donate.unitedway.org/get-involved/ways-to-give/donate – that's the standard behavior we want.
2) GIFT FREQUENCY - change "One Time" to "Single Gift"
3) OPTIONAL COMMENTS - drop the word "Comments" from the title
4) "Special Handling instructions for Processing the Gift" should read "Special Handling Instructions for Processing This Gift"