### PR TITLE
Pre-populate family, given and email from Session.

### DIFF
--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-messages';
+import includes from 'lodash/includes';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
 
@@ -47,6 +48,18 @@ class Step1Controller{
         }
         this.donorDetails = data;
         this.nameFieldsDisabled = this.donorDetails['registration-state'] === 'COMPLETED';
+        if(!this.nameFieldsDisabled && includes([Roles.registered, Roles.identified], this.sessionService.getRole())) {
+          // Pre-populate first, last and email from session if missing from donorDetails
+          if(!this.donorDetails['name']['given-name'] && angular.isDefined(this.sessionService.session.first_name)) {
+            this.donorDetails['name']['given-name'] = this.sessionService.session.first_name;
+          }
+          if(!this.donorDetails['name']['family-name'] && angular.isDefined(this.sessionService.session.last_name)) {
+            this.donorDetails['name']['family-name'] = this.sessionService.session.last_name;
+          }
+          if(angular.isUndefined(this.donorDetails['email']) && angular.isDefined(this.sessionService.session.email)) {
+            this.donorDetails['email'] = this.sessionService.session.email;
+          }
+        }
       });
   }
 

--- a/src/common/components/contactInfo/contactInfo.component.spec.js
+++ b/src/common/components/contactInfo/contactInfo.component.spec.js
@@ -2,6 +2,8 @@ import angular from 'angular';
 import 'angular-mocks';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+import {Sessions} from 'common/services/session/session.service';
+import {cortexSession} from 'common/services/session/fixtures/cortex-session';
 
 import module from './contactInfo.component.js';
 
@@ -62,7 +64,7 @@ describe('contactInfo', function() {
     it('should disable name fields if the user\'s registration state is completed', () => {
       let donorDetails = {
         'donor-type': 'Organization',
-        name: {
+        'name': {
           'given-name': 'Joe',
           'family-name': 'Smith'
         },
@@ -70,6 +72,7 @@ describe('contactInfo', function() {
           'given-name': 'Julie',
           'family-name': 'Smith'
         },
+        'email': 'joe.smith@example.com',
         'registration-state': 'COMPLETED'
       };
       spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of(donorDetails));
@@ -83,6 +86,42 @@ describe('contactInfo', function() {
       self.controller.loadDonorDetails();
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
       expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Household' });
+    });
+
+    describe('pre-populate from session', () => {
+      let $cookies;
+      beforeEach(inject((_$cookies_, $rootScope) => {
+        $cookies = _$cookies_;
+        $cookies.put(Sessions.cortex, cortexSession.registered);
+        $rootScope.$digest();
+      }));
+
+      afterEach( () => {
+        $cookies.remove( Sessions.cortex );
+      } );
+
+      it('should set given, family and name to session values', () => {
+        spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({
+          'donor-type': 'Household',
+          'name': {
+            'given-name': '',
+            'family-name': ''
+          },
+          'email': undefined,
+          'registration-state': 'NEW'
+        }));
+        self.controller.loadDonorDetails();
+        expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
+        expect(self.controller.donorDetails).toEqual({
+          'donor-type': 'Household',
+          'name': {
+            'given-name': 'Charles',
+            'family-name': 'Xavier'
+          },
+          'email': 'professorx@xavier.edu',
+          'registration-state': 'NEW'
+        });
+      })
     });
   });
 

--- a/src/common/components/contactInfo/contactInfo.component.spec.js
+++ b/src/common/components/contactInfo/contactInfo.component.spec.js
@@ -121,7 +121,7 @@ describe('contactInfo', function() {
           'email': 'professorx@xavier.edu',
           'registration-state': 'NEW'
         });
-      })
+      });
     });
   });
 


### PR DESCRIPTION
This pre-populates the Contact Info component's family-name, given-name and email from the Session (key/relay values) if the session exists and the values are missing from donorDetails.