### PR TITLE
Add Rollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "jsencrypt": "npm:jsencrypt@^2.3.1",
       "jwt-decode": "github:auth0/jwt-decode@^2.1.0",
       "lodash": "npm:lodash@^4.14.2",
+      "rollbar-browser": "npm:rollbar-browser@^1.9.1",
       "rxjs": "npm:rxjs@^5.0.0-beta.11"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
       "jwt-decode": "github:auth0/jwt-decode@^2.1.0",
       "lodash": "npm:lodash@^4.14.2",
       "rollbar-browser": "npm:rollbar-browser@^1.9.1",
-      "rxjs": "npm:rxjs@^5.0.0-beta.11"
+      "rxjs": "npm:rxjs@^5.0.0-beta.11",
+      "stacktrace-js": "npm:stacktrace-js@^1.3.1"
     },
     "devDependencies": {
       "angular-mocks": "github:angular/bower-angular-mocks@^1.5.8",

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -4,6 +4,8 @@ import 'babel/external-helpers';
 import angular from 'angular';
 import 'angular-environment';
 
+import rollbarConfig from './rollbar.config';
+
 /* @ngInject */
 function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProvider) {
   $httpProvider.useApplyAsync(true);
@@ -49,4 +51,5 @@ function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProv
 export default angular.module('appConfig', [
     'environment'
 ])
-  .config(appConfig);
+  .config(appConfig)
+  .config(rollbarConfig);

--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -23,10 +23,13 @@ const ccpStagingKey = '-----BEGIN PUBLIC KEY-----' +
 
 const cortexScope = 'crugive';
 
+const rollbarAccessToken = 'a5bb784f937841538494e747f70a4597';
+
 // See envServiceProvider.config in common/app.config.js for url configurations
 
 export {
   ccpKey,
   ccpStagingKey,
-  cortexScope
+  cortexScope,
+  rollbarAccessToken
 };

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -1,7 +1,9 @@
 import { rollbarAccessToken } from 'common/app.constants';
 import rollbar from 'rollbar-browser';
 import stacktrace from 'stacktrace-js';
+import map from 'lodash/map';
 import defaults from 'lodash/defaults';
+import get from 'lodash/get';
 
 /* @ngInject */
 function rollbarConfig(envServiceProvider, $provide) {
@@ -11,7 +13,8 @@ function rollbarConfig(envServiceProvider, $provide) {
     captureUnhandledRejections: true,
     environment: envServiceProvider.get(),
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
-    verbose: envServiceProvider.is('development') // Log rollbar errors to console in development environment
+    verbose: envServiceProvider.is('development'), // Log rollbar errors to console in development environment
+    transform: transformRollbarPayload
   };
   let Rollbar = rollbar.init(rollbarConfig);
 
@@ -28,19 +31,23 @@ function rollbarConfig(envServiceProvider, $provide) {
 
         // Generate message string
         let message = args
-          .map((arg) => angular.toJson(arg))
+          .map((arg) => {
+            if(arg.message){
+              return arg.message; // Message came from $ExceptionHandler
+            }else{
+              return angular.toJson(arg);
+            }
+          })
           .join(', ');
+
+        let origin = args[0].message ? '$ExceptionHandler' : '$log';
 
         stacktrace.get({offline: true})
           .then((stackFrames) => {
             // Ignore first stack frame which is this function
             stackFrames.shift();
-            // Convert stack trace to string
-            stackFrames = stackFrames.map((sf) => {
-              return '    at ' + sf.toString();
-            }).join('\n');
             // Send combined message and stack trace to rollbar
-            Rollbar[rollbarLogLevel](message + '\n' + stackFrames);
+            Rollbar[rollbarLogLevel](message, {stackTrace: stackFrames, origin: origin});
           })
           .catch((error) => {
             // Send message without stack trace to rollbar
@@ -55,10 +62,39 @@ function rollbarConfig(envServiceProvider, $provide) {
 
     return $delegate;
   });
+
+}
+
+function formatStacktraceForRollbar(stackFrames){
+  return map(stackFrames, (frame) => {
+    return {
+      method: frame.functionName,
+      lineno: frame.lineNumber,
+      colno: frame.columnNumber,
+      filename: frame.fileName
+    };
+  });
+}
+
+function transformRollbarPayload(payload){
+  if(get(payload, 'data.body.message.extra.stackTrace')) {
+    // Convert message format to trace format
+    payload.data.body.trace = {
+      frames: formatStacktraceForRollbar(payload.data.body.message.extra.stackTrace),
+      exception: {
+        message: payload.data.body.message.body,
+        class: payload.data.body.message.extra.origin
+      }
+    };
+    delete payload.data.body.message;
+  }
+  return payload;
 }
 
 export {
   rollbarConfig as default,
   rollbar, // For mocking during testing
-  stacktrace // For mocking during testing
+  stacktrace, // For mocking during testing,
+  formatStacktraceForRollbar, // To test this function separately
+  transformRollbarPayload // To test this function separately
 };

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -13,7 +13,6 @@ function rollbarConfig(envServiceProvider, $provide) {
     captureUnhandledRejections: true,
     environment: envServiceProvider.get(),
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
-    verbose: envServiceProvider.is('development'), // Log rollbar errors to console in development environment
     transform: transformRollbarPayload
   };
   let Rollbar = rollbar.init(rollbarConfig);

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -1,11 +1,10 @@
 import { rollbarAccessToken } from 'common/app.constants';
 import rollbar from 'rollbar-browser';
 import stacktrace from 'stacktrace-js';
+import defaults from 'lodash/defaults';
 
 /* @ngInject */
-function rollbarConfig(envServiceProvider, $provide, $windowProvider) {
-  if($windowProvider.$get().__karma__ !== undefined) return; // Don't decorate $log in test env
-
+function rollbarConfig(envServiceProvider, $provide) {
   let rollbarConfig = {
     accessToken: rollbarAccessToken,
     captureUncaught: true,
@@ -37,7 +36,7 @@ function rollbarConfig(envServiceProvider, $provide, $windowProvider) {
             // Ignore first stack frame which is this function
             stackFrames.shift();
             // Convert stack trace to string
-            stackFrames = stackFrames.map(function(sf) {
+            stackFrames = stackFrames.map((sf) => {
               return '    at ' + sf.toString();
             }).join('\n');
             // Send combined message and stack trace to rollbar
@@ -50,10 +49,16 @@ function rollbarConfig(envServiceProvider, $provide, $windowProvider) {
             Rollbar.warning('Error loading stackframes: ' + error);
           });
       };
+
+      defaults($delegate[ngLogLevel], originalFunction); // copy properties of original $log function which specs use
     });
 
     return $delegate;
   });
 }
 
-export default rollbarConfig;
+export {
+  rollbarConfig as default,
+  rollbar, // For mocking during testing
+  stacktrace // For mocking during testing
+};

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -1,0 +1,29 @@
+import { rollbarAccessToken } from 'common/app.constants';
+import rollbar from 'rollbar-browser';
+
+/* @ngInject */
+function rollbarConfig(envServiceProvider, $provide) {
+  let rollbarConfig = {
+    accessToken: rollbarAccessToken,
+    captureUncaught: true,
+    captureUnhandledRejections: true,
+    environment: envServiceProvider.get()
+  };
+  let Rollbar = rollbar.init(rollbarConfig);
+
+  /* @ngInject */
+  $provide.decorator('$log', ($delegate) => {
+    angular.forEach(['log', 'debug', 'info', 'warn', 'error'], (ngLogLevel) => {
+      let originalFunction = $delegate[ngLogLevel];
+      let rollbarLogLevel = ngLogLevel === 'warn' ? 'warning' : ngLogLevel;
+      $delegate[ngLogLevel] = function () {
+        Rollbar[rollbarLogLevel]([].slice.call(arguments)); // Convert arguments to array
+        originalFunction.apply(null, arguments);
+      };
+    });
+
+    return $delegate;
+  });
+}
+
+export default rollbarConfig;

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -1,0 +1,97 @@
+import angular from 'angular';
+import 'angular-mocks';
+import 'angular-environment';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
+import 'rxjs/add/operator/toPromise';
+
+import * as module from './rollbar.config';
+
+describe('rollbarConfig', () => {
+  var self = {};
+
+  beforeEach(() => {
+    // Use rollbar config function somewhere
+    angular.module('testRollbarConfig', ['environment'])
+      .config(module.default);
+
+    // Mock rollbar
+    self.rollbarSpies = {
+      log: jasmine.createSpy('log'),
+      debug: jasmine.createSpy('debug'),
+      info: jasmine.createSpy('info'),
+      warning: jasmine.createSpy('warning'),
+      error: jasmine.createSpy('error')
+    };
+    module.rollbar.init = () => self.rollbarSpies;
+
+    // Mock stacktrace
+    self.stacktraceSpy = spyOn(module.stacktrace, 'get').and.callFake(() => Observable.of(['ignored frame', 'first frame']).toPromise());
+
+    // Init and run the test module
+    angular.mock.module('testRollbarConfig');
+
+    inject(($log, $window) => {
+      self.$log = $log;
+      self.$window = $window;
+    });
+  });
+
+  it('should send $log.log to rollbar and call through to $log', (done) => {
+    spyOn(self.$log, 'log').and.callThrough();
+    self.$log.log('test log');
+    expect(self.$log.log.logs[0]).toEqual(['test log']);
+    self.$window.setTimeout(() => { // Use setTimout to wait until the event loop has been called once to process the stacktrace promise
+      expect(self.rollbarSpies.log).toHaveBeenCalledWith('"test log"\n    at first frame');
+      done(); // Tell jasmine that our async behavior has finished
+    });
+  });
+  it('should send $log.debug to rollbar and call through to $log', (done) => {
+    spyOn(self.$log, 'debug').and.callThrough();
+    self.$log.debug('test debug');
+    expect(self.$log.debug.logs[0]).toEqual(['test debug']);
+    self.$window.setTimeout(() => {
+      expect(self.rollbarSpies.debug).toHaveBeenCalledWith('"test debug"\n    at first frame');
+      done();
+    });
+  });
+  it('should send $log.info to rollbar and call through to $log', (done) => {
+    spyOn(self.$log, 'info').and.callThrough();
+    self.$log.info('test info');
+    expect(self.$log.info.logs[0]).toEqual(['test info']);
+    self.$window.setTimeout(() => {
+      expect(self.rollbarSpies.info).toHaveBeenCalledWith('"test info"\n    at first frame');
+      done();
+    });
+  });
+  it('should send $log.warn to rollbar and call through to $log', (done) => {
+    spyOn(self.$log, 'warn').and.callThrough();
+    self.$log.warn('test warn');
+    expect(self.$log.warn.logs[0]).toEqual(['test warn']);
+    self.$window.setTimeout(() => {
+      expect(self.rollbarSpies.warning).toHaveBeenCalledWith('"test warn"\n    at first frame');
+      done();
+    });
+  });
+  it('should send $log.error to rollbar and call through to $log', (done) => {
+    spyOn(self.$log, 'error').and.callThrough();
+    self.$log.error('test error');
+    expect(self.$log.error.logs[0]).toEqual(['test error']);
+    self.$window.setTimeout(() => {
+      expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"\n    at first frame');
+      done();
+    });
+  });
+  it('should send a log to rollbar even the stacktrace fails', (done) => {
+    spyOn(self.$log, 'error').and.callThrough();
+    self.stacktraceSpy.and.callFake(() => Observable.throw('error message when fetching stack').toPromise());
+    self.$log.error('test error');
+    expect(self.$log.error.logs[0]).toEqual(['test error']);
+    self.$window.setTimeout(() => {
+      expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"');
+      expect(self.rollbarSpies.warning).toHaveBeenCalledWith('Error loading stackframes: error message when fetching stack');
+      done();
+    });
+  });
+});

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -11,87 +11,202 @@ import * as module from './rollbar.config';
 describe('rollbarConfig', () => {
   var self = {};
 
-  beforeEach(() => {
-    // Use rollbar config function somewhere
-    angular.module('testRollbarConfig', ['environment'])
-      .config(module.default);
+  describe('pipe $log to Rollbar', () => {
+    beforeEach(() => {
+      // Use rollbar config function somewhere
+      angular.module('testRollbarConfig', ['environment'])
+        .config(module.default);
 
-    // Mock rollbar
-    self.rollbarSpies = {
-      log: jasmine.createSpy('log'),
-      debug: jasmine.createSpy('debug'),
-      info: jasmine.createSpy('info'),
-      warning: jasmine.createSpy('warning'),
-      error: jasmine.createSpy('error')
-    };
-    module.rollbar.init = () => self.rollbarSpies;
+      // Mock rollbar
+      self.rollbarSpies = {
+        log: jasmine.createSpy('log'),
+        debug: jasmine.createSpy('debug'),
+        info: jasmine.createSpy('info'),
+        warning: jasmine.createSpy('warning'),
+        error: jasmine.createSpy('error')
+      };
+      module.rollbar.init = () => self.rollbarSpies;
 
-    // Mock stacktrace
-    self.stacktraceSpy = spyOn(module.stacktrace, 'get').and.callFake(() => Observable.of(['ignored frame', 'first frame']).toPromise());
 
-    // Init and run the test module
-    angular.mock.module('testRollbarConfig');
+      self.rollbarExtraArgs = {
+        stackTrace: [
+          {
+            functionName: 'a',
+            lineNumber: 1,
+            columnNumber: 1,
+            fileName: 'a.js'
+          }
+        ],
+        origin: '$log'
+      };
 
-    inject(($log, $window) => {
-      self.$log = $log;
-      self.$window = $window;
+      // Mock stacktrace
+      self.stacktraceSpy = spyOn(module.stacktrace, 'get').and.callFake(() =>
+        Observable.of(['ignored frame', self.rollbarExtraArgs.stackTrace[0]]).toPromise());
+
+      // Init and run the test module
+      angular.mock.module('testRollbarConfig');
+
+      inject(($log, $window) => {
+        self.$log = $log;
+        self.$window = $window;
+      });
+    });
+
+    it('should send $log.log to rollbar and call through to $log', (done) => {
+      spyOn(self.$log, 'log').and.callThrough();
+      self.$log.log('test log');
+      expect(self.$log.log.logs[0]).toEqual(['test log']);
+      self.$window.setTimeout(() => { // Use setTimout to wait until the event loop has been called once to process the stacktrace promise
+        expect(self.rollbarSpies.log).toHaveBeenCalledWith('"test log"', self.rollbarExtraArgs);
+        done(); // Tell jasmine that our async behavior has finished
+      });
+    });
+    it('should send $log.debug to rollbar and call through to $log', (done) => {
+      spyOn(self.$log, 'debug').and.callThrough();
+      self.$log.debug('test debug');
+      expect(self.$log.debug.logs[0]).toEqual(['test debug']);
+      self.$window.setTimeout(() => {
+        expect(self.rollbarSpies.debug).toHaveBeenCalledWith('"test debug"', self.rollbarExtraArgs);
+        done();
+      });
+    });
+    it('should send $log.info to rollbar and call through to $log', (done) => {
+      spyOn(self.$log, 'info').and.callThrough();
+      self.$log.info('test info');
+      expect(self.$log.info.logs[0]).toEqual(['test info']);
+      self.$window.setTimeout(() => {
+        expect(self.rollbarSpies.info).toHaveBeenCalledWith('"test info"', self.rollbarExtraArgs);
+        done();
+      });
+    });
+    it('should send $log.warn to rollbar and call through to $log', (done) => {
+      spyOn(self.$log, 'warn').and.callThrough();
+      self.$log.warn('test warn');
+      expect(self.$log.warn.logs[0]).toEqual(['test warn']);
+      self.$window.setTimeout(() => {
+        expect(self.rollbarSpies.warning).toHaveBeenCalledWith('"test warn"', self.rollbarExtraArgs);
+        done();
+      });
+    });
+    it('should send $log.error to rollbar and call through to $log', (done) => {
+      spyOn(self.$log, 'error').and.callThrough();
+      self.$log.error('test error');
+      expect(self.$log.error.logs[0]).toEqual(['test error']);
+      self.$window.setTimeout(() => {
+        expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"', self.rollbarExtraArgs);
+        done();
+      });
+    });
+    it('should send errors from $ExceptionHandler to rollbar', (done) => {
+      spyOn(self.$log, 'error').and.callThrough();
+      self.$log.error(new Error('some exception'));
+      expect(self.$log.error.logs[0]).toEqual([new Error('some exception')]);
+      self.$window.setTimeout(() => {
+        self.rollbarExtraArgs.origin = '$ExceptionHandler';
+        expect(self.rollbarSpies.error).toHaveBeenCalledWith('some exception', self.rollbarExtraArgs);
+        done();
+      });
+    });
+    it('should send a log to rollbar even the stacktrace fails', (done) => {
+      spyOn(self.$log, 'error').and.callThrough();
+      self.stacktraceSpy.and.callFake(() => Observable.throw('error message when fetching stack').toPromise());
+      self.$log.error('test error');
+      expect(self.$log.error.logs[0]).toEqual(['test error']);
+      self.$window.setTimeout(() => {
+        expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"');
+        expect(self.rollbarSpies.warning).toHaveBeenCalledWith('Error loading stackframes: error message when fetching stack');
+        done();
+      });
     });
   });
 
-  it('should send $log.log to rollbar and call through to $log', (done) => {
-    spyOn(self.$log, 'log').and.callThrough();
-    self.$log.log('test log');
-    expect(self.$log.log.logs[0]).toEqual(['test log']);
-    self.$window.setTimeout(() => { // Use setTimout to wait until the event loop has been called once to process the stacktrace promise
-      expect(self.rollbarSpies.log).toHaveBeenCalledWith('"test log"\n    at first frame');
-      done(); // Tell jasmine that our async behavior has finished
+  describe('formatStacktraceForRollbar', () => {
+    it('should rename stack frame object keys', () => {
+      expect(module.formatStacktraceForRollbar([
+        {
+          functionName: 'a',
+          lineNumber: 1,
+          columnNumber: 1,
+          fileName: 'a.js'
+        },
+        {
+          functionName: 'b',
+          lineNumber: 2,
+          columnNumber: 2,
+          fileName: 'b.js'
+        }
+      ]))
+        .toEqual([
+          {
+            method: 'a',
+            lineno: 1,
+            colno: 1,
+            filename: 'a.js'
+          },
+          {
+            method: 'b',
+            lineno: 2,
+            colno: 2,
+            filename: 'b.js'
+          }
+        ]);
     });
   });
-  it('should send $log.debug to rollbar and call through to $log', (done) => {
-    spyOn(self.$log, 'debug').and.callThrough();
-    self.$log.debug('test debug');
-    expect(self.$log.debug.logs[0]).toEqual(['test debug']);
-    self.$window.setTimeout(() => {
-      expect(self.rollbarSpies.debug).toHaveBeenCalledWith('"test debug"\n    at first frame');
-      done();
+
+  describe('transformRollbarPayload', () => {
+    it('should convert the payload from message format to trace format', () => {
+      expect(module.transformRollbarPayload({
+        data: {
+          body: {
+            message: {
+              body: 'some error',
+              extra: {
+                stackTrace: [{
+                  functionName: 'a',
+                  lineNumber: 1,
+                  columnNumber: 1,
+                  fileName: 'a.js'
+                }],
+                origin: '$log'
+              }
+            }
+          }
+        }
+      }))
+        .toEqual({
+          data: {
+            body: {
+              trace: {
+                frames: [{
+                  method: 'a',
+                  lineno: 1,
+                  colno: 1,
+                  filename: 'a.js'
+                }],
+                exception: {
+                  message: 'some error',
+                  class: '$log'
+                }
+              }
+            }
+          }
+        });
     });
-  });
-  it('should send $log.info to rollbar and call through to $log', (done) => {
-    spyOn(self.$log, 'info').and.callThrough();
-    self.$log.info('test info');
-    expect(self.$log.info.logs[0]).toEqual(['test info']);
-    self.$window.setTimeout(() => {
-      expect(self.rollbarSpies.info).toHaveBeenCalledWith('"test info"\n    at first frame');
-      done();
-    });
-  });
-  it('should send $log.warn to rollbar and call through to $log', (done) => {
-    spyOn(self.$log, 'warn').and.callThrough();
-    self.$log.warn('test warn');
-    expect(self.$log.warn.logs[0]).toEqual(['test warn']);
-    self.$window.setTimeout(() => {
-      expect(self.rollbarSpies.warning).toHaveBeenCalledWith('"test warn"\n    at first frame');
-      done();
-    });
-  });
-  it('should send $log.error to rollbar and call through to $log', (done) => {
-    spyOn(self.$log, 'error').and.callThrough();
-    self.$log.error('test error');
-    expect(self.$log.error.logs[0]).toEqual(['test error']);
-    self.$window.setTimeout(() => {
-      expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"\n    at first frame');
-      done();
-    });
-  });
-  it('should send a log to rollbar even the stacktrace fails', (done) => {
-    spyOn(self.$log, 'error').and.callThrough();
-    self.stacktraceSpy.and.callFake(() => Observable.throw('error message when fetching stack').toPromise());
-    self.$log.error('test error');
-    expect(self.$log.error.logs[0]).toEqual(['test error']);
-    self.$window.setTimeout(() => {
-      expect(self.rollbarSpies.error).toHaveBeenCalledWith('"test error"');
-      expect(self.rollbarSpies.warning).toHaveBeenCalledWith('Error loading stackframes: error message when fetching stack');
-      done();
+    it('should leave the payload unmodified if extra.stackTrace is missing', () => {
+      let payload = {
+        data: {
+          body: {
+            message: {
+              body: 'some error',
+              extra: {
+                somethingElse: 1
+              }
+            }
+          }
+        }
+      };
+      expect(module.transformRollbarPayload(payload)).toEqual(payload);
     });
   });
 });

--- a/system.config.js
+++ b/system.config.js
@@ -38,6 +38,7 @@ System.config({
     "plugin-babel-runtime": "npm:babel-runtime@5.8.38",
     "rollbar-browser": "npm:rollbar-browser@1.9.1",
     "rxjs": "npm:rxjs@5.0.0-beta.11",
+    "stacktrace-js": "npm:stacktrace-js@1.3.1",
     "systemjs-babel-build": "npm:systemjs-plugin-babel@0.0.13/systemjs-babel-browser.js",
     "github:angular/bower-angular-cookies@1.5.8": {
       "angular": "github:angular/bower-angular@1.5.8"
@@ -172,6 +173,9 @@ System.config({
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:error-stack-parser@1.3.3": {
+      "stackframe": "npm:stackframe@0.3.1"
+    },
+    "npm:error-stack-parser@1.3.6": {
       "stackframe": "npm:stackframe@0.3.1"
     },
     "npm:fancy-log@1.2.0": {
@@ -472,8 +476,26 @@ System.config({
     "npm:spdx-license-ids@1.2.2": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
+    "npm:stack-generator@1.1.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stackframe": "npm:stackframe@1.0.2"
+    },
     "npm:stackframe@0.3.1": {
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:stackframe@1.0.2": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:stacktrace-gps@2.4.4": {
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "source-map": "npm:source-map@0.5.6",
+      "stackframe": "npm:stackframe@0.3.1"
+    },
+    "npm:stacktrace-js@1.3.1": {
+      "error-stack-parser": "npm:error-stack-parser@1.3.6",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stack-generator": "npm:stack-generator@1.1.0",
+      "stacktrace-gps": "npm:stacktrace-gps@2.4.4"
     },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",

--- a/system.config.js
+++ b/system.config.js
@@ -36,6 +36,7 @@ System.config({
     "lodash": "npm:lodash@4.15.0",
     "plugin-babel": "npm:systemjs-plugin-babel@0.0.13",
     "plugin-babel-runtime": "npm:babel-runtime@5.8.38",
+    "rollbar-browser": "npm:rollbar-browser@1.9.1",
     "rxjs": "npm:rxjs@5.0.0-beta.11",
     "systemjs-babel-build": "npm:systemjs-plugin-babel@0.0.13/systemjs-babel-browser.js",
     "github:angular/bower-angular-cookies@1.5.8": {
@@ -169,6 +170,9 @@ System.config({
     "npm:error-ex@1.3.0": {
       "is-arrayish": "npm:is-arrayish@0.2.1",
       "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:error-stack-parser@1.3.3": {
+      "stackframe": "npm:stackframe@0.3.1"
     },
     "npm:fancy-log@1.2.0": {
       "chalk": "npm:chalk@1.1.3",
@@ -428,6 +432,17 @@ System.config({
     "npm:right-align@0.1.3": {
       "align-text": "npm:align-text@0.1.4"
     },
+    "npm:rollbar-browser@1.9.1": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "console-polyfill": "npm:console-polyfill@0.2.2",
+      "error-stack-parser": "npm:error-stack-parser@1.3.3",
+      "extend": "npm:extend@3.0.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
     "npm:rxjs@5.0.0-beta.11": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
@@ -456,6 +471,9 @@ System.config({
     },
     "npm:spdx-license-ids@1.2.2": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+    },
+    "npm:stackframe@0.3.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",


### PR DESCRIPTION
This adds the generic rollbar error handling but also pipes Angular's `$log` to rollbar with stack traces.

I made a `give-web devs` team on Rollbar but I haven't added you guys yet. Feel free to add yourselves or I can. I just didn't want you guys getting random errors as I test it.