### PR TITLE
Load CCP keys dynamically

### DIFF
--- a/src/app/checkout/step-2/bank-account/bank-account.spec.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.spec.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import 'angular-mocks';
 import size from 'lodash/size';
+import ccp from 'common/lib/ccp';
+import { ccpStagingKey } from 'common/app.constants';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
@@ -11,6 +13,17 @@ describe('checkout', () => {
     describe('bank account', () => {
       beforeEach(angular.mock.module(module.name));
       var self = {};
+
+      beforeEach(() => {
+        angular.mock.module(($provide) => {
+          $provide.value('ccpService', {
+            get: () => {
+              ccp.initialize(ccpStagingKey);
+              return Observable.of(ccp);
+            }
+          });
+        });
+      });
 
       beforeEach(inject(($rootScope, $componentController, $httpBackend, $compile) => {
         self.outerScope = $rootScope.$new();

--- a/src/app/checkout/step-2/credit-card/credit-card.component.js
+++ b/src/app/checkout/step-2/credit-card/credit-card.component.js
@@ -11,6 +11,7 @@ import showErrors from 'common/filters/showErrors.filter';
 import paymentValidationService from 'common/services/paymentValidation.service';
 import orderService from 'common/services/api/order.service';
 import geographiesService from 'common/services/api/geographies.service';
+import ccpService from 'common/services/ccp.service';
 
 import template from './credit-card.tpl';
 
@@ -19,12 +20,13 @@ let componentName = 'checkoutCreditCard';
 class CreditCardController {
 
   /* @ngInject */
-  constructor($scope, $log, paymentValidationService, orderService, geographiesService) {
+  constructor($scope, $log, paymentValidationService, orderService, geographiesService, ccpService) {
     this.$scope = $scope;
     this.$log = $log;
     this.paymentValidationService = paymentValidationService;
     this.orderService = orderService;
     this.geographiesService = geographiesService;
+    this.ccpService = ccpService;
 
     this.creditCardPayment = {};
     this.billingAddress = {
@@ -34,6 +36,7 @@ class CreditCardController {
   }
 
   $onInit(){
+    this.loadCcp();
     this.waitForFormInitialization();
     this.loadDonorDetails();
     this.loadCountries();
@@ -43,6 +46,13 @@ class CreditCardController {
     if (changes.submitted.currentValue === true) {
       this.savePayment();
     }
+  }
+
+  loadCcp(){
+    this.ccpService.get()
+      .subscribe((ccp) => {
+        this.ccp = ccp;
+      });
   }
 
   waitForFormInitialization() {
@@ -133,7 +143,8 @@ export default angular
     showErrors.name,
     paymentValidationService.name,
     orderService.name,
-    geographiesService.name
+    geographiesService.name,
+    ccpService.name
   ])
   .component(componentName, {
     controller: CreditCardController,

--- a/src/app/checkout/step-2/credit-card/credit-card.spec.js
+++ b/src/app/checkout/step-2/credit-card/credit-card.spec.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import 'angular-mocks';
 import size from 'lodash/size';
 import find from 'lodash/find';
+import ccp from 'common/lib/ccp';
+import { ccpStagingKey } from 'common/app.constants';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
@@ -15,6 +17,17 @@ describe('checkout', () => {
     describe('credit card', () => {
       beforeEach(angular.mock.module(module.name));
       var self = {};
+
+      beforeEach(() => {
+        angular.mock.module(($provide) => {
+          $provide.value('ccpService', {
+            get: () => {
+              ccp.initialize(ccpStagingKey);
+              return Observable.of(ccp);
+            }
+          });
+        });
+      });
 
       beforeEach(inject(($rootScope, $httpBackend, $compile) => {
         self.outerScope = $rootScope.$new();

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -18,15 +18,18 @@ function appConfig(envServiceProvider, $compileProvider, $logProvider, $httpProv
     vars: {
       development: {
         apiUrl: 'https://cortex-gateway-stage.cru.org',
-        imgDomain: ''
+        imgDomain: '',
+        ccpKeyUrl: 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current'
       },
       staging: {
         apiUrl: 'https://cortex-gateway-stage.cru.org',
-        imgDomain: '//cru-givestage.s3.amazonaws.com'
+        imgDomain: '//cru-givestage.s3.amazonaws.com',
+        ccpKeyUrl: 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current'
       },
       production: {
         apiUrl: 'https://cortex-gateway.cru.org',
-        imgDomain: '//cru-givestage.s3.amazonaws.com'
+        imgDomain: '//cru-givestage.s3.amazonaws.com',
+        ccpKeyUrl: 'https://ccp.ccci.org/api/v1/rest/client-encryption-keys/current'
       }
     }
   });

--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -1,3 +1,6 @@
+// These CCP keys are used as backup keys if a network request for one fails.
+// They should be updated annually (around mid-April) as CCP rotates encryption keys.
+// Last updated 08/11/2016
 const ccpKey = '-----BEGIN PUBLIC KEY-----' +
   'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiiBT37BsBVBgKfF6z78X' +
   'lOl73+HexgTND1Z7qCIScFPSRlQd+svsYah7kQKjNFGPYvz9dmBgNKq1EmdML2nz' +

--- a/src/common/services/ccp.service.js
+++ b/src/common/services/ccp.service.js
@@ -1,0 +1,48 @@
+import angular from 'angular';
+import ccp from 'common/lib/ccp';
+import 'angular-environment';
+import appConfig from 'common/app.config';
+import { ccpKey, ccpStagingKey } from 'common/app.constants';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/from';
+import 'rxjs/add/operator/pluck';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/map';
+
+let serviceName = 'ccpService';
+
+class Ccp {
+
+  /*@ngInject*/
+  constructor(envService, $http, $log){
+    this.envService = envService;
+    this.$http = $http;
+    this.$log = $log;
+  }
+
+  get(){
+    if(this.currentRequest){
+      return this.currentRequest; // Use cached/pending request
+    }
+    this.currentRequest = Observable.from(this.$http.get(this.envService.read('ccpKeyUrl')))
+      .pluck('data')
+      .catch((error) => {
+        this.$log.warn('Using backup CCP encryption key. There was an error retrieving the key from CCP', error);
+        return Observable.of(this.envService.is('production') ? ccpKey : ccpStagingKey); // Use hardcoded backup key
+      })
+      .map((key) => {
+        ccp.initialize(key);
+        return ccp;
+      });
+
+    return this.currentRequest;
+  }
+}
+
+export default angular
+  .module(serviceName, [
+    'environment',
+    appConfig.name
+  ])
+  .service(serviceName, Ccp);

--- a/src/common/services/ccp.service.spec.js
+++ b/src/common/services/ccp.service.spec.js
@@ -1,0 +1,59 @@
+import angular from 'angular';
+import 'angular-mocks';
+import { ccpKey, ccpStagingKey } from 'common/app.constants';
+import ccp from 'common/lib/ccp';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+import module from './ccp.service';
+
+describe('ccp service', () => {
+  beforeEach(angular.mock.module(module.name));
+  var self = {};
+
+  beforeEach(inject(($httpBackend, envService, ccpService) => {
+    self.$httpBackend = $httpBackend;
+    self.envService = envService;
+    self.ccpService = ccpService;
+  }));
+
+  afterEach(function() {
+    self.$httpBackend.verifyNoOutstandingExpectation();
+    self.$httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('get', () => {
+    it('should use previous Observable if it exists', () => {
+      self.ccpService.currentRequest = Observable.of('initialized placeholder');
+      self.ccpService.get()
+        .subscribe((initializedCcp) => {
+          expect(initializedCcp).toEqual('initialized placeholder');
+        });
+    });
+    function testCcpInit(env, url, status, response){
+      self.envService.set(env);
+      self.$httpBackend.expectGET(url).respond(status, response);
+      self.ccpService.get()
+        .subscribe((initializedCcp) => {
+          expect(initializedCcp).toEqual(ccp);
+          expect(self.ccpService.currentRequest).toBeDefined();
+          // Test that ccp doesn't throw a key undefined error
+          expect((new initializedCcp.CardNumber('4111111111111111')).validate()).toBeNull();
+        });
+
+      self.$httpBackend.flush();
+    }
+    it('should load the production key from the ccp servers', () => {
+      testCcpInit('production', 'https://ccp.ccci.org/api/v1/rest/client-encryption-keys/current', 200, ccpKey);
+    });
+    it('should load the staging key from the ccp servers', () => {
+      testCcpInit('staging', 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current', 200, ccpStagingKey);
+    });
+    it('should load the hardcoded backup production key if there is an error fetching it from the ccp servers', () => {
+      testCcpInit('production', 'https://ccp.ccci.org/api/v1/rest/client-encryption-keys/current', -1);
+    });
+    it('should load the hardcoded backup staging key if there is an error fetching it from the ccp servers', () => {
+      testCcpInit('staging', 'https://ccpstaging.ccci.org/api/v1/rest/client-encryption-keys/current', -1);
+    });
+  });
+});

--- a/src/common/services/paymentValidation.service.js
+++ b/src/common/services/paymentValidation.service.js
@@ -1,29 +1,29 @@
 import angular from 'angular';
 import _ from 'lodash';
-import ccp from 'common/lib/ccp';
 import 'angular-environment';
-import { ccpKey, ccpStagingKey } from 'common/app.constants';
+import appConfig from 'common/app.config';
 import toString from 'lodash/toString';
 import capitalize from 'lodash/capitalize';
+
+import ccpService from 'common/services/ccp.service';
 
 let serviceName = 'paymentValidationService';
 
 class PaymentValidation {
 
   /*@ngInject*/
-  constructor(envService){
+  constructor(envService, ccpService){
     this.envService = envService;
+    this.ccpService = ccpService;
 
-    this.initializeCcp();
+    this.loadCcp();
   }
 
-  initializeCcp(){
-    if(this.envService.is('production')){
-      ccp.initialize(ccpKey);
-    }else{
-      ccp.initialize(ccpStagingKey);
-    }
-    this.ccp = ccp;
+  loadCcp(){
+    this.ccpService.get()
+      .subscribe((ccp) => {
+        this.ccp = ccp;
+      });
   }
 
   validateRoutingNumber(){
@@ -68,6 +68,8 @@ class PaymentValidation {
 
 export default angular
   .module(serviceName, [
-    'environment'
+    'environment',
+    appConfig.name,
+    ccpService.name
   ])
   .service(serviceName, PaymentValidation);

--- a/src/common/services/paymentValidation.spec.js
+++ b/src/common/services/paymentValidation.spec.js
@@ -1,31 +1,29 @@
 import angular from 'angular';
 import 'angular-mocks';
-import module from './paymentValidation.service.js';
-import 'angular-environment';
+import ccp from 'common/lib/ccp';
+import { ccpStagingKey } from 'common/app.constants';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import module from './paymentValidation.service';
 
 describe('payment validation service', () => {
   beforeEach(angular.mock.module(module.name));
   var self = {};
 
-  beforeEach(inject((envService, paymentValidationService) => {
-    self.envService = envService;
-    self.paymentValidationService = paymentValidationService;
-  }));
-
-  describe('ccp initialization', () => {
-    it('should be initialized correctly in staging', () => {
-      self.envService.set('staging');
-      self.paymentValidationService.initializeCcp();
-      // Test that ccp doesn't throw a key undefined error
-      expect(self.paymentValidationService.validateCardNumber()('4111 1111 1111 1111')).toEqual(true);
-    });
-    it('should be initialized correctly in production', () => {
-      self.envService.set('production');
-      self.paymentValidationService.initializeCcp();
-      // Test that ccp doesn't throw a key undefined error
-      expect(self.paymentValidationService.validateCardNumber()('4111 1111 1111 1111')).toEqual(true);
+  beforeEach(() => {
+    angular.mock.module(($provide) => {
+      $provide.value('ccpService', {
+        get: () => {
+          ccp.initialize(ccpStagingKey);
+          return Observable.of(ccp);
+        }
+      });
     });
   });
+
+  beforeEach(inject((paymentValidationService) => {
+    self.paymentValidationService = paymentValidationService;
+  }));
 
   describe('validateRoutingNumber', () => {
     it('should return true for valid routing numbers', () => {


### PR DESCRIPTION
Fetch CCP key from remote URL and fallback to hardcoded key if there is an error.

- Add CCP service which returns an Observable containing CCP when the keys are loaded and it has been initialized
- Add ccpKeyUrl to angular environment