### PR TITLE
Upon submitting the addNewPaymentMethod modal, return to step 2…

### DIFF
--- a/src/app/checkout/checkout.tpl.html
+++ b/src/app/checkout/checkout.tpl.html
@@ -5,7 +5,10 @@
         <div class="col-md-12">
           <div class="panel">
             <div class="panel-body">
-              <loading ng-if="$ctrl.loadingCartData"></loading>
+              <div class="text-center" ng-if="$ctrl.loadingCartData" translate>
+                Loading cart data...
+                <loading inline="true"></loading>
+              </div>
               <div class="alert alert-warning" role="alert" ng-if="$ctrl.cartData && !$ctrl.cartData.items.length">
                 <p translate>Your cart is empty</p>
               </div>

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -34,13 +34,18 @@ class Step2Controller{
     this.loadingPaymentMethods = false;
   }
 
-  onSubmit(success, data, error){
+  onSubmit(success, data, error, stayOnStep){
     this.submissionError.error = '';
+    this.submitSuccess = false;
 
     if(success && data){
       this.orderService.addPaymentMethod(data)
         .subscribe(() => {
+          if(stayOnStep){
+            this.submitSuccess = true;
+          }else{
             this.changeStep({newStep: 'review'});
+          }
           },
           (error) => {
             this.$log.error('Error saving payment method', error);

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -44,14 +44,22 @@ describe('checkout', () => {
     describe('onSubmit', () => {
       it('should save payment data when success is true and data is defined', () => {
         spyOn(self.controller, 'changeStep');
-        spyOn(self.controller.orderService, 'addPaymentMethod').and.callFake(() => Observable.of(''));
+        spyOn(self.controller.orderService, 'addPaymentMethod').and.returnValue(Observable.of(''));
         self.controller.onSubmit(true, {bankAccount: {}});
         expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'review' });
         expect(self.controller.orderService.addPaymentMethod).toHaveBeenCalledWith({bankAccount: {}});
       });
+      it('should save payment data and not change step when success is true, data is defined, and stayOnStep is true', () => {
+        spyOn(self.controller, 'changeStep');
+        spyOn(self.controller.orderService, 'addPaymentMethod').and.returnValue(Observable.of(''));
+        self.controller.onSubmit(true, {bankAccount: {}}, undefined, true);
+        expect(self.controller.changeStep).not.toHaveBeenCalled();
+        expect(self.controller.submitSuccess).toEqual(true);
+        expect(self.controller.orderService.addPaymentMethod).toHaveBeenCalledWith({bankAccount: {}});
+      });
       it('should handle an error saving payment data', () => {
         spyOn(self.controller, 'changeStep');
-        spyOn(self.controller.orderService, 'addPaymentMethod').and.callFake(() => Observable.throw({ data: 'some error' }));
+        spyOn(self.controller.orderService, 'addPaymentMethod').and.returnValue(Observable.throw({ data: 'some error' }));
         self.controller.onSubmit(true, {bankAccount: {}});
         expect(self.controller.orderService.addPaymentMethod).toHaveBeenCalledWith({bankAccount: {}});
         expect(self.controller.submitted).toEqual(false);

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -23,7 +23,7 @@
   </div>
 
   <div ng-if="$ctrl.existingPaymentMethods">
-    <checkout-existing-payment-methods submitted="$ctrl.submitted" submission-error="$ctrl.submissionError" on-submit="$ctrl.onSubmit(success, data, error)" on-load="$ctrl.handleExistingPaymentLoading(success, hasExistingPaymentMethods, error)"></checkout-existing-payment-methods>
+    <checkout-existing-payment-methods submitted="$ctrl.submitted" submission-error="$ctrl.submissionError" on-submit="$ctrl.onSubmit(success, data, error, stayOnStep)" submit-success="$ctrl.submitSuccess" on-load="$ctrl.handleExistingPaymentLoading(success, hasExistingPaymentMethods, error)"></checkout-existing-payment-methods>
   </div>
 </div>
 

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -16,7 +16,7 @@
     </div>
   </div>
 
-  <form novalidate ng-submit="$ctrl.submitDetails();" name="$ctrl.detailsForm">
+  <form novalidate ng-keyup="$event.key === 'Enter' && $ctrl.submitDetails()" name="$ctrl.detailsForm">
     <div class="mb">
       <h4 class="panel-title  border-bottom-small  visible" translate>Your Information</h4>
 

--- a/src/common/components/loading/loading.tpl.html
+++ b/src/common/components/loading/loading.tpl.html
@@ -1,4 +1,4 @@
-<div ng-class="{ 'loading-wrap' : !$ctrl.inline }">
+<div ng-class="{ 'loading-wrap' : !$ctrl.inline, 'text-center' : $ctrl.inline }">
   <span class="loading loading1"></span>
   <span class="loading loading2"></span>
   <span class="loading loading3"></span>

--- a/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
+++ b/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
@@ -1,4 +1,4 @@
-<form novalidate name="$ctrl.bankPaymentForm">
+<form novalidate name="$ctrl.bankPaymentForm" ng-keyup="$event.key === 'Enter' && $ctrl.savePayment()">
 
   <div class="mb_x">
 

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -1,4 +1,4 @@
-<form novalidate name="$ctrl.creditCardPaymentForm">
+<form novalidate name="$ctrl.creditCardPaymentForm" ng-keyup="$event.key === 'Enter' && $ctrl.savePayment()">
 
   <div class="mb">
 

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -134,7 +134,7 @@ class Order{
         }
       })
       .map((selector) => {
-        let paymentMethods = selector.choices;
+        let paymentMethods = selector.choices || [];
         if(selector.chosen) {
           selector.chosen.description.chosen = true;
           paymentMethods.unshift(selector.chosen);

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -288,82 +288,86 @@ describe('order service', () => {
   });
 
   describe('getExistingPaymentMethods', () => {
-    let expectedResponse = [{
-      "self": {
-        "type": "elasticpath.bankaccounts.bank-account",
-        "uri": "/paymentmethods/crugive/giydcmzyge=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydcmzyge="
-      },
-      "links": [{
-        "rel": "list",
-        "type": "elasticpath.collections.links",
-        "uri": "/paymentmethods/crugive",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+    let expectedResponse, clonedPaymentMethodSelectorResponse;
+    beforeEach(() => {
+      clonedPaymentMethodSelectorResponse = angular.copy(paymentMethodSelectorResponse);
+      expectedResponse = [{
+        "self": {
+          "type": "elasticpath.bankaccounts.bank-account",
+          "uri": "/paymentmethods/crugive/giydcmzyge=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydcmzyge="
+        },
+        "links": [{
+          "rel": "list",
+          "type": "elasticpath.collections.links",
+          "uri": "/paymentmethods/crugive",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+        }, {
+          "rel": "bankaccount",
+          "type": "elasticpath.bankaccounts.bank-account",
+          "uri": "/bankaccounts/paymentmethods/crugive/giydcmzyge=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcmzyge="
+        }],
+        "account-type": "Checking",
+        "bank-name": "First Bank",
+        "display-account-number": "6548",
+        "encrypted-account-number": "FAecKEPeUdW6KjbHo/na/hXlAS9OjZR51dlBgKKInf2mJh4bSP9WMvsKfAAL1rW7o6P9Rmx87dp0rDz0NArbWGIdsYeoFVOaIATzQqAe4ECuy0gfHcDva26HmgriGqRWkWPDeQvEdU9jENu0XKskxAjk2sBLJOHhoTCi8+LTLUrNwu40CSdT/PGNK8/lnO27wTZDPmc221xJ6hzB/F+0sRRvJhWky2oxA491MG+SRk7lWhccqSq5KtrijfA88Ebb/EivnsSJwqZgv/WNIP2u/V3dsMF1YRtyEsEAkmgxCCYBye2TT5ehIVOChQdlUbHxF+z/izrmn+0u2IYXvyX4dw==",
+        "routing-number": "121042882",
+        "chosen": true,
+        "selectAction": "/paymentmethods/crugive/giydcmzyge=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
       }, {
-        "rel": "bankaccount",
-        "type": "elasticpath.bankaccounts.bank-account",
-        "uri": "/bankaccounts/paymentmethods/crugive/giydcmzyge=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcmzyge="
-      }],
-      "account-type": "Checking",
-      "bank-name": "First Bank",
-      "display-account-number": "6548",
-      "encrypted-account-number": "FAecKEPeUdW6KjbHo/na/hXlAS9OjZR51dlBgKKInf2mJh4bSP9WMvsKfAAL1rW7o6P9Rmx87dp0rDz0NArbWGIdsYeoFVOaIATzQqAe4ECuy0gfHcDva26HmgriGqRWkWPDeQvEdU9jENu0XKskxAjk2sBLJOHhoTCi8+LTLUrNwu40CSdT/PGNK8/lnO27wTZDPmc221xJ6hzB/F+0sRRvJhWky2oxA491MG+SRk7lWhccqSq5KtrijfA88Ebb/EivnsSJwqZgv/WNIP2u/V3dsMF1YRtyEsEAkmgxCCYBye2TT5ehIVOChQdlUbHxF+z/izrmn+0u2IYXvyX4dw==",
-      "routing-number": "121042882",
-      "chosen": true,
-      "selectAction": "/paymentmethods/crugive/giydcmzyge=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
-    }, {
-      "self": {
-        "type": "elasticpath.bankaccounts.bank-account",
-        "uri": "/paymentmethods/crugive/giydcnzyga=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydcnzyga="
-      },
-      "links": [{
-        "rel": "list",
-        "type": "elasticpath.collections.links",
-        "uri": "/paymentmethods/crugive",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+        "self": {
+          "type": "elasticpath.bankaccounts.bank-account",
+          "uri": "/paymentmethods/crugive/giydcnzyga=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydcnzyga="
+        },
+        "links": [{
+          "rel": "list",
+          "type": "elasticpath.collections.links",
+          "uri": "/paymentmethods/crugive",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+        }, {
+          "rel": "bankaccount",
+          "type": "elasticpath.bankaccounts.bank-account",
+          "uri": "/bankaccounts/paymentmethods/crugive/giydcnzyga=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcnzyga="
+        }],
+        "account-type": "Savings",
+        "bank-name": "2nd Bank",
+        "display-account-number": "3456",
+        "encrypted-account-number": "",
+        "routing-number": "021000021",
+        "selectAction": "/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
       }, {
-        "rel": "bankaccount",
-        "type": "elasticpath.bankaccounts.bank-account",
-        "uri": "/bankaccounts/paymentmethods/crugive/giydcnzyga=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcnzyga="
-      }],
-      "account-type": "Savings",
-      "bank-name": "2nd Bank",
-      "display-account-number": "3456",
-      "encrypted-account-number": "",
-      "routing-number": "021000021",
-      "selectAction": "/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
-    }, {
-      "self": {
-        "type": "cru.creditcards.named-credit-card",
-        "uri": "/paymentmethods/crugive/giydembug4=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydembug4="
-      },
-      "links": [{
-        "rel": "list",
-        "type": "elasticpath.collections.links",
-        "uri": "/paymentmethods/crugive",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
-      }, {
-        "rel": "creditcard",
-        "type": "cru.creditcards.named-credit-card",
-        "uri": "/creditcards/paymentmethods/crugive/giydembug4=",
-        "href": "https://cortex-gateway-stage.cru.org/cortex/creditcards/paymentmethods/crugive/giydembug4="
-      }],
-      "card-number": "1111",
-      "card-type": "Visa",
-      "cardholder-name": "Test Card",
-      "expiry-month": "11",
-      "expiry-year": "2019",
-      "selectAction": "/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
-    }];
+        "self": {
+          "type": "cru.creditcards.named-credit-card",
+          "uri": "/paymentmethods/crugive/giydembug4=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive/giydembug4="
+        },
+        "links": [{
+          "rel": "list",
+          "type": "elasticpath.collections.links",
+          "uri": "/paymentmethods/crugive",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+        }, {
+          "rel": "creditcard",
+          "type": "cru.creditcards.named-credit-card",
+          "uri": "/creditcards/paymentmethods/crugive/giydembug4=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/creditcards/paymentmethods/crugive/giydembug4="
+        }],
+        "card-number": "1111",
+        "card-type": "Visa",
+        "cardholder-name": "Test Card",
+        "expiry-month": "11",
+        "expiry-year": "2019",
+        "selectAction": "/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq="
+      }];
+    });
 
     it('should load a user\'s existing payment methods', () => {
       self.$httpBackend.expectGET(
         'https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
-      ).respond(200, paymentMethodSelectorResponse);
+      ).respond(200, clonedPaymentMethodSelectorResponse);
 
       self.orderService.getExistingPaymentMethods()
         .subscribe((data) => {
@@ -374,15 +378,33 @@ describe('order service', () => {
     });
     it('should load a user\'s existing payment methods even if there is no chosen one', () => {
       // Move the payment method in chosen to be one of the choices for this test
-      paymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice.push(paymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0]);
-      delete paymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen;
+      clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice.push(clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0]);
+      delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen;
 
       self.$httpBackend.expectGET(
         'https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
-      ).respond(200, paymentMethodSelectorResponse);
+      ).respond(200, clonedPaymentMethodSelectorResponse);
 
       // Since there is no chosen element, this payment method should not be marked as chosen
       delete expectedResponse[0].chosen;
+
+      self.orderService.getExistingPaymentMethods()
+        .subscribe((data) => {
+          expect(data).toEqual(expectedResponse);
+        });
+
+      self.$httpBackend.flush();
+    });
+    it('should load a user\'s existing payment methods even if there is no choice element and only a chosen one', () => {
+      // Delete all the choices so there is only a chosen element for this test
+      delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice;
+
+      self.$httpBackend.expectGET(
+        'https://cortex-gateway-stage.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+      ).respond(200, clonedPaymentMethodSelectorResponse);
+
+      // Since there are no choices, there should only be one the one chosen paymentMethod
+      expectedResponse = [expectedResponse[0]];
 
       self.orderService.getExistingPaymentMethods()
         .subscribe((data) => {


### PR DESCRIPTION
… and show the new payment method in the list

- Use inline loading component for checkout loading cart and add description text
- Center inline loading component by default
- Always try to load payment methods as a guest user may have added one and come back to step 2 from review
- Make enter key work throughout checkout as most of the submit buttons are outside of the component containing the form
- In order service, make sure paymentMethods is always an array, even if there are no choices and only a chosen element

https://jira.cru.org/browse/EP-1306