### PR TITLE
Add tests to step 1, homeSignIn, accountBenefits, and paymentMethodDisplay

### DIFF
--- a/src/app/checkout/step-1/step-1.component.js
+++ b/src/app/checkout/step-1/step-1.component.js
@@ -22,7 +22,44 @@ class Step1Controller{
     this.orderService = orderService;
     this.geographiesService = geographiesService;
 
-    this.init();
+    this.donorDetails = {
+      mailingAddress: {
+        country: 'US'
+      }
+    };
+  }
+
+  $onInit(){
+    this.loadDonorDetails();
+    this.loadCountries();
+  }
+
+  loadDonorDetails(){
+    this.orderService.getDonorDetails()
+      .subscribe((data) => {
+        if(data['donor-type'] === ''){
+          data['donor-type'] = 'Household';
+        }
+        this.donorDetails = data;
+      });
+  }
+
+  loadCountries(){
+    this.geographiesService.getCountries()
+      .subscribe((data) => {
+        this.countries = data;
+        this.refreshRegions(this.donorDetails.mailingAddress.country);
+      });
+  }
+
+  refreshRegions(country){
+    country = find(this.countries, {name: country});
+    if(!country){ return; }
+
+    this.geographiesService.getRegions(country)
+      .subscribe((data) => {
+        this.regions = data;
+      });
   }
 
   submitDetails(){
@@ -41,31 +78,6 @@ class Step1Controller{
         this.$log.warn('Error saving donor contact info', error);
         this.submissionError = error.data;
         this.$window.scrollTo(0, 0);
-      });
-  }
-
-  refreshRegions(country){
-    country = find(this.countries, {name: country});
-    if(!country){ return; }
-
-    this.geographiesService.getRegions(country)
-      .subscribe((data) => {
-        this.regions = data;
-      });
-  }
-
-  init(){
-    this.orderService.getDonorDetails()
-      .subscribe((data) => {
-        if(data['donor-type'] === ''){
-          data['donor-type'] = 'Household';
-        }
-        this.donorDetails = data;
-      });
-
-    this.geographiesService.getCountries()
-      .subscribe((data) => {
-        this.countries = data;
       });
   }
 }

--- a/src/app/checkout/step-1/step-1.spec.js
+++ b/src/app/checkout/step-1/step-1.spec.js
@@ -1,5 +1,11 @@
 import angular from 'angular';
 import 'angular-mocks';
+import find from 'lodash/find';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+
+import countriesResponse from 'common/services/api/fixtures/cortex-countries.fixture.js';
+
 import module from './step-1.component';
 
 describe('checkout', function() {
@@ -7,16 +13,119 @@ describe('checkout', function() {
     beforeEach(angular.mock.module(module.name));
     var self = {};
 
-    beforeEach(inject(function($rootScope, $componentController) {
-      var $scope = $rootScope.$new();
-
-      self.controller = $componentController(module.name, {
-        $scope: $scope
+    beforeEach(inject(function($componentController) {
+      self.controller = $componentController(module.name, {}, {
+        changeStep: jasmine.createSpy('changeStep')
       });
     }));
 
-    it('to be defined', function() {
-      expect(self.controller).toBeDefined();
+    describe('$onInit', () => {
+      it('load the necessary data', () => {
+        spyOn(self.controller, 'loadCountries');
+        spyOn(self.controller, 'loadDonorDetails');
+        self.controller.$onInit();
+        expect(self.controller.loadCountries).toHaveBeenCalled();
+        expect(self.controller.loadDonorDetails).toHaveBeenCalled();
+      });
+    });
+
+    describe('loadDonorDetails', () => {
+      it('should get the donor\'s details', () => {
+        spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': 'Organization' }));
+        self.controller.loadDonorDetails();
+        expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
+        expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Organization' });
+      });
+      it('should set the donor type if it is an empty string', () => {
+        spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': '' }));
+        self.controller.loadDonorDetails();
+        expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
+        expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Household' });
+      });
+    });
+
+    describe('loadCountries', () => {
+      it('should get the list of countries', () => {
+        spyOn(self.controller.geographiesService, 'getCountries').and.callFake(() => Observable.of(['country1', 'country2']));
+        spyOn(self.controller, 'refreshRegions');
+        self.controller.loadCountries();
+        expect(self.controller.countries).toEqual(['country1', 'country2']);
+        expect(self.controller.refreshRegions).toHaveBeenCalled();
+      });
+    });
+
+    describe('refreshRegions', () => {
+      it('should get the list of regions of a given country', () => {
+        self.controller.countries = countriesResponse._element;
+        spyOn(self.controller.geographiesService, 'getRegions').and.callFake(() => Observable.of(['region1', 'region2']));
+        self.controller.refreshRegions('US');
+        expect(self.controller.geographiesService.getRegions).toHaveBeenCalledWith(find(countriesResponse._element, { name: 'US' }));
+        expect(self.controller.regions).toEqual(['region1', 'region2']);
+      });
+      it('should do nothing if the country doesn\'t exist in the loaded list of countries', () => {
+        self.controller.countries = countriesResponse._element;
+        spyOn(self.controller.geographiesService, 'getRegions');
+        self.controller.refreshRegions('USA');
+        expect(self.controller.geographiesService.getRegions).not.toHaveBeenCalled();
+        expect(self.controller.regions).toBeUndefined();
+      });
+    });
+
+    describe('submitDetails', () => {
+      it('should scroll to top if there are errors', () => {
+        self.controller.detailsForm = {
+          $valid: false
+        };
+        spyOn(self.controller.$window, 'scrollTo');
+        spyOn(self.controller.orderService, 'updateDonorDetails');
+        spyOn(self.controller.orderService, 'addEmail');
+        self.controller.submitDetails();
+        expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0);
+        expect(self.controller.orderService.updateDonorDetails).not.toHaveBeenCalled();
+        expect(self.controller.orderService.addEmail).not.toHaveBeenCalled();
+      });
+      it('should save donor details and email', () => {
+        self.controller.detailsForm = {
+          $valid: true
+        };
+        self.controller.donorDetails = {
+          'given-name': 'Fname',
+          email: 'someone@asdf.com'
+        };
+        spyOn(self.controller.$window, 'scrollTo');
+        spyOn(self.controller.orderService, 'updateDonorDetails').and.returnValue(Observable.of('donor details success'));
+        spyOn(self.controller.orderService, 'addEmail').and.returnValue(Observable.of('email success'));
+        self.controller.submitDetails();
+        expect(self.controller.orderService.updateDonorDetails).toHaveBeenCalledWith({
+          'given-name': 'Fname',
+          email: 'someone@asdf.com'
+        });
+        expect(self.controller.orderService.addEmail).toHaveBeenCalledWith('someone@asdf.com');
+        expect(self.controller.changeStep).toHaveBeenCalledWith({newStep: 'payment'});
+        expect(self.controller.$window.scrollTo).not.toHaveBeenCalled();
+      });
+      it('should handle an error saving donor details or email', () => {
+        self.controller.detailsForm = {
+          $valid: true
+        };
+        self.controller.donorDetails = {
+          'given-name': 'Fname',
+          email: 'someone@asdf.com'
+        };
+        spyOn(self.controller.$window, 'scrollTo');
+        spyOn(self.controller.orderService, 'updateDonorDetails').and.returnValue(Observable.throw({ data: 'donor details error' }));
+        spyOn(self.controller.orderService, 'addEmail').and.returnValue(Observable.throw({ data: 'email error' }));
+        self.controller.submitDetails();
+        expect(self.controller.orderService.updateDonorDetails).toHaveBeenCalledWith({
+          'given-name': 'Fname',
+          email: 'someone@asdf.com'
+        });
+        expect(self.controller.orderService.addEmail).toHaveBeenCalledWith('someone@asdf.com');
+        expect(self.controller.changeStep).not.toHaveBeenCalled();
+        expect(self.controller.$log.warn.logs[0]).toEqual(['Error saving donor contact info', { data: 'donor details error' }]);
+        expect(self.controller.submissionError).toEqual('donor details error');
+        expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0);
+      });
     });
   });
 });

--- a/src/app/checkout/step-1/step-1.tpl.html
+++ b/src/app/checkout/step-1/step-1.tpl.html
@@ -206,8 +206,7 @@
                         name="addressCountry" required
                         ng-model="$ctrl.donorDetails.mailingAddress.country"
                         ng-options="v.name as v['display-name'] for v in $ctrl.countries | orderBy:'\'display-name\''"
-                        ng-change="$ctrl.refreshRegions($ctrl.donorDetails.mailingAddress.country)"
-                        ng-init="$ctrl.refreshRegions($ctrl.donorDetails.mailingAddress.country)">
+                        ng-change="$ctrl.refreshRegions($ctrl.donorDetails.mailingAddress.country)">
                 </select>
                 <div role="alert" ng-messages="$ctrl.detailsForm.addressCountry.$error" ng-if="($ctrl.detailsForm.addressCountry | showErrors)">
                   <div class="help-block" ng-message="required" translate>You must select a country</div>

--- a/src/app/homeSignIn/homeSignIn.component.js
+++ b/src/app/homeSignIn/homeSignIn.component.js
@@ -20,11 +20,7 @@ class HomeSignInController {
 
   $onInit() {
     this.isSigningIn = false;
-    this.showSignInForm = true;
-
-    if ( includes( ['IDENTIFIED', 'REGISTERED'], this.sessionService.getRole() ) ) {
-      this.showSignInForm = false;
-    }
+    this.showSignInForm = !includes( ['IDENTIFIED', 'REGISTERED'], this.sessionService.getRole() );
   }
 
   signIn() {

--- a/src/app/homeSignIn/homeSignIn.spec.js
+++ b/src/app/homeSignIn/homeSignIn.spec.js
@@ -88,4 +88,12 @@ describe('home sign in', function() {
       expect( $ctrl.sessionModalService.signUp ).toHaveBeenCalled();
     } );
   });
+
+  describe( 'forgotPassword', () => {
+    it( 'opens forgotPassword Modal', () => {
+      spyOn( $ctrl.sessionModalService, 'forgotPassword' );
+      $ctrl.forgotPassword();
+      expect( $ctrl.sessionModalService.forgotPassword ).toHaveBeenCalled();
+    } );
+  });
 });

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
@@ -1,0 +1,20 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+import module from './accountBenefits.component';
+
+describe('thank you', function() {
+  describe('accountBenefits', function() {
+    beforeEach(angular.mock.module(module.name));
+    var self = {};
+
+    beforeEach(inject(function($componentController) {
+      self.controller = $componentController(module.name);
+    }));
+
+    it('should be defined', () => {
+      expect(self.controller).toBeDefined();
+      expect(self.controller.sessionModalService).toBeDefined();
+    });
+  });
+});

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -130,7 +130,7 @@ describe('credit card form', () => {
   describe('loadDonorDetails', () => {
     it('should get the donor\'s details', () => {
       spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of('some details'));
-      self.controller.loadDonorDetails('US');
+      self.controller.loadDonorDetails();
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
       expect(self.controller.donorDetails).toEqual('some details');
     });

--- a/src/common/components/paymentMethods/paymentMethodDisplay.component.js
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.component.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-environment';
+import appConfig from 'common/app.config';
 
 import template from './paymentMethodDisplay.tpl';
 
@@ -15,7 +16,9 @@ class PaymentMethodDisplayController{
 
 export default angular
   .module(componentName, [
-    template.name
+    template.name,
+    'environment',
+    appConfig.name
   ])
   .component(componentName, {
     controller: PaymentMethodDisplayController,

--- a/src/common/components/paymentMethods/paymentMethodDisplay.component.spec.js
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.component.spec.js
@@ -1,0 +1,18 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+import module from './paymentMethodDisplay.component';
+
+describe('paymentMethodDisplay', function() {
+  beforeEach(angular.mock.module(module.name));
+  var self = {};
+
+  beforeEach(inject(function($componentController) {
+    self.controller = $componentController(module.name);
+  }));
+
+  it('should be defined', () => {
+    expect(self.controller).toBeDefined();
+    expect(self.controller.imgDomain).toEqual('');
+  });
+});

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -3,7 +3,6 @@ import JSONPath from 'common/lib/jsonPath';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/toPromise';
 
 import cortexApiService from '../cortexApi.service';
 


### PR DESCRIPTION
- Refactor step 1 component to be more testable
- Remove unneeded arg when testing loadDonorDetails in creditCardForm component
- Remove unused toPromise operator from designations service