### PR TITLE
Add slightly better nested zoom support to cortexApiService

### DIFF
--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -2,7 +2,7 @@ import angular from 'angular';
 import 'angular-messages';
 import toString from 'lodash/toString';
 import range from 'lodash/range';
-import defaults from 'lodash/defaults';
+import assign from 'lodash/assign';
 import 'rxjs/add/operator/combineLatest';
 
 import displayAddressComponent from 'common/components/display-address/display-address.component';
@@ -91,7 +91,7 @@ class CreditCardController {
     this.orderService.getDonorDetails()
       .subscribe((data) => {
         this.donorDetails = data;
-        defaults(this.billingAddress, this.donorDetails.mailingAddress);
+        assign(this.billingAddress, this.donorDetails.mailingAddress);
       });
   }
 

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -97,11 +97,18 @@ describe('credit card form', () => {
 
   describe('loadDonorDetails', () => {
     it('should get the donor\'s details', () => {
-      spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of('some details'));
+      let donorDetails = {
+        "donor-type": "Household",
+        mailingAddress: {
+          country: 'CA',
+          streetAddress: '123 Some Street'
+        }
+      };
+      spyOn(self.controller.orderService, 'getDonorDetails').and.returnValue(Observable.of(donorDetails));
       self.controller.loadDonorDetails();
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
-      expect(self.controller.donorDetails).toEqual('some details');
-      expect(self.controller.billingAddress).toEqual(jasmine.objectContaining({ isMailingAddress: true, country: 'US', streetAddress: '', extendedAddress: '', locality: '', region: '', postalCode: '' }));
+      expect(self.controller.donorDetails).toEqual(donorDetails);
+      expect(self.controller.billingAddress).toEqual(jasmine.objectContaining({ isMailingAddress: true, country: 'CA', streetAddress: '123 Some Street'}));
     });
   });
 

--- a/src/common/services/hateoasHelper.spec.js
+++ b/src/common/services/hateoasHelper.spec.js
@@ -38,6 +38,9 @@ describe('HATEOAS helper service', function() {
       cartResponse._order.push('item 2');
       expect(self.hateoasHelperService.getElement(cartResponse, 'order', true)).toEqual([cartResponse._order[0], 'item 2']);
     });
+    it('should try the path without a prefixed underscore if it couldn\'t find the path with an underscore', () => {
+      expect(self.hateoasHelperService.getElement({ test: ['some value'] }, 'test')).toEqual('some value');
+    });
     it('should return undefined for an unknown element', () => {
       expect(self.hateoasHelperService.getElement(cartResponse, ['order', 'nonexistent'])).toBeUndefined();
     });
@@ -130,10 +133,19 @@ describe('HATEOAS helper service', function() {
           {
             someKey: 'someValue'
           }
+        ],
+        paymentmeans: [
+          {
+            _creditcard: [
+              {
+                someKey: 'someValue'
+              }
+            ]
+          }
         ]
       };
       this.zoomString = 'lineitems:element';
-      this.childZoomStrings = ['lineitems:element:code', 'lineitems:element:rates[]'];
+      this.childZoomStrings = ['lineitems:element:code', 'lineitems:element:rates[]', 'lineitems:element:paymentmeans:creditcard'];
     });
 
     it('should take an element and map the child zoom strings to keys', () => {
@@ -145,7 +157,10 @@ describe('HATEOAS helper service', function() {
           {
             someKey: 'someValue'
           }
-        ]
+        ],
+        paymentmeansCreditcard: {
+          someKey: 'someValue'
+        }
       });
     });
     it('should return undefined if the zoom isn\'t found', () => {
@@ -159,6 +174,15 @@ describe('HATEOAS helper service', function() {
         _rates: [
           {
             someKey: 'someValue'
+          }
+        ],
+        paymentmeans: [
+          {
+            _creditcard: [
+              {
+                someKey: 'someValue'
+              }
+            ]
           }
         ],
         code2: undefined,


### PR DESCRIPTION
- For a sub zoom key, look at both the underscore prefixed and unprefixed versions of the key
- camelCase zoom mapped keys
- In mapChildZoomElements, search in original element, not mapped one
- In creditCardForm, fix loading mailingAddress into billingAddress and the failing test there