### PR TITLE
Disables modal resize (until better solution is found).

### DIFF
--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -99,11 +99,13 @@ class RegisterAccountModalController {
     this.setLoading( {loading: false} );
   }
 
+  // TODO: Fix this ($provide or css class manipulation) angular.element.scope() always returns undefined when debugInfo is disabled.
+  // eslint-disable-next-line no-unused-vars
   setModalSize( size ) {
     // Modal size is unchangeable after initialization. This allows us to fetch the dialogs scope and change it.
     // eslint-disable-next-line angular/document-service
-    let scope = angular.element( document.getElementsByClassName( 'modal-dialog' ) ).scope();
-    scope.size = size;
+    // let scope = angular.element( document.getElementsByClassName( 'modal-dialog' ) ).scope();
+    // scope.size = size;
   }
 }
 

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -174,7 +174,8 @@ describe( 'registerAccountModal', function () {
     } );
   } );
 
-  describe( 'setModalSize( size )', () => {
+  // eslint-disable-next-line jasmine/no-disabled-tests
+  xdescribe( 'setModalSize( size )', () => {
     let scope = {size: 'lg'};
     beforeEach( () => {
       spyOn( angular, 'element' ).and.callFake( () => {


### PR DESCRIPTION
This is broken in production where $compileProvider.enableDebugInfo(false) is set. Disabling will allow register-account modal to start working again. This has the side effect of 'contact-info' modal not resizing to the correct size during the registerAccount workflow.