### PR TITLE
Fixes issue with signIn Modal closing on invalid user/pass

### DIFF
--- a/src/common/components/signInModal/signInModal.component.js
+++ b/src/common/components/signInModal/signInModal.component.js
@@ -42,7 +42,6 @@ export default angular
     bindings:    {
       modalTitle:    '=',
       onStateChange: '&',
-      onSuccess:     '&',
-      onFailure:     '&'
+      onSuccess:     '&'
     }
   } );

--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -2,7 +2,7 @@
   <p ng-if="$ctrl.identified" class="text-center mb0">
     <strong translate>Welcome back, {{$ctrl.session.first_name}} {{$ctrl.session.last_name}}!</strong>
   </p>
-  <sign-in-form on-success="$ctrl.onSuccess()" on-failure="$ctrl.onFailure()"></sign-in-form>
+  <sign-in-form on-success="$ctrl.onSuccess()"></sign-in-form>
   <p class="text-center" ng-class="{'mt mb0': $ctrl.identified}">
     <span translate>Forgot your password?</span>
     <a href ng-click="$ctrl.onStateChange({state: 'reset-password'})" translate>Reset It</a>

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -23,8 +23,7 @@
         <sign-in-modal ng-switch-when="sign-in"
                        modal-title="$ctrl.modalTitle"
                        on-state-change="$ctrl.stateChanged(state)"
-                       on-success="$ctrl.onSignInSuccess()"
-                       on-failure="$ctrl.onFailure()">
+                       on-success="$ctrl.onSignInSuccess()">
         </sign-in-modal>
       </div>
     </div>


### PR DESCRIPTION
We shouldn't do anything onFailure (close the modal). Let the signInForm handle failure state. If the user wants to close the modal, then can do it manually.