### PR TITLE
Add better error messages to checkout step 2

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -66,8 +66,12 @@ class ExistingPaymentMethodsController {
       size: 'large new-payment-method-modal',
       backdrop: 'static', // Disables closing on click
       resolve: {
+        submissionError: this.submissionError,
         onSubmit: () => this.onSubmit
       }
+    });
+    this.addNewPaymentMethodModal.result.then(null, () => {
+      this.onSubmit({success: false, error: ''}); // To clear the submissionErrors object in step 2
     });
   }
 
@@ -84,7 +88,7 @@ class ExistingPaymentMethodsController {
         },
         (error) => {
           this.$log.error('Error selecting payment method', error);
-          this.onSubmit({success: false});
+          this.onSubmit({success: false, error: error});
         });
   }
 }
@@ -103,6 +107,7 @@ export default angular
     templateUrl: template.name,
     bindings: {
       submitted: '<',
+      submissionError: '<',
       onSubmit: '&',
       onLoad: '&'
     }

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -19,6 +19,7 @@ class Step2Controller{
     this.submitted = false;
     this.loadingPaymentMethods = true;
     this.existingPaymentMethods = true;
+    this.submissionError = {error: ''};
   }
 
   handleExistingPaymentLoading(success, hasExistingPaymentMethods, error){
@@ -27,12 +28,14 @@ class Step2Controller{
     }else{
       this.existingPaymentMethods = false;
       this.$log.warn('Error loading existing payment methods', error);
-      //TODO: should we show the user that there was an error or should we let them just add a new payment method
+      this.loadingExistingPaymentError = error;
     }
     this.loadingPaymentMethods = false;
   }
 
-  onSubmit(success, data){
+  onSubmit(success, data, error){
+    this.submissionError.error = '';
+
     if(success && data){
       this.orderService.addPaymentMethod(data)
         .subscribe(() => {
@@ -41,12 +44,13 @@ class Step2Controller{
           (error) => {
             this.$log.error('Error saving payment method', error);
             this.submitted = false;
-            //TODO: add error handling
+            this.submissionError.error = error.data;
           });
     }else if(success){
       this.changeStep({newStep: 'review'});
     }else{
       this.submitted = false;
+      this.submissionError.error = error;
     }
   }
 }

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -37,6 +37,7 @@ describe('checkout', () => {
         expect(self.controller.existingPaymentMethods).toEqual(false);
         expect(self.controller.loadingPaymentMethods).toEqual(false);
         expect(self.controller.$log.warn.logs[0]).toEqual(['Error loading existing payment methods', 'some error']);
+        expect(self.controller.loadingExistingPaymentError).toEqual('some error');
       });
     });
 
@@ -50,11 +51,12 @@ describe('checkout', () => {
       });
       it('should handle an error saving payment data', () => {
         spyOn(self.controller, 'changeStep');
-        spyOn(self.controller.orderService, 'addPaymentMethod').and.callFake(() => Observable.throw('some error'));
+        spyOn(self.controller.orderService, 'addPaymentMethod').and.callFake(() => Observable.throw({ data: 'some error' }));
         self.controller.onSubmit(true, {bankAccount: {}});
         expect(self.controller.orderService.addPaymentMethod).toHaveBeenCalledWith({bankAccount: {}});
         expect(self.controller.submitted).toEqual(false);
-        expect(self.controller.$log.error.logs[0]).toEqual(['Error saving payment method', 'some error']);
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error saving payment method', { data: 'some error' }]);
+        expect(self.controller.submissionError.error).toEqual('some error');
       });
       it('should call changeStep if save was successful and there was no data (assumes another component saved the data)', () => {
         spyOn(self.controller, 'changeStep');
@@ -63,8 +65,9 @@ describe('checkout', () => {
       });
       it('should set submitted to false if save was unsuccessful', () => {
         self.controller.submitted = true;
-        self.controller.onSubmit(false);
+        self.controller.onSubmit(false, undefined, 'some error');
         expect(self.controller.submitted).toEqual(false);
+        expect(self.controller.submissionError.error).toEqual('some error');
       });
     });
   });

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -6,13 +6,28 @@
     <span class="loading loading4"></span>
   </div>
 </div>
+<div class="alert alert-danger" role="alert" ng-if="$ctrl.submissionError.error || $ctrl.loadingExistingPaymentError">
+  <p ng-if="$ctrl.loadingExistingPaymentError" ng-switch="$ctrl.loadingExistingPaymentError">
+    <span ng-switch-default translate>
+      We ran into a problem trying to load your saved payment methods. Please enter your payment details below. Sorry for the inconvenience.
+    </span>
+  </p>
+  <p ng-if="$ctrl.submissionError.error" ng-switch="$ctrl.submissionError.error">
+    <span ng-switch-when="Invalid routing number" translate>
+      The routing number you entered does not seem to be valid. Please verify that it is correct.
+    </span>
+    <span ng-switch-default translate>
+      There was an unknown error saving your payment. Please verify all your info and try again. If you are still seeing this message, contact support.
+    </span>
+  </p>
+</div>
 <div ng-show="!$ctrl.loadingPaymentMethods"><!-- ng-show allows checkout-existing-payment-methods component to be instantiated to check for existingPaymentMethods -->
   <div ng-if="!$ctrl.existingPaymentMethods">
     <add-new-payment-method submitted="$ctrl.submitted" on-submit="$ctrl.onSubmit(success, data)"></add-new-payment-method>
   </div>
 
   <div ng-if="$ctrl.existingPaymentMethods">
-    <checkout-existing-payment-methods submitted="$ctrl.submitted" on-submit="$ctrl.onSubmit(success, data)" on-load="$ctrl.handleExistingPaymentLoading(success, hasExistingPaymentMethods, error)"></checkout-existing-payment-methods>
+    <checkout-existing-payment-methods submitted="$ctrl.submitted" submission-error="$ctrl.submissionError" on-submit="$ctrl.onSubmit(success, data, error)" on-load="$ctrl.handleExistingPaymentLoading(success, hasExistingPaymentMethods, error)"></checkout-existing-payment-methods>
   </div>
 </div>
 

--- a/src/common/components/paymentMethods/addNewPaymentMethod/addNewPaymentMethod.modal.tpl.html
+++ b/src/common/components/paymentMethods/addNewPaymentMethod/addNewPaymentMethod.modal.tpl.html
@@ -2,6 +2,16 @@
   <div class="row">
     <div class="col-sm-12">
       <h3 class="text-center border-bottom-small" translate>Add Payment Method</h3>
+      <div class="alert alert-danger" role="alert" ng-if="$ctrl.resolve.submissionError.error">
+        <p ng-if="$ctrl.resolve.submissionError.error" ng-switch="$ctrl.resolve.submissionError.error">
+          <span ng-switch-when="Invalid routing number" translate>
+            The routing number you entered does not seem to be valid. Please verify that it is correct.
+          </span>
+          <span ng-switch-default translate>
+            There was an unknown error saving your payment. Please verify all your info and try again. If you are still seeing this message, contact support.
+          </span>
+        </p>
+      </div>
       <add-new-payment-method submitted="$ctrl.submitted" on-submit="$ctrl.onSubmit(success, data)"></add-new-payment-method>
     </div>
   </div>


### PR DESCRIPTION
- Show loading and submission errors at top of step 2
- Pass submission errors back into the addNewPaymentMethodModal to show at the top of the modal