### PR TITLE
Fixes lost q param after closing modal.

### DIFF
--- a/src/common/components/resetPasswordModal/resetPasswordModal.component.js
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.component.js
@@ -37,6 +37,12 @@ class ResetPasswordModalController {
     this.setPristine();
   }
 
+  $onDestroy() {
+    angular.forEach( ['e', 'k'], ( key ) => {
+      this.$location.search( key, null );
+    } );
+  }
+
   resetPassword() {
     if ( !this.form.$valid ) {
       return;
@@ -50,7 +56,7 @@ class ResetPasswordModalController {
         this.isLoading = false;
         this.passwordChanged = true;
         // Remove modal name and modal params on success
-        this.modalState.name(null);
+        this.modalState.name( null );
         this.$location.search( 'e', null );
         this.$location.search( 'k', null );
       }, ( error ) => {

--- a/src/common/components/resetPasswordModal/resetPasswordModal.component.spec.js
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.component.spec.js
@@ -47,6 +47,15 @@ describe( 'resetPasswordModal', function () {
     } );
   } );
 
+  describe( '$onDestroy', () => {
+    it( 'removes query params', () => {
+      spyOn( $ctrl.$location, 'search' );
+      $ctrl.$onDestroy();
+      expect( $ctrl.$location.search ).toHaveBeenCalledWith( 'e', null );
+      expect( $ctrl.$location.search ).toHaveBeenCalledWith( 'k', null );
+    } );
+  } );
+
   describe( 'resetPassword', () => {
     let deferred;
     beforeEach( inject( function ( _$q_ ) {

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -8,7 +8,7 @@ import sessionModalWindowTemplate from './sessionModalWindow.tpl';
 let serviceName = 'sessionModalService';
 
 /*@ngInject*/
-function SessionModalService( $uibModal, $location, modalStateService ) {
+function SessionModalService( $uibModal, modalStateService ) {
 
   function openModal( type, options ) {
     type = angular.isDefined( type ) ? type : 'sign-in';
@@ -27,12 +27,8 @@ function SessionModalService( $uibModal, $location, modalStateService ) {
       .open( modalOptions )
       .result
       .finally( () => {
-        // Clear the modal name and params when modals close
+        // Clear the modal name when modals close
         modalStateService.name( null );
-        let params = $location.search();
-        angular.forEach( params, ( value, key ) => {
-          $location.search( key, null );
-        } );
       } );
   }
 

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -37,23 +37,20 @@ describe( 'sessionModalService', function () {
     } );
 
     describe( 'modal closes', () => {
-      let deferred, $rootScope, $location, modalStateService;
+      let deferred, $rootScope, modalStateService;
       beforeEach( inject( function ( _$q_, _$rootScope_, _$location_, _modalStateService_ ) {
         $rootScope = _$rootScope_;
-        $location = _$location_;
         modalStateService = _modalStateService_;
         deferred = _$q_.defer();
         spyOn( modalStateService, 'name' );
-        spyOn( $location, 'search' );
         $uibModal.open.and.returnValue( {result: deferred.promise} );
       } ) );
 
-      it( 'removes modal name and params', () => {
+      it( 'removes modal name', () => {
         sessionModalService.open();
         deferred.resolve();
         $rootScope.$digest();
         expect( modalStateService.name ).toHaveBeenCalledWith( null );
-        expect( $location.search ).toHaveBeenCalled();
       } );
     } );
   } );


### PR DESCRIPTION
This fixes https://jira.cru.org/browse/EP-1237
This completely removes the code that was removing all query params when a modal closed. It will now be up to the individual modal components to remove query params they care about.