### PR TITLE
Add Rollbar person tracking

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -5,6 +5,8 @@ import map from 'lodash/map';
 import defaults from 'lodash/defaults';
 import get from 'lodash/get';
 
+let Rollbar;
+
 /* @ngInject */
 function rollbarConfig(envServiceProvider, $provide) {
   let rollbarConfig = {
@@ -15,7 +17,7 @@ function rollbarConfig(envServiceProvider, $provide) {
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
     transform: transformRollbarPayload
   };
-  let Rollbar = rollbar.init(rollbarConfig);
+  Rollbar = rollbar.init(rollbarConfig);
 
   /* @ngInject */
   $provide.decorator('$log', ($delegate) => {
@@ -90,8 +92,26 @@ function transformRollbarPayload(payload){
   return payload;
 }
 
+function updateRollbarPerson(session){
+  let person = {};
+  if(session){
+    person = {
+      id: session.sub,
+      username: session.first_name + ' ' + session.last_name,
+      email: session.email
+    };
+  }
+
+  Rollbar.configure({
+    payload: {
+      person: person
+    }
+  });
+}
+
 export {
   rollbarConfig as default,
+  updateRollbarPerson,
   rollbar, // For mocking during testing
   stacktrace, // For mocking during testing,
   formatStacktraceForRollbar, // To test this function separately

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -23,7 +23,8 @@ describe('rollbarConfig', () => {
         debug: jasmine.createSpy('debug'),
         info: jasmine.createSpy('info'),
         warning: jasmine.createSpy('warning'),
-        error: jasmine.createSpy('error')
+        error: jasmine.createSpy('error'),
+        configure: jasmine.createSpy('configure')
       };
       module.rollbar.init = () => self.rollbarSpies;
 
@@ -119,6 +120,26 @@ describe('rollbarConfig', () => {
         done();
       });
     });
+
+    describe('updateRollbarPerson', () => {
+      it('should add person info to the rollbar configuration', () => {
+        module.updateRollbarPerson({
+          sub: 'cas|12345',
+          first_name: 'Fname',
+          last_name: 'Lname',
+          email: 'someone@email.com'
+        });
+        expect(self.rollbarSpies.configure).toHaveBeenCalledWith( {
+          payload: {
+            person: {
+              id: 'cas|12345',
+              username: 'Fname Lname',
+              email: 'someone@email.com'
+            }
+          }
+        } );
+      } );
+    } );
   });
 
   describe('formatStacktraceForRollbar', () => {

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -7,6 +7,8 @@ import {BehaviorSubject} from 'rxjs';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
 
+import { updateRollbarPerson } from 'common/rollbar.config.js';
+
 import appConfig from 'common/app.config';
 
 let serviceName = 'sessionService';
@@ -137,6 +139,8 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
 
     // Update sessionSubject with new value
     sessionSubject.next( session );
+
+    updateRollbarPerson( session );
   }
 
   function setSessionTimeout( timeout ) {


### PR DESCRIPTION
- Update rollbar person object when session changes

I figured this would be helpful for debugging errors and helping users. It'd be nice to figure out sourcemaps at some point so the rollbar stack traces are more useful. There's been a couple of cryptic ones recently.