### PR TITLE
Don't require CCV for existing credit card payments since we aren't collecting it

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -84,6 +84,7 @@ class ExistingPaymentMethodsController {
   selectPayment(){
     this.orderService.selectPaymentMethod(this.selectedPaymentMethod)
       .subscribe(() => {
+          this.orderService.storeCardSecurityCode('existing payment method');
           this.onSubmit({success: true});
         },
         (error) => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -5,7 +5,7 @@ import 'angular-ui-bootstrap';
 import paymentMethodDisplay from 'common/components/paymentMethods/paymentMethodDisplay.component';
 import addNewPaymentMethodModal from 'common/components/paymentMethods/addNewPaymentMethod/addNewPaymentMethod.modal.component';
 
-import orderService from 'common/services/api/order.service';
+import orderService, {existingPaymentMethodFlag} from 'common/services/api/order.service';
 import sessionService from 'common/services/session/session.service';
 
 import template from './existingPaymentMethods.tpl';
@@ -84,7 +84,7 @@ class ExistingPaymentMethodsController {
   selectPayment(){
     this.orderService.selectPaymentMethod(this.selectedPaymentMethod)
       .subscribe(() => {
-          this.orderService.storeCardSecurityCode('existing payment method');
+          this.orderService.storeCardSecurityCode(existingPaymentMethodFlag);
           this.onSubmit({success: true});
         },
         (error) => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -142,15 +142,24 @@ describe('checkout', () => {
       });
 
       describe('selectPayment', () => {
+        beforeEach(() => {
+          spyOn(self.controller.orderService, 'selectPaymentMethod');
+          spyOn(self.controller.orderService, 'storeCardSecurityCode');
+        });
+
         it('should save the selected payment', () => {
-          spyOn(self.controller.orderService, 'selectPaymentMethod').and.callFake(() => Observable.of('success'));
+          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account' } };
+          self.controller.orderService.selectPaymentMethod.and.returnValue(Observable.of('success'));
           self.controller.selectPayment();
+          expect(self.controller.orderService.selectPaymentMethod).toHaveBeenCalledWith(self.controller.selectedPaymentMethod);
           expect(self.controller.onSubmit).toHaveBeenCalledWith({success: true});
+          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith('existing payment method');
         });
         it('should handle a failed request to save the selected payment', () => {
-          spyOn(self.controller.orderService, 'selectPaymentMethod').and.callFake(() => Observable.throw('some error'));
+          self.controller.orderService.selectPaymentMethod.and.returnValue(Observable.throw('some error'));
           self.controller.selectPayment();
           expect(self.controller.onSubmit).toHaveBeenCalledWith({success: false, error: 'some error'});
+          expect(self.controller.orderService.storeCardSecurityCode).not.toHaveBeenCalled();
           expect(self.controller.$log.error.logs[0]).toEqual(['Error selecting payment method', 'some error']);
         });
       });

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -5,6 +5,8 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/toPromise';
 
+import {existingPaymentMethodFlag} from 'common/services/api/order.service';
+
 import module from './existingPaymentMethods.component';
 
 describe('checkout', () => {
@@ -153,7 +155,7 @@ describe('checkout', () => {
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).toHaveBeenCalledWith(self.controller.selectedPaymentMethod);
           expect(self.controller.onSubmit).toHaveBeenCalledWith({success: true});
-          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith('existing payment method');
+          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(existingPaymentMethodFlag);
         });
         it('should handle a failed request to save the selected payment', () => {
           self.controller.orderService.selectPaymentMethod.and.returnValue(Observable.throw('some error'));

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -91,7 +91,11 @@ class Step3Controller{
       submitRequest = this.orderService.submit();
     }else if(this.creditCardPaymentDetails){
       let encryptedCcv = this.orderService.retrieveCardSecurityCode();
-      submitRequest = encryptedCcv ? this.orderService.submit(encryptedCcv) : Observable.throw('Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly');
+      if(encryptedCcv === 'existing payment method'){
+        submitRequest = this.orderService.submit();
+      }else{
+        submitRequest = encryptedCcv ? this.orderService.submit(encryptedCcv) : Observable.throw('Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly');
+      }
     }else{
       submitRequest = Observable.throw('Current payment type is unknown');
     }

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -6,7 +6,7 @@ import displayAddressComponent from 'common/components/display-address/display-a
 import displayRateTotals from 'common/components/displayRateTotals/displayRateTotals.component';
 import loadingComponent from 'common/components/loading/loading.component';
 
-import orderService from 'common/services/api/order.service';
+import orderService, {existingPaymentMethodFlag} from 'common/services/api/order.service';
 import capitalizeFilter from 'common/filters/capitalize.filter';
 import desigSrcDirective from 'common/directives/desigSrc.directive';
 
@@ -91,7 +91,7 @@ class Step3Controller{
       submitRequest = this.orderService.submit();
     }else if(this.creditCardPaymentDetails){
       let encryptedCcv = this.orderService.retrieveCardSecurityCode();
-      if(encryptedCcv === 'existing payment method'){
+      if(encryptedCcv === existingPaymentMethodFlag){
         submitRequest = this.orderService.submit();
       }else{
         submitRequest = encryptedCcv ? this.orderService.submit(encryptedCcv) : Observable.throw('Submitting a credit card purchase requires a CCV and the CCV was not retrieved correctly');

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import 'angular-mocks';
-import module from './step-3.component';
-
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+
+import {existingPaymentMethodFlag} from 'common/services/api/order.service';
+
+import module from './step-3.component';
 
 describe('checkout', () => {
   describe('step 3', () => {
@@ -250,7 +252,7 @@ describe('checkout', () => {
       });
       it('should submit the order without a CCV if paying with an existing credit card', () => {
         self.controller.creditCardPaymentDetails = {};
-        self.storedCcv = 'existing payment method';
+        self.storedCcv = existingPaymentMethodFlag;
         self.controller.submitOrder();
         expect(self.controller.orderService.submit).toHaveBeenCalledWith();
         expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -248,6 +248,14 @@ describe('checkout', () => {
         expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
         expect(self.controller.$window.location.href).toEqual('thank-you.html');
       });
+      it('should submit the order without a CCV if paying with an existing credit card', () => {
+        self.controller.creditCardPaymentDetails = {};
+        self.storedCcv = 'existing payment method';
+        self.controller.submitOrder();
+        expect(self.controller.orderService.submit).toHaveBeenCalledWith();
+        expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+        expect(self.controller.$window.location.href).toEqual('thank-you.html');
+      });
       it('should handle an error submitting an order with a credit card', () => {
         self.controller.orderService.submit.and.callFake(() => Observable.throw('error saving credit card'));
         self.controller.creditCardPaymentDetails = {};

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -16,6 +16,8 @@ import hateoasHelperService from 'common/services/hateoasHelper.service';
 import formatAddressForCortex from '../addressHelpers/formatAddressForCortex';
 import formatAddressForTemplate from '../addressHelpers/formatAddressForTemplate';
 
+export const existingPaymentMethodFlag = 'existing_payment_method';
+
 let serviceName = 'orderService';
 
 class Order{
@@ -230,7 +232,7 @@ class Order{
   }
 
   storeCardSecurityCode(encryptedCcv){
-    if(encryptedCcv === 'existing payment method' || toString(encryptedCcv).length > 50){
+    if(encryptedCcv === existingPaymentMethodFlag || toString(encryptedCcv).length > 50){
       this.sessionStorage.setItem('ccv', encryptedCcv);
     }else{
       throw new Error('The CCV should be encrypted and the provided CCV looks like it is too short to be encrypted correctly');

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -230,7 +230,7 @@ class Order{
   }
 
   storeCardSecurityCode(encryptedCcv){
-    if(toString(encryptedCcv).length > 50){
+    if(encryptedCcv === 'existing payment method' || toString(encryptedCcv).length > 50){
       this.sessionStorage.setItem('ccv', encryptedCcv);
     }else{
       throw new Error('The CCV should be encrypted and the provided CCV looks like it is too short to be encrypted correctly');

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -580,6 +580,11 @@ describe('order service', () => {
       self.orderService.storeCardSecurityCode(encryptedCcv);
       expect(self.$window.sessionStorage.getItem('ccv')).toEqual(encryptedCcv);
     });
+    it('should allow \'existing payment method\' to be stored', () => {
+      let encryptedCcv = 'existing payment method';
+      self.orderService.storeCardSecurityCode(encryptedCcv);
+      expect(self.$window.sessionStorage.getItem('ccv')).toEqual(encryptedCcv);
+    });
     it('should throw an error when it looks like the security code is unencrypted (has less than 50 chars)', () => {
       expect(() => self.orderService.storeCardSecurityCode('1234')).toThrowError('The CCV should be encrypted and the provided CCV looks like it is too short to be encrypted correctly');
     });

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -5,7 +5,7 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import formatAddressForTemplate from '../addressHelpers/formatAddressForTemplate';
 
-import module from './order.service';
+import module, {existingPaymentMethodFlag} from './order.service';
 
 import cartResponse from 'common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js';
 import paymentMethodResponse from 'common/services/api/fixtures/cortex-order-paymentmethod.fixture.js';
@@ -581,7 +581,7 @@ describe('order service', () => {
       expect(self.$window.sessionStorage.getItem('ccv')).toEqual(encryptedCcv);
     });
     it('should allow \'existing payment method\' to be stored', () => {
-      let encryptedCcv = 'existing payment method';
+      let encryptedCcv = existingPaymentMethodFlag;
       self.orderService.storeCardSecurityCode(encryptedCcv);
       expect(self.$window.sessionStorage.getItem('ccv')).toEqual(encryptedCcv);
     });


### PR DESCRIPTION
- Store 'existing payment method' to ccv in session storage so step 3 knows it doesn't need to send a CCV

https://jira.cru.org/browse/EP-1327