### PR TITLE
Fix gift comment collapsing

### DIFF
--- a/src/app/productConfig/productConfigModal.tpl.html
+++ b/src/app/productConfig/productConfigModal.tpl.html
@@ -133,21 +133,21 @@
           <div class="panel-body pt0">
             <ul class="list-unstyled">
               <li>
-                <a class="commentLink" href="" ng-click="showRecipientComments = !showRecipientComments" translate>Send a Message to {{$ctrl.productData.displayName}}</a>
+                <a class="commentLink" href="" ng-click="!$ctrl.itemConfig['recipient-comments'] && (showRecipientComments = !showRecipientComments)" translate>Send a Message to {{$ctrl.productData.displayName}}</a>
                 <textarea class="staff-comments give-modal-comments"
                           rows="3"
                           maxlength="250"
                           ng-model="$ctrl.itemConfig['recipient-comments']"
-                          ng-if="showRecipientComments || $ctrl.itemConfig['recipient-comments']"
+                          ng-if="showRecipientComments"
                           style="display:block;"></textarea>
               </li>
               <li>
-                <a class="commentLink" href="" ng-click="showDSComments = !showDSComments" translate>Special Handling Instructions for Processing This Gift</a>
+                <a class="commentLink" href="" ng-click="!$ctrl.itemConfig['donation-services-comments'] && (showDSComments = !showDSComments)" translate>Special Handling Instructions for Processing This Gift</a>
                 <textarea class="cru-comments give-modal-comments"
                           rows="3"
                           maxlength="250"
                           ng-model="$ctrl.itemConfig['donation-services-comments']"
-                          ng-if="showDSComments || $ctrl.itemConfig['donation-services-comments']"
+                          ng-if="showDSComments"
                           style="display:block;"></textarea>
               </li>
             </ul>


### PR DESCRIPTION
In productConfig modal, disable click actions on comment headings when there is content in the box.
https://jira.cru.org/browse/EP-1201
With the old code, if you opened the comment, typed something, and tried to close it by clicking the heading an odd number of times while there was still content then it would instantly be closed if there was no content in the box.

This might not be the cleanest way to fix it but this keeps all the code in the view as it was before.