### PR TITLE
Return order info after submitting purchase

### DIFF
--- a/src/app/checkout/step-2/bank-account/bank-account.component.js
+++ b/src/app/checkout/step-2/bank-account/bank-account.component.js
@@ -79,8 +79,7 @@ class BankAccountController{
           'encrypted-account-number': ccpAccountNumber.encrypt(),
           'routing-number': this.bankPayment.routingNumber
         })
-        .subscribe((data) => {
-            this.$log.info('added bank account', data);
+        .subscribe(() => {
             this.onSave({success: true});
           },
           (error) => {

--- a/src/app/checkout/step-2/credit-card/credit-card.component.js
+++ b/src/app/checkout/step-2/credit-card/credit-card.component.js
@@ -120,8 +120,7 @@ class CreditCardController {
           'expiry-year': this.creditCardPayment.expiryYear
         })
         .combineLatest(this.orderService.addBillingAddress(billingAddress))
-        .subscribe((data) => {
-            this.$log.info('added credit card and billing address', data);
+        .subscribe(() => {
             this.orderService.storeCardSecurityCode(ccpSecurityCode.encrypt());
             this.onSave({success: true});
           },

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -76,9 +76,9 @@ class Step3Controller{
     }else{
       submitRequest = Observable.throw('Current payment type is unknown');
     }
-    submitRequest.subscribe(() => {
+    submitRequest.subscribe((data) => {
         this.orderService.clearCardSecurityCode();
-        this.$log.info('Submitted purchase successfully');
+        this.$log.info('Submitted purchase successfully', data);
         // TODO: transition to thank you page
       },
       (error) => {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -200,10 +200,11 @@ class Order{
   submit(ccv){
     return this.getPurchaseForm()
       .mergeMap((data) => {
-        let postData = ccv ? {"security-code": ccv} : undefined;
+        let postData = ccv ? {"security-code": ccv} : {};
         return this.cortexApiService.post({
           path: this.hateoasHelperService.getLink(data.enhancedpurchaseform, 'createenhancedpurchaseaction'),
-          data: postData
+          data: postData,
+          followLocation: true
         });
       });
   }

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -431,8 +431,8 @@ describe('order service', () => {
     });
     it('should send a request to finalize the purchase', () => {
       self.$httpBackend.expectPOST(
-        'https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=',
-        null
+        'https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        {}
       ).respond(200, 'success');
 
       self.orderService.submit()
@@ -444,7 +444,7 @@ describe('order service', () => {
     });
     it('should send a request to finalize the purchase and with a CCV', () => {
       self.$httpBackend.expectPOST(
-        'https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=',
+        'https://cortex-gateway-stage.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
         {"security-code": '123'}
       ).respond(200, 'success');
 


### PR DESCRIPTION
- Remove old info logs
- Log purchase info on submit
- Send empty object on submit without CCV in the body instead of undefined so $http sends a content type
- On submit, followLocation

This should help testers see some data for now and will help my thank you component.