### PR TITLE
Move getNextDrawDate to new common api service

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -8,7 +8,7 @@ import giftUpdate from 'common/components/giftViews/giftUpdate/giftUpdate.compon
 import loading from 'common/components/loading/loading.component';
 
 import donationsService from 'common/services/api/donations.service';
-import giftDatesService from 'common/services/giftHelpers/giftDates.service';
+import commonService from 'common/services/api/common.service';
 
 import template from './editRecurringGifts.tpl';
 
@@ -17,10 +17,10 @@ let componentName = 'step1EditRecurringGifts';
 class EditRecurringGiftsController {
 
   /* @ngInject */
-  constructor($log, donationsService, giftDatesService) {
+  constructor($log, donationsService, commonService) {
     this.$log = $log;
     this.donationsService = donationsService;
-    this.giftDatesService = giftDatesService;
+    this.commonService = commonService;
   }
 
   $onInit(){
@@ -30,7 +30,7 @@ class EditRecurringGiftsController {
   loadGifts(){
     this.loading = true;
     this.loadingError = false;
-    Observable.forkJoin(this.donationsService.getRecurringGifts(), this.giftDatesService.getNextDrawDate())
+    Observable.forkJoin(this.donationsService.getRecurringGifts(), this.commonService.getNextDrawDate())
       .subscribe(([gifts, nextDrawDate]) => {
           this.recurringGifts = gifts;
           this.nextDrawDate = nextDrawDate;
@@ -63,7 +63,7 @@ export default angular
     giftUpdate.name,
     loading.name,
     donationsService.name,
-    giftDatesService.name
+    commonService.name
   ])
   .component(componentName, {
     controller: EditRecurringGiftsController,

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
@@ -29,7 +29,7 @@ describe('editRecurringGiftsModal', () => {
     describe('loadGifts', () => {
       it('should load gifts', () => {
         spyOn(self.controller.donationsService, 'getRecurringGifts').and.returnValue(Observable.of('gifts response'));
-        spyOn(self.controller.giftDatesService, 'getNextDrawDate').and.returnValue(Observable.of('nextDrawDate response'));
+        spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('nextDrawDate response'));
         self.controller.loadGifts();
         expect(self.controller.loading).toEqual(false);
         expect(self.controller.loadingError).toEqual(false);
@@ -38,7 +38,7 @@ describe('editRecurringGiftsModal', () => {
       });
       it('should handle an error loading gifts', () => {
         spyOn(self.controller.donationsService, 'getRecurringGifts').and.returnValue(Observable.throw('gifts error'));
-        spyOn(self.controller.giftDatesService, 'getNextDrawDate').and.returnValue(Observable.throw('nextDrawDate error'));
+        spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.throw('nextDrawDate error'));
         self.controller.loadGifts();
         expect(self.controller.loading).toEqual(false);
         expect(self.controller.loadingError).toEqual(true);

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -5,6 +5,7 @@ import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/operator/map';
 
 import cortexApiService from '../cortexApi.service';
+import commonService from './common.service';
 import giftDatesService from '../giftHelpers/giftDates.service';
 
 let serviceName = 'cartService';
@@ -12,8 +13,9 @@ let serviceName = 'cartService';
 class Cart {
 
   /*@ngInject*/
-  constructor(cortexApiService, giftDatesService){
+  constructor(cortexApiService, commonService, giftDatesService){
     this.cortexApiService = cortexApiService;
+    this.commonService = commonService;
     this.giftDatesService = giftDatesService;
   }
 
@@ -23,7 +25,7 @@ class Cart {
         params: {
           zoom: 'lineitems:element:availability,lineitems:element:item:code,lineitems:element:item:definition,lineitems:element:rate,lineitems:element:total,ratetotals:element,total,lineitems:element:itemfields'
         }
-      }), this.giftDatesService.getNextDrawDate())
+      }), this.commonService.getNextDrawDate())
       .map(([cartResponse, nextDrawDate]) => {
         if (!cartResponse || !cartResponse._lineitems) {
           return {};
@@ -134,6 +136,7 @@ class Cart {
 export default angular
   .module(serviceName, [
     cortexApiService.name,
+    commonService.name,
     giftDatesService.name
   ])
   .service(serviceName, Cart);

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -29,12 +29,12 @@ describe('cart service', () => {
           'lineitems:element:rate,lineitems:element:total,ratetotals:element,total,lineitems:element:itemfields')
         .respond(200, cartResponse);
 
-      spyOn(self.cartService.giftDatesService, 'getNextDrawDate').and.returnValue(Observable.of('2016-10-01'));
+      spyOn(self.cartService.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2016-10-01'));
 
       self.cartService.get()
         .subscribe((data) => {
           //verify response
-          expect(self.cartService.giftDatesService.getNextDrawDate).toHaveBeenCalled();
+          expect(self.cartService.commonService.getNextDrawDate).toHaveBeenCalled();
           expect(data.items.length).toEqual(3);
           expect(data.items[0].designationNumber).toEqual('0358433');
           expect(data.items[1].giftStartDate.toString()).toEqual(moment('2016-10-09').toString());

--- a/src/common/services/api/common.service.js
+++ b/src/common/services/api/common.service.js
@@ -1,0 +1,28 @@
+import angular from 'angular';
+import 'rxjs/add/operator/pluck';
+
+import cortexApiService from '../cortexApi.service';
+
+let serviceName = 'commonService';
+
+class Common {
+
+  /*@ngInject*/
+  constructor(cortexApiService){
+    this.cortexApiService = cortexApiService;
+  }
+
+  getNextDrawDate(){
+    return this.cortexApiService.get({
+        path: ['nextdrawdate'],
+        cache: true
+      })
+      .pluck('next-draw-date');
+  }
+}
+
+export default angular
+  .module(serviceName, [
+    cortexApiService.name
+  ])
+  .service(serviceName, Common);

--- a/src/common/services/api/common.service.spec.js
+++ b/src/common/services/api/common.service.spec.js
@@ -1,0 +1,31 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+import module from './common.service';
+
+describe('common service', () => {
+  beforeEach(angular.mock.module(module.name));
+  var self = {};
+
+  beforeEach(inject((commonService, $httpBackend) => {
+    self.commonService = commonService;
+    self.$httpBackend = $httpBackend;
+  }));
+
+  afterEach(() => {
+    self.$httpBackend.verifyNoOutstandingExpectation();
+    self.$httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('getNextDrawDate', () => {
+    it('should get next draw date', () => {
+      self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/nextdrawdate')
+        .respond(200, {"next-draw-date": "2016-10-01"});
+      self.commonService.getNextDrawDate().subscribe(date => {
+        expect(date).toEqual('2016-10-01');
+      });
+
+      self.$httpBackend.flush();
+    });
+  });
+});

--- a/src/common/services/giftHelpers/giftDates.service.js
+++ b/src/common/services/giftHelpers/giftDates.service.js
@@ -3,17 +3,14 @@ import moment from 'moment';
 import range from 'lodash/range';
 import map from 'lodash/map';
 import toString from 'lodash/toString';
-import 'rxjs/add/operator/pluck';
-
-import cortexApiService from '../cortexApi.service';
 
 let serviceName = 'giftDatesService';
 
 class Profile {
 
   /*@ngInject*/
-  constructor(cortexApiService){
-    this.cortexApiService = cortexApiService;
+  constructor(){
+
   }
 
   possibleTransactionDays() {
@@ -29,14 +26,6 @@ class Profile {
     });
     months.push('and ' + months.pop());
     return months.join(', ');
-  }
-
-  getNextDrawDate(){
-    return this.cortexApiService.get({
-        path: ['nextdrawdate'],
-        cache: true
-      })
-      .pluck('next-draw-date');
   }
 
   // Given a transactionDay, find the next occurrence of that day on or after nextDrawDate
@@ -65,6 +54,6 @@ class Profile {
 
 export default angular
   .module(serviceName, [
-    cortexApiService.name
+
   ])
   .service(serviceName, Profile);

--- a/src/common/services/giftHelpers/giftDates.service.spec.js
+++ b/src/common/services/giftHelpers/giftDates.service.spec.js
@@ -47,18 +47,6 @@ describe('giftDates service', () => {
     });
   });
 
-  describe('getNextDrawDate', () => {
-    it('should get next draw date', () => {
-      self.$httpBackend.expectGET('https://cortex-gateway-stage.cru.org/cortex/nextdrawdate')
-        .respond(200, {"next-draw-date": "2016-10-01"});
-      self.giftDatesService.getNextDrawDate().subscribe(date => {
-        expect(date).toEqual('2016-10-01');
-      });
-
-      self.$httpBackend.flush();
-    });
-  });
-
   describe('startDate', () => {
     it('should calculate gift start date', () => {
       expect(self.giftDatesService.startDate('10', '2017-01-02').toString()).toEqual(moment('2017-01-10').toString());

--- a/src/common/services/productModal.service.js
+++ b/src/common/services/productModal.service.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 import 'angular-ui-bootstrap';
 import designationsService from 'common/services/api/designations.service';
-import giftDatesService from 'common/services/giftHelpers/giftDates.service';
+import commonService from 'common/services/api/common.service';
 import templateModal from 'app/productConfig/productConfigModal.tpl';
 import modalController from 'app/productConfig/productConfig.modal';
 import modalStateService from 'common/services/modalState.service';
@@ -10,7 +10,7 @@ import {giveGiftParams} from 'app/productConfig/productConfig.modal';
 let serviceName = 'productModalService';
 
 /*@ngInject*/
-function ProductModalService( $uibModal, $location, designationsService, giftDatesService, modalStateService ) {
+function ProductModalService( $uibModal, $location, designationsService, commonService, modalStateService ) {
   let modalOpen = false;
 
   function configureProduct( code, config, isEdit ) {
@@ -30,7 +30,7 @@ function ProductModalService( $uibModal, $location, designationsService, giftDat
             return designationsService.productLookup( code ).toPromise();
           },
           nextDrawDate: function(){
-            return giftDatesService.getNextDrawDate().toPromise();
+            return commonService.getNextDrawDate().toPromise();
           },
           itemConfig:  () => config,
           isEdit:      () => isEdit
@@ -57,7 +57,7 @@ export default angular
   .module( serviceName, [
     'ui.bootstrap',
     designationsService.name,
-    giftDatesService.name,
+    commonService.name,
     modalController.name,
     modalStateService.name,
     templateModal.name

--- a/src/common/services/productModal.spec.js
+++ b/src/common/services/productModal.spec.js
@@ -4,21 +4,21 @@ import module from './productModal.service';
 
 describe( 'productModalService', function () {
   beforeEach( angular.mock.module( module.name ) );
-  let productModalService, designationsService, giftDatesService, $uibModal, $rootScope;
+  let productModalService, designationsService, commonService, $uibModal, $rootScope;
 
   // eslint-disable-next-line no-undef
   installPromiseMatchers();
 
-  beforeEach( inject( function ( _productModalService_, _designationsService_, _giftDatesService_, _$uibModal_, _$rootScope_, _$q_ ) {
+  beforeEach( inject( function ( _productModalService_, _designationsService_, _commonService_, _$uibModal_, _$rootScope_, _$q_ ) {
     productModalService = _productModalService_;
     designationsService = _designationsService_;
-    giftDatesService = _giftDatesService_;
+    commonService = _commonService_;
     $uibModal = _$uibModal_;
     $rootScope = _$rootScope_;
     // Spy On $uibModal.open and return mock object
     spyOn( $uibModal, 'open' ).and.returnValue( {result: {finally: angular.noop}} );
     spyOn( designationsService, 'productLookup' ).and.returnValue( {toPromise: () => _$q_.defer().promise} );
-    spyOn( giftDatesService, 'getNextDrawDate' ).and.returnValue( {toPromise: () => _$q_.defer().promise} );
+    spyOn( commonService, 'getNextDrawDate' ).and.returnValue( {toPromise: () => _$q_.defer().promise} );
   } ) );
 
   it( 'should be defined', () => {


### PR DESCRIPTION
@Omicron7 I think I need to make giftDates service purely functional and just export the class instead of using an angular service so the new recurringGiftModel can access these functions. This is just a first step.

I hadn't found a good place for getNextDrawDate. Now it has its own home. Feel free to suggest different naming. It didn't really belong with any of the other api services.