### PR TITLE
Minor cleanup

### DIFF
--- a/src/common/components/signInModal/signInModal.component.js
+++ b/src/common/components/signInModal/signInModal.component.js
@@ -5,6 +5,8 @@ import sessionService from 'common/services/session/session.service';
 import signInForm from 'common/components/signInForm/signInForm.component';
 import template from './signInModal.tpl';
 
+import {Roles} from 'common/services/session/session.service';
+
 let componentName = 'signInModal';
 
 class SignInModalController {
@@ -18,7 +20,7 @@ class SignInModalController {
 
   $onInit() {
     this.modalTitle = this.gettext( 'Sign In' );
-    if ( includes( ['IDENTIFIED', 'REGISTERED'], this.sessionService.getRole() ) ) {
+    if ( includes( [Roles.identified, Roles.registered], this.sessionService.getRole() ) ) {
       this.identified = true;
       this.username = this.session.email;
     }

--- a/src/common/components/signInModal/signInModal.component.spec.js
+++ b/src/common/components/signInModal/signInModal.component.spec.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import 'angular-mocks';
 import module from './signInModal.component';
 
+import {Roles} from 'common/services/session/session.service';
+
 describe( 'signInModal', function () {
   beforeEach( angular.mock.module( module.name ) );
   let $ctrl, bindings;
@@ -22,7 +24,7 @@ describe( 'signInModal', function () {
   describe( '$onInit', () => {
     describe( 'with \'REGISTERED\' cortex-session', () => {
       beforeEach( () => {
-        spyOn( $ctrl.sessionService, 'getRole' ).and.returnValue( 'REGISTERED' );
+        spyOn( $ctrl.sessionService, 'getRole' ).and.returnValue( Roles.registered );
         $ctrl.session.email = 'professorx@xavier.edu';
         $ctrl.$onInit();
       } );
@@ -33,9 +35,9 @@ describe( 'signInModal', function () {
         expect( $ctrl.identified ).toEqual( true );
       } );
     } );
-    describe( 'with \'GUEST\' cortex-session', () => {
+    describe( 'with \'PUBLIC\' cortex-session', () => {
       beforeEach( () => {
-        spyOn( $ctrl.sessionService, 'getRole' ).and.returnValue( 'GUEST' );
+        spyOn( $ctrl.sessionService, 'getRole' ).and.returnValue(  Roles.public );
         $ctrl.$onInit();
       } );
 


### PR DESCRIPTION
This is just a minor tweak. Use sessionService Roles instead of hardcoded strings.
Originally, I was looking into the issue @OzzieOrca mentioned about Forgot Password not being styled correctly, but it's styled exactly the same as crugive.site.