### PR TITLE
Add generic error to sign-in

### DIFF
--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import 'angular-gettext';
 import includes from 'lodash/includes';
 
 import loadingOverlay from 'common/components/loadingOverlay/loadingOverlay.component';
@@ -11,8 +12,9 @@ let componentName = 'signInForm';
 class SignInFormController {
 
   /* @ngInject */
-  constructor( sessionService ) {
+  constructor( sessionService, gettext ) {
     this.sessionService = sessionService;
+    this.gettext = gettext;
   }
 
   $onInit() {
@@ -32,7 +34,9 @@ class SignInFormController {
         this.onSuccess();
       }, ( error ) => {
         this.isSigningIn = false;
-        this.errorMessage = error.data.error;
+        this.errorMessage = (angular.isUndefined( error.data ) || error.data === null) ?
+          this.gettext( 'An error has occurred signing in. Please try again.' ) :
+          error.data.error;
         this.onFailure();
       } );
   }
@@ -42,7 +46,8 @@ export default angular
   .module( componentName, [
     template.name,
     sessionService.name,
-    loadingOverlay.name
+    loadingOverlay.name,
+    'gettext'
   ] )
   .component( componentName, {
     controller:  SignInFormController,

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -79,5 +79,21 @@ describe( 'signInForm', function () {
       expect( $ctrl.errorMessage ).toEqual( 'Error Signing In' );
       expect( $ctrl.isSigningIn ).toEqual( false );
     } );
+
+    it( 'has unknown error signing in', () => {
+      deferred.reject( {} );
+      $rootScope.$digest();
+      expect( bindings.onFailure ).toHaveBeenCalled();
+      expect( $ctrl.errorMessage ).toEqual( 'An error has occurred signing in. Please try again.' );
+      expect( $ctrl.isSigningIn ).toEqual( false );
+    });
+
+    it( 'has missing error signing in', () => {
+      deferred.reject( {data: null} );
+      $rootScope.$digest();
+      expect( bindings.onFailure ).toHaveBeenCalled();
+      expect( $ctrl.errorMessage ).toEqual( 'An error has occurred signing in. Please try again.' );
+      expect( $ctrl.isSigningIn ).toEqual( false );
+    });
   } );
 } );


### PR DESCRIPTION
Scotty encountered sign-in requests that didn't have any data or error attached. This adds a generic error in that case.