### PR TITLE
Forgot Password, Reset Password and modalState service.

### DIFF
--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.component.js
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.component.js
@@ -1,0 +1,80 @@
+import angular from 'angular';
+import 'angular-gettext';
+import sessionService from 'common/services/session/session.service';
+import template from './forgotPasswordModal.tpl';
+
+let componentName = 'forgotPasswordModal';
+
+class ForgotPasswordModalController {
+
+  /* @ngInject */
+  constructor( $location, $document, $httpParamSerializer, gettext, sessionService ) {
+    this.$location = $location;
+    this.$document = $document;
+    this.$httpParamSerializer = $httpParamSerializer;
+    this.gettext = gettext;
+    this.sessionService = sessionService;
+  }
+
+  $onInit() {
+    this.emailSent = false;
+    this.isLoading = false;
+    this.setPristine();
+    this.modalTitle = this.gettext( 'Reset Password' );
+  }
+
+  forgotPassword() {
+    this.setPristine();
+    this.isLoading = true;
+    this.sessionService
+      .forgotPassword( this.email, this.resetPasswordUrl() )
+      .subscribe( () => {
+        this.emailSent = true;
+        this.isLoading = false;
+      }, ( error ) => {
+        this.forgotError = true;
+        this.isLoading = false;
+        switch ( error.data.error ) {
+          case 'user_not_found':
+          case 'password_cant_change':
+            this.errors[error.data.error] = true;
+            break;
+          default:
+            this.errors['unknown'] = true;
+        }
+      } );
+  }
+
+  resetPasswordUrl() {
+    // Create in memory <a> to do url manipulation and set it to current location
+    let url = this.$document[0].createElement( 'a' );
+    url.href = this.$location.absUrl();
+    // Add theme=cru to existing query params
+    let params = this.$location.search();
+    params.theme = 'cru';
+    url.search = this.$httpParamSerializer( params );
+    // Set url fragment to #reset-pssword
+    url.hash = 'reset-password';
+    return url.href;
+  }
+
+  setPristine() {
+    this.errors = {};
+    this.forgotError = false;
+  }
+}
+
+export default angular
+  .module( componentName, [
+    'gettext',
+    template.name,
+    sessionService.name
+  ] )
+  .component( componentName, {
+    controller:  ForgotPasswordModalController,
+    templateUrl: template.name,
+    bindings:    {
+      modalTitle:    '=',
+      onStateChange: '&'
+    }
+  } );

--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.component.spec.js
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.component.spec.js
@@ -1,0 +1,104 @@
+import angular from 'angular';
+import 'angular-mocks';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/from';
+import module from './forgotPasswordModal.component';
+
+describe( 'forgotPasswordModal', function () {
+  beforeEach( angular.mock.module( module.name ) );
+  let $ctrl, $rootScope;
+
+  beforeEach( inject( function ( _$componentController_, _$rootScope_ ) {
+    $rootScope = _$rootScope_;
+    $ctrl = _$componentController_( module.name );
+  } ) );
+
+  it( 'to be defined', () => {
+    expect( $ctrl ).toBeDefined();
+  } );
+
+  describe( '$onInit()', () => {
+    it( 'initializes the componenet', () => {
+      $ctrl.$onInit();
+      expect( $ctrl.emailSent ).toEqual( false );
+      expect( $ctrl.isLoading ).toEqual( false );
+      expect( $ctrl.modalTitle ).toEqual( 'Reset Password' );
+    } );
+  } );
+
+  describe( 'forgotPassword()', () => {
+    let deferred;
+    beforeEach( inject( function ( _$q_ ) {
+      deferred = _$q_.defer();
+      spyOn( $ctrl.sessionService, 'forgotPassword' ).and.callFake( () => Observable.from( deferred.promise ) );
+      spyOn( $ctrl, 'resetPasswordUrl' ).and.returnValue( 'http://example.com' );
+      $ctrl.email = 'professorx@xavier.edu';
+      $ctrl.forgotPassword();
+    } ) );
+
+    it( 'sets isLoading to true and calls sessionService.resetPassword', () => {
+      expect( $ctrl.isLoading ).toEqual( true );
+      expect( $ctrl.resetPasswordUrl ).toHaveBeenCalled();
+      expect( $ctrl.sessionService.forgotPassword )
+        .toHaveBeenCalledWith( 'professorx@xavier.edu', 'http://example.com' );
+    } );
+
+    describe( 'forgotPassword success', () => {
+      beforeEach( () => {
+        deferred.resolve();
+        $rootScope.$digest();
+      } );
+
+      it( 'sets emailSent', () => {
+        expect( $ctrl.forgotError ).toEqual( false );
+        expect( $ctrl.isLoading ).toEqual( false );
+        expect( $ctrl.emailSent ).toEqual( true );
+      } );
+    } );
+
+    describe( 'forgotPassword failure', () => {
+      describe( '403 Forbidden', () => {
+        it( 'sets \'password_cant_change\' error', () => {
+          deferred.reject( {status: 403, data: {error: 'password_cant_change'}} );
+          $rootScope.$digest();
+          expect( $ctrl.forgotError ).toEqual( true );
+          expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {password_cant_change: true} ) );
+        } );
+      } );
+      describe( '404 Not Found', () => {
+        it( 'sets \'user_not_found\' error', () => {
+          deferred.reject( {status: 404, data: {error: 'user_not_found'}} );
+          $rootScope.$digest();
+          expect( $ctrl.forgotError ).toEqual( true );
+          expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {user_not_found: true} ) );
+        } );
+      } );
+      describe( '500 Internal Server Error', () => {
+        it( 'sets \'unknown\' error', () => {
+          deferred.reject( {status: 500, data: {error: 'unknown'}} );
+          $rootScope.$digest();
+          expect( $ctrl.forgotError ).toEqual( true );
+          expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {unknown: true} ) );
+        } );
+      } );
+    } );
+  } );
+
+  describe( 'resetPasswordUrl()', () => {
+    beforeEach( () => {
+      $ctrl.$location = {
+        absUrl: jasmine.createSpy( 'absUrl' ).and.returnValue( 'http://example.com/index.html?key=value' ),
+        search: jasmine.createSpy( 'search' ).and.returnValue( {key: 'value'} )
+      };
+      spyOn( $ctrl, '$httpParamSerializer' ).and.callThrough();
+    } );
+
+    it( 'adds theme=cru and #reset-password to the current url', () => {
+      expect( $ctrl.resetPasswordUrl() ).toEqual( 'http://example.com/index.html?key=value&theme=cru#reset-password' );
+      expect( $ctrl.$httpParamSerializer ).toHaveBeenCalledWith( jasmine.objectContaining( {
+        key:   'value',
+        theme: 'cru'
+      } ) );
+    } );
+  } );
+} );

--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.tpl.html
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.tpl.html
@@ -1,0 +1,42 @@
+<div class="col-md-12 col-xs-12">
+  <div ng-if="$ctrl.emailSent">
+    <div class="alert alert-success">
+      <p translate>An email containing a link to reset your password has been sent to <em>{{$ctrl.email}}</em>.</p>
+    </div>
+  </div>
+  <div ng-if="!$ctrl.emailSent">
+    <p translate>Enter your registered email address below and we'll send you a link to reset your password.</p>
+    <div class="alert alert-danger" role="alert" ng-messages="$ctrl.errors" ng-if="$ctrl.forgotError">
+      <div ng-message="email_not_found" translate>Email Address not Found.<br />
+        Perhaps you've never <a ng-click="$ctrl.onStateChange({state: 'sign-up'})">Signed Up</a>? Questions,
+        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+      </div>
+      <div ng-message="password_cant_change" translate>You are not allowed to reset your password here.<br />Please
+        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+      </div>
+    </div>
+    <form ng-if="!$ctrl.emailSent" name="$ctrl.form" style="position: relative;">
+      <div class="alert alert-danger" role="alert" ng-if="$ctrl.forgotError" translate>An Error has Occurred.</div>
+      <div class="form-group">
+        <label for="email" translate>Email</label>
+        <input type="email"
+               name="email"
+               id="email"
+               class="form-control form-control-subtle"
+               placeholder="Email"
+               ng-model="$ctrl.email"
+               required>
+      </div>
+      <button type="submit"
+              class="btn btn-block btn-primary"
+              ng-click="$ctrl.forgotPassword()"
+              ng-disabled="!$ctrl.form.$valid"
+              translate>Reset My Password
+      </button>
+      <loading-overlay ng-if="$ctrl.isLoading"></loading-overlay>
+    </form>
+  </div>
+  <p class="mt- text-center"><span translate>Never mind</span>
+    <a href ng-click="$ctrl.onStateChange({state: 'sign-in'})" translate>Back to Sign In</a>
+  </p>
+</div>

--- a/src/common/components/resetPasswordModal/resetPasswordModal.component.js
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.component.js
@@ -1,27 +1,85 @@
 import angular from 'angular';
 import 'angular-gettext';
+import 'angular-messages';
+import modalStateService from 'common/services/modalState.service';
 import sessionService from 'common/services/session/session.service';
+import showErrors from 'common/filters/showErrors.filter';
 import template from './resetPasswordModal.tpl';
+import valueMatch from 'common/directives/valueMatch.directive';
 
 let componentName = 'resetPasswordModal';
 
 class ResetPasswordModalController {
 
   /* @ngInject */
-  constructor( gettext ) {
+  constructor( gettext, sessionService, modalStateService ) {
     this.gettext = gettext;
+    this.sessionService = sessionService;
+    this.modalState = modalStateService;
   }
 
   $onInit() {
     this.modalTitle = this.gettext( 'Reset Password' );
+    if ( this.modalState.params.hasOwnProperty( 'e' ) ) {
+      this.email = this.modalState.params['e'];
+    }
+    if ( this.modalState.params.hasOwnProperty( 'k' ) ) {
+      this.resetKey = this.modalState.params['k'];
+    }
+    // Change state to forgot-password if we are missing required fields.
+    if ( angular.isUndefined( this.email ) || angular.isUndefined( this.resetKey ) ) {
+      this.onStateChange( {state: 'forgot-password'} );
+    }
+    this.isLoading = false;
+    this.passwordChanged = false;
+    this.setPristine();
+  }
+
+  resetPassword() {
+    if ( !this.form.$valid ) {
+      return;
+    }
+
+    this.setPristine();
+    this.isLoading = true;
+    this.sessionService
+      .resetPassword( this.email, this.password, this.resetKey )
+      .subscribe( () => {
+        this.isLoading = false;
+        this.passwordChanged = true;
+        // Remove modal name and modal params on success
+        this.modalState.setName();
+        delete this.modalState.params.e;
+        delete this.modalState.params.k;
+      }, ( error ) => {
+        this.isLoading = false;
+        this.hasError = true;
+        switch ( error.data.error ) {
+          case 'invalid_reset_key':
+          case 'password_cant_change':
+            this.errors[error.data.error] = true;
+            break;
+          default:
+            this.errors['unknown'] = true;
+        }
+      } );
+  }
+
+  setPristine() {
+    this.errors = {};
+    this.hasError = false;
   }
 }
 
 export default angular
   .module( componentName, [
     'gettext',
+    'ngMessages',
     template.name,
-    sessionService.name
+    showErrors.name,
+    sessionService.name,
+    modalStateService.name,
+    valueMatch.name
   ] )
   .component( componentName, {
     controller:  ResetPasswordModalController,

--- a/src/common/components/resetPasswordModal/resetPasswordModal.component.spec.js
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.component.spec.js
@@ -1,23 +1,123 @@
 import angular from 'angular';
 import 'angular-mocks';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/from';
 import module from './resetPasswordModal.component';
 
 describe( 'resetPasswordModal', function () {
   beforeEach( angular.mock.module( module.name ) );
-  let $ctrl;
+  let $ctrl, $rootScope;
 
-  beforeEach( inject( function ( _$componentController_ ) {
-    $ctrl = _$componentController_( module.name );
+  beforeEach( inject( function ( _$componentController_, _$rootScope_ ) {
+    $rootScope = _$rootScope_;
+    $ctrl = _$componentController_(
+      module.name, {
+        modalStateService: {
+          params:  {},
+          setName: jasmine.createSpy( 'setName' )
+        }
+      }, {
+        form:          {$valid: true},
+        onStateChange: jasmine.createSpy( 'onStateChange' )
+      }
+    );
   } ) );
 
-  it( 'to be defined', function () {
-    expect( $ctrl ).toBeDefined();
+  describe( '$onInit()', () => {
+    describe( 'missing required modalState.params', () => {
+      it( 'changes to \'forgot-password\' state', () => {
+        $ctrl.$onInit();
+        expect( $ctrl.onStateChange ).toHaveBeenCalledWith( {state: 'forgot-password'} );
+      } );
+    } );
+
+    describe( 'with modalState.params', () => {
+      beforeEach( () => {
+        $ctrl.modalState.params = {e: 'professorx@xavier.edu', k: 'abc123def456'};
+      } );
+
+      it( 'initializes the modal', () => {
+        $ctrl.$onInit();
+        expect( $ctrl.onStateChange ).not.toHaveBeenCalled();
+        expect( $ctrl.email ).toEqual( 'professorx@xavier.edu' );
+        expect( $ctrl.resetKey ).toEqual( 'abc123def456' );
+        expect( $ctrl.isLoading ).toEqual( false );
+        expect( $ctrl.passwordChanged ).toEqual( false );
+        expect( $ctrl.modalTitle ).toEqual( 'Reset Password' );
+      } );
+    } );
   } );
 
-  describe( '$onInit()', () => {
-    it( 'initializes the modal', () => {
-      $ctrl.$onInit();
-      expect( $ctrl.modalTitle ).toEqual( 'Reset Password' );
+  describe( 'resetPassword', () => {
+    let deferred;
+    beforeEach( inject( function ( _$q_ ) {
+      deferred = _$q_.defer();
+      spyOn( $ctrl.sessionService, 'resetPassword' ).and.callFake( () => Observable.from( deferred.promise ) );
+    } ) );
+
+    describe( 'invalid form', () => {
+      it( 'does not submit the form', () => {
+        $ctrl.form.$valid = false;
+        $ctrl.resetPassword();
+        expect( $ctrl.sessionService.resetPassword ).not.toHaveBeenCalled();
+      } );
+    } );
+
+    describe( 'valid form', () => {
+      beforeEach( () => {
+        $ctrl.email = 'professorx@xavier.edu';
+        $ctrl.password = 'Cerebro123';
+        $ctrl.resetKey = 'abc123def456';
+        $ctrl.resetPassword();
+      } );
+
+      it( 'sets isLoading to true and calls sessionService.resetPassword', () => {
+        expect( $ctrl.isLoading ).toEqual( true );
+        expect( $ctrl.sessionService.resetPassword )
+          .toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', 'abc123def456' );
+      } );
+
+      describe( 'resetPassword success', () => {
+        beforeEach( () => {
+          $ctrl.modalState.params = {e: 'professorx@xavier.edu', k: 'abc123def456'};
+          deferred.resolve();
+          $rootScope.$digest();
+        } );
+
+        it( 'sets passwordChanged', () => {
+          expect( $ctrl.isLoading ).toEqual( false );
+          expect( $ctrl.passwordChanged ).toEqual( true );
+          expect( $ctrl.modalState.setName ).toHaveBeenCalled();
+          expect( $ctrl.modalState.params ).toEqual( {} );
+        } );
+      } );
+
+      describe( 'resetPassword failure', () => {
+        describe( '400 Bad Request', () => {
+          it( 'sets \'invalid_reset_key\' error', () => {
+            deferred.reject( {status: 400, data: {error: 'invalid_reset_key'}} );
+            $rootScope.$digest();
+            expect( $ctrl.hasError ).toEqual( true );
+            expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {invalid_reset_key: true} ) );
+          } );
+        } );
+        describe( '403 Forbidden', () => {
+          it( 'sets \'password_cant_change\' error', () => {
+            deferred.reject( {status: 403, data: {error: 'password_cant_change'}} );
+            $rootScope.$digest();
+            expect( $ctrl.hasError ).toEqual( true );
+            expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {password_cant_change: true} ) );
+          } );
+        } );
+        describe( '500 Internal Server Error', () => {
+          it( 'sets \'unknown\' error', () => {
+            deferred.reject( {status: 500, data: {error: 'unknown'}} );
+            $rootScope.$digest();
+            expect( $ctrl.hasError ).toEqual( true );
+            expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {unknown: true} ) );
+          } );
+        } );
+      } );
     } );
   } );
 } );

--- a/src/common/components/resetPasswordModal/resetPasswordModal.tpl.html
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.tpl.html
@@ -1,12 +1,61 @@
 <div class="col-md-12 col-xs-12">
-  <p>Enter your registered email address below and we'll send a new password to that email.</p>
-  <form>
-    <div class="form-group">
-      <label for="email">Email</label>
-      <input type="email" class="form-control form-control-subtle" placeholder="Email">
+  <div ng-if="!$ctrl.passwordChanged">
+    <div class="alert alert-danger" role="alert" ng-messages="$ctrl.errors" ng-if="$ctrl.hasError">
+      <div ng-message="invalid_reset_key" translate>An error has occurred. (Invalid Password Reset Key)<br />
+        Please try sending another
+        <a ng-click="$ctrl.onStateChange({state: 'forgot-password'})">Reset Password</a> email, or
+        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+      </div>
+      <div ng-message="password_cant_change" translate>You are not allowed to reset your password here.<br />Please
+        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+      </div>
     </div>
-    <button type="submit" class="btn btn-block btn-primary">Reset My Password</button>
-  </form>
-  <p class="mt- text-center">Never mind
-    <a href ng-click="$ctrl.onStateChange({state: 'sign-in'})">Back to Sign In</a></p>
+    <form name="$ctrl.form" style="position: relative;">
+      <div class="form-group" ng-class="{'has-success': $ctrl.form.password.$valid, 'has-error': ($ctrl.form.password | showErrors) }">
+        <label for="password" translate>New Password</label>
+        <input id="password"
+               name="password"
+               type="password"
+               class="form-control form-control-subtle"
+               ng-model="$ctrl.password"
+               minlength="8"
+               ng-pattern="/^(?=.*\d)(?=.*[a-zA-Z]).{6,}$/"
+               required>
+        <div ng-if="($ctrl.form.password | showErrors)" ng-messages="$ctrl.form.password.$error">
+          <span class="help-block" ng-message="required" translate>Password is required.</span>
+          <span class="help-block" ng-message="minlength" translate>Must be 8 or more characters.</span>
+          <span class="help-block" ng-message="pattern" translate>Must include 1 letter and 1 number.</span>
+        </div>
+      </div>
+
+      <div class="form-group" ng-class="{'has-success': $ctrl.form.password_check.$valid, 'has-error': ($ctrl.form.password_check  | showErrors) }">
+        <label for="password_check" translate>Confirm Password</label>
+        <input id="password_check"
+               name="password_check"
+               type="password"
+               class="form-control form-control-subtle"
+               ng-model="$ctrl.password_check"
+               value-match="password"
+               required>
+        <div ng-if="($ctrl.form.password_check | showErrors)" ng-messages="$ctrl.form.password_check.$error">
+          <span class="help-block" ng-message="required" translate>Password is required.</span>
+          <span class="help-block" ng-message="valueMatch" translate>Passwords must match.</span>
+        </div>
+      </div>
+      <button type="submit"
+              class="btn btn-block btn-primary"
+              ng-disabled="!$ctrl.form.$valid"
+              ng-click="$ctrl.resetPassword()"
+              translate>Reset My Password
+      </button>
+      <loading-overlay ng-if="$ctrl.isLoading"></loading-overlay>
+    </form>
+    <p class="mt- text-center" translate>Never mind
+      <a href ng-click="$ctrl.onStateChange({state: 'sign-in'})">Back to Sign In</a>
+    </p>
+  </div>
+  <div ng-if="$ctrl.passwordChanged" class="alert alert-success">
+    <p translate>Your password has successfully been updated.</p>
+    <p translate>Return to <a ng-click="$ctrl.onStateChange({state: 'sign-in'})">Sign In</a>.</p>
+  </div>
 </div>

--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -5,7 +5,7 @@
   <sign-in-form on-success="$ctrl.onSuccess()"></sign-in-form>
   <p class="text-center" ng-class="{'mt mb0': $ctrl.identified}">
     <span translate>Forgot your password?</span>
-    <a href ng-click="$ctrl.onStateChange({state: 'reset-password'})" translate>Reset It</a>
+    <a href ng-click="$ctrl.onStateChange({state: 'forgot-password'})" translate>Reset It</a>
   </p>
   <p class="text-center" ng-if="$ctrl.identified">
     <span translate>Not {{$ctrl.session.first_name}} {{$ctrl.session.last_name}}?</span>

--- a/src/common/components/signUpModal/signUpModal.tpl.html
+++ b/src/common/components/signUpModal/signUpModal.tpl.html
@@ -3,12 +3,12 @@
     <div ng-message="400" translate>An error occurred during sign up.<br />Please Check your Email Address and Password and try again.</div>
     <div ng-message="403" translate>An error occurred during sign up.<br />This is most likely caused by the use of a reserved domain name in your email address. You might try to
       <a ng-click="$ctrl.onStateChange({state: 'sign-in'})">Sign In</a>,
-      <a ng-click="$ctrl.onStateChange({state: 'reset-password'})">Reset your Password</a>or
+      <a ng-click="$ctrl.onStateChange({state: 'forgot-password'})">Reset your Password</a>or
       <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
     </div>
     <div ng-message="409" translate>An account with this Email Address already exists.<br />Please
       <a ng-click="$ctrl.onStateChange({state: 'sign-in'})">Sign In</a> or
-      <a ng-click="$ctrl.onStateChange({state: 'reset-password'})">Reset your Password</a>.
+      <a ng-click="$ctrl.onStateChange({state: 'forgot-password'})">Reset your Password</a>.
     </div>
   </div>
   <form name="$ctrl.signUpForm" style="position: relative;">

--- a/src/common/services/modalState.service.js
+++ b/src/common/services/modalState.service.js
@@ -1,0 +1,68 @@
+import angular from 'angular';
+let serviceName = 'modalStateService';
+
+/*@ngInject*/
+function ModalStateService() {
+  let registeredModals = {};
+
+  this.registerModal = registerModal;
+
+  function registerModal( name, injectableFn ) {
+    registeredModals[name] = injectableFn;
+  }
+
+  /*@ngInject*/
+  this.$get = function ( $injector, $location, $rootScope ) {
+    let modalParams = $location.search();
+
+    // eslint-disable-next-line angular/on-watch
+    $rootScope.$watch( () => modalParams, syncModalParams, true );
+
+    return {
+      params:      modalParams,
+      setParams:   setModalParams,
+      setName:     setModalName,
+      invokeModal: invokeModal
+    };
+
+    function invokeModal( name ) {
+      if ( registeredModals.hasOwnProperty( name ) ) {
+        return $injector.invoke( registeredModals[name] );
+      }
+    }
+
+    function setModalName( name ) {
+      $location.hash( angular.isDefined( name ) ? name : '' );
+    }
+
+    function setModalParams( params ) {
+      params = angular.isDefined( params ) ? params : {};
+      angular.copy( params, modalParams );
+    }
+
+    // Syncs modalParams with $location query params
+    function syncModalParams( params ) {
+      if ( angular.isUndefined( params ) ) {
+        return;
+      }
+
+      $location.search( '' );
+      angular.forEach( params, ( value, key ) => {
+        $location.search( key, value );
+      } );
+    }
+  };
+}
+
+/*@ngInject*/
+function modalStateServiceRunner( $location, modalStateService ) {
+  let name = $location.hash();
+  if ( angular.isDefined( name ) && name !== "" ) {
+    modalStateService.invokeModal( name );
+  }
+}
+
+export default angular
+  .module( serviceName, [] )
+  .provider( serviceName, ModalStateService )
+  .run( modalStateServiceRunner );

--- a/src/common/services/modalState.spec.js
+++ b/src/common/services/modalState.spec.js
@@ -1,0 +1,107 @@
+import angular from 'angular';
+import 'angular-mocks';
+import module from './modalState.service';
+
+describe( 'modalStateServiceProvider', () => {
+  beforeEach( angular.mock.module( module.name ) );
+  let modalStateServiceProvider;
+
+  beforeEach( () => {
+    angular.mock.module( function ( _modalStateServiceProvider_ ) {
+      modalStateServiceProvider = _modalStateServiceProvider_;
+      modalStateServiceProvider.registerModal( 'test-modal', angular.noop );
+    } );
+  } );
+
+  it( 'to be defined', inject( function () {
+    expect( modalStateServiceProvider ).toBeDefined();
+    expect( modalStateServiceProvider.registerModal ).toBeDefined();
+  } ) );
+
+  describe( 'modalStateService.invokeModal()', () => {
+    let modalStateService, $injector;
+
+    beforeEach( inject( function ( _modalStateService_, _$injector_ ) {
+      $injector = _$injector_;
+      modalStateService = _modalStateService_;
+      spyOn( $injector, 'invoke' );
+    } ) );
+
+    it( 'invokes registered modal', () => {
+      modalStateService.invokeModal( 'test-modal' );
+      expect( $injector.invoke ).toHaveBeenCalledWith( jasmine.any( Function ) );
+    } );
+
+    it( 'does not invoke unknown modal', () => {
+      modalStateService.invokeModal( 'unknown' );
+      expect( $injector.invoke ).not.toHaveBeenCalled();
+    } );
+  } );
+} );
+
+describe( 'modalStateService', () => {
+  beforeEach( angular.mock.module( module.name ) );
+  let modalStateService, $rootScope, $location;
+
+  beforeEach( inject( function ( _modalStateService_, _$rootScope_, _$location_ ) {
+    modalStateService = _modalStateService_;
+    $rootScope = _$rootScope_;
+    $location = _$location_;
+  } ) );
+
+  it( 'to be defined', () => {
+    expect( modalStateService ).toBeDefined();
+  } );
+
+  describe( 'setParams', () => {
+    beforeEach( () => {
+      spyOn( $location, 'search' );
+    } );
+
+    it( 'adds params to $location', () => {
+      modalStateService.setParams( {a: 1, b: 2} );
+      $rootScope.$digest();
+      expect( $location.search ).toHaveBeenCalledWith( '' );
+      expect( $location.search ).toHaveBeenCalledWith( 'a', 1 );
+      expect( $location.search ).toHaveBeenCalledWith( 'b', 2 );
+    } );
+
+    it( 'allows undefined', () => {
+      modalStateService.setParams();
+      $rootScope.$digest();
+      expect( $location.search ).toHaveBeenCalledWith( '' );
+    } );
+  } );
+
+  describe( 'params', () => {
+    beforeEach( () => {
+      spyOn( $location, 'search' );
+    } );
+
+    it( 'changes are reflected to $location', () => {
+      modalStateService.params.c = 4;
+      $rootScope.$digest();
+      expect( $location.search ).toHaveBeenCalledWith( '' );
+      expect( $location.search ).toHaveBeenCalledWith( 'c', 4 );
+    } );
+  } );
+
+  describe( 'setName', () => {
+    beforeEach( () => {
+      spyOn( $location, 'hash' );
+    } );
+
+    it( 'sets $location hash', () => {
+      modalStateService.setName( 'test-modal' );
+      $rootScope.$digest();
+      expect( $location.hash ).toHaveBeenCalledWith( 'test-modal' );
+    } );
+
+    it( 'allows undefined', () => {
+      modalStateService.setName();
+      $rootScope.$digest();
+      expect( $location.hash ).toHaveBeenCalledWith( '' );
+    } );
+  } );
+} );
+

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -12,7 +12,7 @@ import appConfig from 'common/app.config';
 let serviceName = 'sessionService';
 
 /*@ngInject*/
-function session( $cookies, $rootScope, $http, $q, envService ) {
+function session( $cookies, $rootScope, $http, envService ) {
   var session = {},
     sessionSubject = new BehaviorSubject( session );
 
@@ -31,7 +31,9 @@ function session( $cookies, $rootScope, $http, $q, envService ) {
     getRole:        currentRole,
     signIn:         signIn,
     signOut:        signOut,
-    signUp:         signUp
+    signUp:         signUp,
+    forgotPassword: forgotPassword,
+    resetPassword:  resetPassword
   };
 
   /* Public Methods */
@@ -70,6 +72,37 @@ function session( $cookies, $rootScope, $http, $q, envService ) {
           password:  password,
           firstName: first_name,
           lastName:  last_name
+        }
+      } ) )
+      .map( ( response ) => response.data );
+  }
+
+  function forgotPassword( email, passwordResetUrl ) {
+    // https://github.com/CruGlobal/cortex_gateway/wiki/Send-Forgot-Password-Email
+    return Observable
+      .from( $http( {
+        method:          'POST',
+        url:             casApiUrl( '/send_forgot_password_email' ),
+        withCredentials: true,
+        data:            {
+          email:            email,
+          passwordResetUrl: passwordResetUrl
+        }
+      } ) )
+      .map( ( response ) => response.data );
+  }
+
+  function resetPassword( email, password, resetKey ) {
+    // https://github.com/CruGlobal/cortex_gateway/wiki/Set-Password-By-Reset-Key
+    return Observable
+      .from( $http( {
+        method:          'POST',
+        url:             casApiUrl( '/reset_password' ),
+        withCredentials: true,
+        data:            {
+          email:    email,
+          password: password,
+          resetKey: resetKey
         }
       } ) )
       .map( ( response ) => response.data );

--- a/src/common/services/session/session.spec.js
+++ b/src/common/services/session/session.spec.js
@@ -1,8 +1,8 @@
 import angular from 'angular';
 import 'angular-mocks';
 import module from './session.service';
-import { cortexSession } from './fixtures/cortex-session';
-import { giveSession } from './fixtures/give-session';
+import {cortexSession} from './fixtures/cortex-session';
+import {giveSession} from './fixtures/give-session';
 
 describe( 'session service', function () {
   beforeEach( angular.mock.module( module.name ) );
@@ -102,7 +102,7 @@ describe( 'session service', function () {
       it( 'returns \'PUBLIC\'', () => {
         expect( self.sessionService.getRole() ).toEqual( 'PUBLIC' );
       } );
-    });
+    } );
 
     describe( 'with \'IDENTIFIED\' cortex-session', () => {
       beforeEach( () => {
@@ -181,6 +181,37 @@ describe( 'session service', function () {
         .signOut()
         .then( ( response ) => {
           expect( response.data ).toEqual( {} );
+        } );
+      self.$httpBackend.flush();
+    } );
+  } );
+
+  describe( 'forgotPassword', () => {
+    it( 'makes http request to cas/send_forgot_password_email', () => {
+      self.$httpBackend.expectPOST( 'https://cortex-gateway-stage.cru.org/cas/send_forgot_password_email', {
+        email:            'professorx@xavier.edu',
+        passwordResetUrl: 'http://example.com/index.html?theme=cru#reset-password'
+      } ).respond( 200, {} );
+      self.sessionService
+        .forgotPassword( 'professorx@xavier.edu', 'http://example.com/index.html?theme=cru#reset-password' )
+        .subscribe( ( data ) => {
+          expect( data ).toEqual( {} );
+        } );
+      self.$httpBackend.flush();
+    } );
+  } );
+
+  describe( 'resetPassword', () => {
+    it( 'makes http request to cas/reset_password', () => {
+      self.$httpBackend.expectPOST( 'https://cortex-gateway-stage.cru.org/cas/reset_password', {
+        email:    'professorx@xavier.edu',
+        password: 'Cerebro123',
+        resetKey: 'abc123def456'
+      } ).respond( 200, {} );
+      self.sessionService
+        .resetPassword( 'professorx@xavier.edu', 'Cerebro123', 'abc123def456' )
+        .subscribe( ( data ) => {
+          expect( data ).toEqual( {} );
         } );
       self.$httpBackend.flush();
     } );

--- a/src/common/services/session/sessionModal.controller.js
+++ b/src/common/services/session/sessionModal.controller.js
@@ -3,6 +3,7 @@ import angular from 'angular';
 import signInModal from 'common/components/signInModal/signInModal.component';
 import signUpModal from 'common/components/signUpModal/signUpModal.component';
 import resetPasswordModal from 'common/components/resetPasswordModal/resetPasswordModal.component';
+import forgotPasswordModal from 'common/components/forgotPasswordModal/forgotPasswordModal.component';
 
 let controllerName = 'sessionModalController';
 
@@ -40,6 +41,7 @@ export default angular
   .module( controllerName, [
     signInModal.name,
     signUpModal.name,
-    resetPasswordModal.name
+    resetPasswordModal.name,
+    forgotPasswordModal.name
   ] )
   .controller( controllerName, SessionModalController );

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-bootstrap';
+import modalStateService from 'common/services/modalState.service';
 import sessionModalController from './sessionModal.controller';
 import sessionModalTemplate from './sessionModal.tpl';
 import sessionModalWindowTemplate from './sessionModalWindow.tpl';
@@ -7,7 +8,7 @@ import sessionModalWindowTemplate from './sessionModalWindow.tpl';
 let serviceName = 'sessionModalService';
 
 /*@ngInject*/
-function sessionModal( $uibModal ) {
+function SessionModalService( $uibModal, modalStateService ) {
 
   function openModal( type, options ) {
     type = angular.isDefined( type ) ? type : 'sign-in';
@@ -24,21 +25,37 @@ function sessionModal( $uibModal ) {
     }, options );
     return $uibModal
       .open( modalOptions )
-      .result;
+      .result
+      .finally( () => {
+        // Clear the modal name and params when modals close
+        modalStateService.setName();
+        modalStateService.setParams();
+      } );
   }
 
   return {
-    open:   openModal,
-    signIn: () => openModal( 'sign-in' ),
-    signUp: () => openModal( 'sign-up' )
+    open:           openModal,
+    signIn:         () => openModal( 'sign-in' ),
+    signUp:         () => openModal( 'sign-up' ),
+    forgotPassword: () => openModal( 'forgot-password' ),
+    resetPassword:  () => openModal( 'reset-password', {backdrop: 'static'} )
   };
 }
 
 export default angular
   .module( serviceName, [
     'ui.bootstrap',
+    modalStateService.name,
     sessionModalController.name,
     sessionModalTemplate.name,
     sessionModalWindowTemplate.name
   ] )
-  .factory( serviceName, sessionModal );
+  .factory( serviceName, SessionModalService )
+  .config( function ( modalStateServiceProvider ) {
+    modalStateServiceProvider.registerModal(
+      'reset-password',
+      /*@ngInject*/
+      function ( sessionModalService ) {
+        sessionModalService.resetPassword();
+      } );
+  } );

--- a/src/common/services/session/sessionModal.spec.js
+++ b/src/common/services/session/sessionModal.spec.js
@@ -1,16 +1,18 @@
 import angular from 'angular';
 import 'angular-mocks';
 import module from './sessionModal.service';
+import modalStateModule from 'common/services/modalState.service';
 
 describe( 'sessionModalService', function () {
   beforeEach( angular.mock.module( module.name ) );
-  let sessionModalService, $uibModal;
+  let sessionModalService, $uibModal, modalStateService;
 
-  beforeEach( inject( function ( _sessionModalService_, _$uibModal_ ) {
+  beforeEach( inject( function ( _sessionModalService_, _$uibModal_, _modalStateService_ ) {
     sessionModalService = _sessionModalService_;
     $uibModal = _$uibModal_;
+    modalStateService = _modalStateService_;
     // Spy On $uibModal.open and return mock object
-    spyOn( $uibModal, 'open' ).and.returnValue( {result: angular.noop} );
+    spyOn( $uibModal, 'open' ).and.returnValue( {result: {finally: angular.noop}} );
   } ) );
 
   it( 'should be defined', () => {
@@ -32,7 +34,26 @@ describe( 'sessionModalService', function () {
     it( 'should allow options', () => {
       sessionModalService.open( 'sign-up', {backdrop: false, keyboard: false} );
       expect( $uibModal.open ).toHaveBeenCalledTimes( 1 );
-      expect( $uibModal.open ).toHaveBeenCalledWith(jasmine.objectContaining({backdrop: false, keyboard: false}));
+      expect( $uibModal.open ).toHaveBeenCalledWith( jasmine.objectContaining( {backdrop: false, keyboard: false} ) );
+    } );
+
+    describe( 'modal closes', () => {
+      let deferred, $rootScope;
+      beforeEach( inject( function ( _$q_, _$rootScope_ ) {
+        $rootScope = _$rootScope_;
+        deferred = _$q_.defer();
+        spyOn( modalStateService, 'setName' );
+        spyOn( modalStateService, 'setParams' );
+        $uibModal.open.and.returnValue( {result: deferred.promise} );
+      } ) );
+
+      it( 'removes modal name and params', () => {
+        sessionModalService.open();
+        deferred.resolve();
+        $rootScope.$digest();
+        expect( modalStateService.setName ).toHaveBeenCalled();
+        expect( modalStateService.setParams ).toHaveBeenCalled();
+      } );
     } );
   } );
 
@@ -49,6 +70,54 @@ describe( 'sessionModalService', function () {
       sessionModalService.signUp();
       expect( $uibModal.open ).toHaveBeenCalledTimes( 1 );
       expect( $uibModal.open.calls.argsFor( 0 )[0].resolve.state() ).toEqual( 'sign-up' );
+    } );
+  } );
+
+  describe( 'forgotPassword', () => {
+    it( 'should open forgotPassword modal', () => {
+      sessionModalService.forgotPassword();
+      expect( $uibModal.open ).toHaveBeenCalledTimes( 1 );
+      expect( $uibModal.open.calls.argsFor( 0 )[0].resolve.state() ).toEqual( 'forgot-password' );
+    } );
+  } );
+
+  describe( 'resetPassword', () => {
+    it( 'should open resetPassword modal', () => {
+      sessionModalService.resetPassword();
+      expect( $uibModal.open ).toHaveBeenCalledTimes( 1 );
+      expect( $uibModal.open.calls.argsFor( 0 )[0].resolve.state() ).toEqual( 'reset-password' );
+    } );
+  } );
+} );
+
+describe( 'sessionModalService module config', () => {
+  let modalStateServiceProvider;
+
+  beforeEach( () => {
+    angular.mock.module( modalStateModule.name, function ( _modalStateServiceProvider_ ) {
+      modalStateServiceProvider = _modalStateServiceProvider_;
+      spyOn( modalStateServiceProvider, 'registerModal' );
+    } );
+    angular.mock.module( module.name );
+  } );
+
+  it( 'config to register \'reset-password\' modal', inject( function () {
+    expect( modalStateServiceProvider.registerModal ).toHaveBeenCalledWith( 'reset-password', jasmine.any( Function ) );
+  } ) );
+
+  describe( 'invoke \'reset-password\' modal function', () => {
+    let sessionModalService, $injector;
+
+    beforeEach( inject( function ( _sessionModalService_, _$injector_ ) {
+      sessionModalService = _sessionModalService_;
+      $injector = _$injector_;
+      spyOn( sessionModalService, 'resetPassword' );
+    } ) );
+
+    it( 'calls sessionModalService.resetPassword()', () => {
+      let fn = modalStateServiceProvider.registerModal.calls.argsFor( 0 )[1];
+      $injector.invoke( fn );
+      expect( sessionModalService.resetPassword ).toHaveBeenCalled();
     } );
   } );
 } );

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -20,6 +20,10 @@
     <div class="row">
 
       <div ng-switch="$ctrl.state">
+        <forgot-password-modal ng-switch-when="forgot-password"
+                               modal-title="$ctrl.modalTitle"
+                               on-state-change="$ctrl.stateChanged(state)">
+        </forgot-password-modal>
         <reset-password-modal ng-switch-when="reset-password"
                               modal-title="$ctrl.modalTitle"
                               on-state-change="$ctrl.stateChanged(state)">


### PR DESCRIPTION
This adds a Forgot Password Modal, Reset Password Modal and a new service modalState.

modalStateService has a provider that allows registering of named modals and  the method to display them. The service attaches a module.run method, which looks at the url #hash and displays the modal at app start. The service also has methods for setting and getting additional query param properties. This allows deeplinking to modals.

example: resetPasswordModal registers 'reset-password' names modal. If the application starts with #reset-modal in the url, the service will display the reset-password modal.