### PR TITLE
Add change callback to sessionEnforcerService

### DIFF
--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -38,10 +38,13 @@ class CheckoutController{
   }
 
   $onInit() {
-    this.enforcerId = this.sessionEnforcerService([Roles.public, Roles.registered], () => {
-      this.loadCart();
-    }, () => {
-      this.$window.location = 'cart.html';
+    this.enforcerId = this.sessionEnforcerService([Roles.public, Roles.registered], {
+      'sign-in': () => {
+        this.loadCart();
+      },
+      cancel: () => {
+        this.$window.location = 'cart.html';
+      }
     });
     this.loadCart();
   }

--- a/src/app/checkout/checkout.spec.js
+++ b/src/app/checkout/checkout.spec.js
@@ -54,23 +54,24 @@ describe( 'checkout', function () {
     } );
     it( 'initializes the component', () => {
       expect( self.controller.sessionEnforcerService ).toHaveBeenCalledWith(
-        [Roles.public, Roles.registered],
-        jasmine.any( Function ),
-        jasmine.any( Function )
+        [Roles.public, Roles.registered], jasmine.objectContaining( {
+          'sign-in': jasmine.any( Function ),
+          cancel:    jasmine.any( Function )
+        } )
       );
       expect( self.controller.loadCart ).toHaveBeenCalled();
     } );
 
     describe( 'sessionEnforcerService success', () => {
       it( 'executes success callback', () => {
-        self.controller.sessionEnforcerService.calls.argsFor( 0 )[1]();
+        self.controller.sessionEnforcerService.calls.argsFor( 0 )[1]['sign-in']();
         expect( self.controller.loadCart ).toHaveBeenCalledTimes( 2 );
       } );
     } );
 
     describe( 'sessionEnforcerService failure', () => {
       it( 'executes failure callback', () => {
-        self.controller.sessionEnforcerService.calls.argsFor( 0 )[2]();
+        self.controller.sessionEnforcerService.calls.argsFor( 0 )[1]['cancel']();
         expect( self.controller.$window.location ).toEqual( 'cart.html' );
       } );
     } );

--- a/src/common/services/session/sessionEnforcer.service.spec.js
+++ b/src/common/services/session/sessionEnforcer.service.spec.js
@@ -32,43 +32,48 @@ describe( 'sessionEnforcerService', function () {
       expect( sessionModalService.open ).not.toHaveBeenCalled();
     } );
 
-    it( 'accepts success and failure callbacks', () => {
+    it( 'accepts \'sign-in\', \'cancel\' and \'change\' callbacks', () => {
       expect( sessionEnforcerService(
-        [Roles.public, Roles.registered],
-        ()=> {
-        },
-        ()=> {
+        [Roles.public, Roles.registered], {
+          'sign-in': () => {
+          },
+          cancel:    () => {
+          },
+          change:    () => {
+          }
         }
       ) ).toEqual( jasmine.any( String ) );
       expect( sessionModalService.open ).not.toHaveBeenCalled();
     } );
 
     describe( 'does not include current role', () => {
-      let success, failure, $rootScope;
+      let signIn, cancel, change, $rootScope;
       beforeEach( inject( function ( _$rootScope_ ) {
         $rootScope = _$rootScope_;
-        success = jasmine.createSpy( 'success' );
-        failure = jasmine.createSpy( 'failure' );
-        sessionEnforcerService( [Roles.registered], success, failure );
+        signIn = jasmine.createSpy( 'success' );
+        cancel = jasmine.createSpy( 'failure' );
+        change = jasmine.createSpy( 'change' );
+        sessionEnforcerService( [Roles.registered], {'sign-in': signIn, cancel: cancel, change: change} );
       } ) );
 
-      it( 'opens sign-in modal', () => {
+      it( 'opens sign-in modal and calls \'change\' callback', () => {
+        expect( change ).toHaveBeenCalledWith( Roles.public );
         expect( sessionModalService.open ).toHaveBeenCalledWith( 'sign-in', {backdrop: 'static', keyboard: false} );
       } );
 
       describe( 'sign-in success', () => {
-        it( 'calls success callback', () => {
+        it( 'calls \'sign-in\' callback', () => {
           deferred.resolve();
           $rootScope.$digest();
-          expect( success ).toHaveBeenCalled();
+          expect( signIn ).toHaveBeenCalled();
         } );
       } );
 
       describe( 'sign-in canceled', () => {
-        it( 'calls failure callback', () => {
+        it( 'calls \'cancel\' callback', () => {
           deferred.reject();
           $rootScope.$digest();
-          expect( failure ).toHaveBeenCalled();
+          expect( cancel ).toHaveBeenCalled();
         } );
       } );
     } );


### PR DESCRIPTION
I was finding the need for a callback that occurred when the session changed to a non-enforced role. This will now allow components to visually hide sensitive information while waiting for the sessionEnforcer to either issue sign-in or cancel callbacks.

Also changed the way callbacks are passed to the constructor. This will allow components to pass only the callbacks they care about.