### PR TITLE
On saving recurring gifts, group donation lines back into donation groups

### DIFF
--- a/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
+++ b/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
@@ -29,7 +29,7 @@
                 ng-model="$ctrl.gift.frequency">
           <option value="Monthly" translate>Monthly</option>
           <option value="Quarterly" translate>Quarterly</option>
-          <option value="Annually" translate>Annually</option>
+          <option value="Annual" translate>Annually</option>
         </select>
       </div>
     </div>
@@ -65,7 +65,7 @@
     </div>
   </div>
 
-  <div ng-if="$ctrl.gift.frequency === 'Annually'">
+  <div ng-if="$ctrl.gift.frequency === 'Annual'">
     <p>You have selected <strong>annually</strong> as a frequency.
       Please tell us in which months you would like your annual gifts to be made
     </p>

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -5,8 +5,9 @@ import {startMonth, startDate} from 'common/services/giftHelpers/giftDates.servi
 
 export default class RecurringGiftModel {
 
-  constructor(gift, nextDrawDate, paymentMethods) {
+  constructor(gift, parentDonation, nextDrawDate, paymentMethods) {
     this.gift = gift;
+    this.parentDonation = parentDonation;
     this.nextDrawDate = nextDrawDate;
     this.paymentMethods = paymentMethods;
   }
@@ -43,11 +44,11 @@ export default class RecurringGiftModel {
   }
 
   get frequency() {
-    return this.gift['updated-rate']['recurrence']['interval'] || this.gift['rate']['recurrence']['interval'];
+    return this.gift['updated-rate']['recurrence']['interval'] || this.parentDonation['rate']['recurrence']['interval'];
   }
 
   set frequency(value) {
-    this.gift['updated-rate']['recurrence']['interval'] = value !== this.gift['rate']['recurrence']['interval'] ? value : '';
+    this.gift['updated-rate']['recurrence']['interval'] = value !== this.parentDonation['rate']['recurrence']['interval'] ? value : '';
     if(value === 'Monthly' || this.gift['updated-rate']['recurrence']['interval'] === '' && this.gift['updated-recurring-day-of-month'] === ''){
       this.clearStartDate(); // Don't need to update start date if gift if Monthly or if frequency and transaction day are unchanged
     }else{
@@ -56,11 +57,11 @@ export default class RecurringGiftModel {
   }
 
   get transactionDay(){
-    return this.gift['updated-recurring-day-of-month'] || this.gift['recurring-day-of-month'];
+    return this.gift['updated-recurring-day-of-month'] || this.parentDonation['recurring-day-of-month'];
   }
 
   set transactionDay(value){
-    this.gift['updated-recurring-day-of-month'] = value !== this.gift['recurring-day-of-month'] ? value : '';
+    this.gift['updated-recurring-day-of-month'] = value !== this.parentDonation['recurring-day-of-month'] ? value : '';
     if(this.frequency === 'Monthly' || this.gift['updated-rate']['recurrence']['interval'] === '' && this.gift['updated-recurring-day-of-month'] === ''){
       this.clearStartDate(); // Don't need to update start date if gift is Monthly or if the frequency is unchanged and the transaction day is unchanged
     }else{
@@ -74,7 +75,7 @@ export default class RecurringGiftModel {
 
   set startMonth(value){
     let updatedStartDate = moment(startMonth(this.transactionDay, value, this.nextDrawDate));
-    if(updatedStartDate.isSame(this.gift['next-draw-date']['display-value'], 'month') || this.gift['updated-rate']['recurrence']['interval'] === '' && this.gift['updated-recurring-day-of-month'] === '' && moment(this.gift['next-draw-date']['display-value']).format('M') === updatedStartDate.format('M')){
+    if(updatedStartDate.isSame(this.parentDonation['next-draw-date']['display-value'], 'month') || this.gift['updated-rate']['recurrence']['interval'] === '' && this.gift['updated-recurring-day-of-month'] === '' && moment(this.parentDonation['next-draw-date']['display-value']).format('M') === updatedStartDate.format('M')){
       this.clearStartDate(); // Don't need to update start date if draw date year and month are still correct, or if frequency, transaction day, and start month are unchanged
     }else {
       this.gift['updated-start-month'] = updatedStartDate.format('MM');
@@ -90,7 +91,7 @@ export default class RecurringGiftModel {
       // We have to take transactionDay into account here when it is modified for monthly gifts since they don't set the updated-start-month/year fields
       giftDate = startDate(this.transactionDay, this.nextDrawDate);
     }else{
-      giftDate = moment(this.gift['next-draw-date']['display-value']);
+      giftDate = moment(this.parentDonation['next-draw-date']['display-value']);
     }
     return giftDate;
   }

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -20,7 +20,12 @@ describe('recurringGift model', () => {
         'updated-rate': {recurrence: {interval: ''}},
         'updated-recurring-day-of-month': '',
         'updated-start-month': '',
-        'updated-start-year': '',
+        'updated-start-year': ''
+      },
+      {
+        'donation-row-id': '1-K0LPOL',
+        'donation-status': 'Active',
+        'effective-status': "Active",
         rate: {recurrence: {interval: 'Monthly'}},
         'recurring-day-of-month': '15',
         'next-draw-date': {'display-value': '2015-05-06', value: 1430895600}
@@ -130,12 +135,10 @@ describe('recurringGift model', () => {
 
     it('should update frequency', () => {
       giftModel.frequency = 'Quarterly';
-      expect(giftModel.gift['rate']['recurrence']['interval']).toEqual('Monthly');
       expect(giftModel.gift['updated-rate']['recurrence']['interval']).toEqual('Quarterly');
     });
     it('should clear updated frequency if it is the same as the original', () => {
       giftModel.frequency = 'Monthly';
-      expect(giftModel.gift['rate']['recurrence']['interval']).toEqual('Monthly');
       expect(giftModel.gift['updated-rate']['recurrence']['interval']).toEqual('');
     });
     it('should init start date when updated to a non monthly value', () => {
@@ -151,14 +154,14 @@ describe('recurringGift model', () => {
       expect(giftModel.initStartMonth).not.toHaveBeenCalled();
     });
     it('should clear start date when changed back to the original value and transaction day is unchanged', () => {
-      giftModel.gift['rate']['recurrence']['interval'] = 'Quarterly';
+      giftModel.parentDonation['rate']['recurrence']['interval'] = 'Quarterly';
       giftModel.gift['updated-recurring-day-of-month'] = '';
       giftModel.frequency = 'Quarterly';
       expect(giftModel.clearStartDate).toHaveBeenCalled();
       expect(giftModel.initStartMonth).not.toHaveBeenCalled();
     });
     it('should init start date when changed back to the original value and but transaction day is changed', () => {
-      giftModel.gift['rate']['recurrence']['interval'] = 'Quarterly';
+      giftModel.parentDonation['rate']['recurrence']['interval'] = 'Quarterly';
       giftModel.gift['updated-recurring-day-of-month'] = '10';
       giftModel.frequency = 'Quarterly';
       expect(giftModel.clearStartDate).not.toHaveBeenCalled();
@@ -184,12 +187,10 @@ describe('recurringGift model', () => {
 
     it('should update transaction day', () => {
       giftModel.transactionDay = '11';
-      expect(giftModel.gift['recurring-day-of-month']).toEqual('15');
       expect(giftModel.gift['updated-recurring-day-of-month']).toEqual('11');
     });
     it('should clear updated transaction day if it is the same as the original', () => {
       giftModel.transactionDay = '15';
-      expect(giftModel.gift['recurring-day-of-month']).toEqual('15');
       expect(giftModel.gift['updated-recurring-day-of-month']).toEqual('');
     });
     it('should clear start date when frequency is Monthly', () => {
@@ -199,14 +200,14 @@ describe('recurringGift model', () => {
       expect(giftModel.initStartMonth).not.toHaveBeenCalled();
     });
     it('should clear start date when frequency was Monthly and the frequency is unchanged', () => {
-      giftModel.gift['rate']['recurrence']['interval'] = 'Monthly';
+      giftModel.parentDonation['rate']['recurrence']['interval'] = 'Monthly';
       giftModel.gift['updated-rate']['recurrence']['interval'] = '';
       giftModel.transactionDay = '15';
       expect(giftModel.clearStartDate).toHaveBeenCalled();
       expect(giftModel.initStartMonth).not.toHaveBeenCalled();
     });
     it('should clear start date when the frequency is unchanged and transaction day is unchanged', () => {
-      giftModel.gift['rate']['recurrence']['interval'] = 'Quarterly';
+      giftModel.parentDonation['rate']['recurrence']['interval'] = 'Quarterly';
       giftModel.gift['updated-rate']['recurrence']['interval'] = '';
       giftModel.transactionDay = '15';
       expect(giftModel.clearStartDate).toHaveBeenCalled();
@@ -219,7 +220,7 @@ describe('recurringGift model', () => {
       expect(giftModel.clearStartDate).not.toHaveBeenCalled();
     });
     it('should init start date when transaction day is changed', () => {
-      giftModel.gift['rate']['recurrence']['interval'] = 'Quarterly';
+      giftModel.parentDonation['rate']['recurrence']['interval'] = 'Quarterly';
       giftModel.gift['updated-rate']['recurrence']['interval'] = '';
       giftModel.transactionDay = 11;
       expect(giftModel.clearStartDate).not.toHaveBeenCalled();

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -122,10 +122,17 @@ describe( 'donations service', () => {
           'updated-rate': {recurrence: {interval: ''}},
           'updated-recurring-day-of-month': '',
           'updated-start-month': '',
-          'updated-start-year': '',
+          'updated-start-year': ''
+        } );
+        expect( gifts[0].parentDonation ).toEqual( {
+          'donation-lines': jasmine.any(Array),
+          'donation-row-id': '1-GVVEB4',
+          'donation-status': 'Active',
+          'effective-status': 'Active',
+          'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000},
           rate: {recurrence: {interval: 'Monthly'}},
           'recurring-day-of-month': '15',
-          'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000}
+          'start-date': { 'display-value': '2015-09-29', value: 1443484800000 }
         } );
         expect( gifts[0].paymentMethods ).toEqual( [ paymentMethod ] );
         expect( gifts[0].nextDrawDate ).toEqual( '2015-06-09' );
@@ -137,28 +144,8 @@ describe( 'donations service', () => {
   describe( 'updateRecurringGifts' , () => {
     let gift;
     beforeEach(() => {
-      gift = new RecurringGiftModel({
-        amount: 25,
-        'designation-name': 'David and Margo Neibling (0105987)',
-        'designation-number': '0105987',
-        'donation-line-row-id': '1-GVVEB6',
-        'donation-line-status': 'Standard',
-        'payment-method-id': 'giydcnzyga=',
-        'updated-donation-line-status': '',
-        'updated-payment-method-id': '',
-        'updated-rate': {recurrence: {interval: ''}},
-        'updated-recurring-day-of-month': '',
-        'updated-start-month': '',
-        'updated-start-year': '',
-        rate: {recurrence: {interval: 'Monthly'}},
-        'recurring-day-of-month': '15',
-        'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000}
-      });
-    });
-
-    it('should update a recurring gift', () => {
-      $httpBackend
-        .expectPUT( 'https://cortex-gateway-stage.cru.org/cortex/donations/recurring/crugive/active', {donations: { 'donation-lines': [{
+      gift = new RecurringGiftModel(
+        {
           amount: 25,
           'designation-name': 'David and Margo Neibling (0105987)',
           'designation-number': '0105987',
@@ -170,11 +157,45 @@ describe( 'donations service', () => {
           'updated-rate': {recurrence: {interval: ''}},
           'updated-recurring-day-of-month': '',
           'updated-start-month': '',
-          'updated-start-year': '',
+          'updated-start-year': ''
+        },
+        {
           rate: {recurrence: {interval: 'Monthly'}},
-          'recurring-day-of-month': '15',
-          'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000}
-        }]} } )
+          'donation-status': 'Active',
+          'effective-status':  'Active',
+          'donation-row-id': '1-GVVEB5'
+        }
+      );
+    });
+
+    it('should update a recurring gift', () => {
+      $httpBackend
+        .expectPUT( 'https://cortex-gateway-stage.cru.org/cortex/donations/recurring/crugive/active', {
+          donations: [
+            {
+              'donation-lines': [
+                {
+                  amount: 25,
+                  'designation-name': 'David and Margo Neibling (0105987)',
+                  'designation-number': '0105987',
+                  'donation-line-row-id': '1-GVVEB6',
+                  'donation-line-status': 'Standard',
+                  'payment-method-id': 'giydcnzyga=',
+                  'updated-donation-line-status': '',
+                  'updated-payment-method-id': '',
+                  'updated-rate': {recurrence: {interval: ''}},
+                  'updated-recurring-day-of-month': '',
+                  'updated-start-month': '',
+                  'updated-start-year': ''
+                }
+              ],
+              rate: {recurrence: {interval: 'Monthly'}},
+              'donation-status': 'Active',
+              'effective-status':  'Active',
+              'donation-row-id': '1-GVVEB5'
+            }
+          ]
+        } )
         .respond( 204, {} );
 
       donationsService.updateRecurringGifts(gift).subscribe(() => {});
@@ -183,39 +204,45 @@ describe( 'donations service', () => {
 
     it('should update recurring gifts', () => {
       $httpBackend
-        .expectPUT( 'https://cortex-gateway-stage.cru.org/cortex/donations/recurring/crugive/active', {donations: { 'donation-lines': [{
-          amount: 25,
-          'designation-name': 'David and Margo Neibling (0105987)',
-          'designation-number': '0105987',
-          'donation-line-row-id': '1-GVVEB6',
-          'donation-line-status': 'Standard',
-          'payment-method-id': 'giydcnzyga=',
-          'updated-donation-line-status': '',
-          'updated-payment-method-id': '',
-          'updated-rate': {recurrence: {interval: ''}},
-          'updated-recurring-day-of-month': '',
-          'updated-start-month': '',
-          'updated-start-year': '',
-          rate: {recurrence: {interval: 'Monthly'}},
-          'recurring-day-of-month': '15',
-          'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000}
-        }, {
-          amount: 25,
-          'designation-name': 'David and Margo Neibling (0105987)',
-          'designation-number': '0105987',
-          'donation-line-row-id': '1-GVVEB6',
-          'donation-line-status': 'Standard',
-          'payment-method-id': 'giydcnzyga=',
-          'updated-donation-line-status': '',
-          'updated-payment-method-id': '',
-          'updated-rate': {recurrence: {interval: ''}},
-          'updated-recurring-day-of-month': '',
-          'updated-start-month': '',
-          'updated-start-year': '',
-          rate: {recurrence: {interval: 'Monthly'}},
-          'recurring-day-of-month': '15',
-          'next-draw-date': {'display-value': '2016-01-15', value: 1452816000000}
-        } ]} } )
+        .expectPUT( 'https://cortex-gateway-stage.cru.org/cortex/donations/recurring/crugive/active', {
+          donations: [
+            {
+              'donation-lines': [
+                {
+                  amount: 25,
+                  'designation-name': 'David and Margo Neibling (0105987)',
+                  'designation-number': '0105987',
+                  'donation-line-row-id': '1-GVVEB6',
+                  'donation-line-status': 'Standard',
+                  'payment-method-id': 'giydcnzyga=',
+                  'updated-donation-line-status': '',
+                  'updated-payment-method-id': '',
+                  'updated-rate': {recurrence: {interval: ''}},
+                  'updated-recurring-day-of-month': '',
+                  'updated-start-month': '',
+                  'updated-start-year': ''
+                }, {
+                  amount: 25,
+                  'designation-name': 'David and Margo Neibling (0105987)',
+                  'designation-number': '0105987',
+                  'donation-line-row-id': '1-GVVEB6',
+                  'donation-line-status': 'Standard',
+                  'payment-method-id': 'giydcnzyga=',
+                  'updated-donation-line-status': '',
+                  'updated-payment-method-id': '',
+                  'updated-rate': {recurrence: {interval: ''}},
+                  'updated-recurring-day-of-month': '',
+                  'updated-start-month': '',
+                  'updated-start-year': ''
+                }
+              ],
+              rate: {recurrence: {interval: 'Monthly'}},
+              'donation-status': 'Active',
+              'effective-status':  'Active',
+              'donation-row-id': '1-GVVEB5'
+            }
+          ]
+        } )
         .respond( 204, {} );
 
       donationsService.updateRecurringGifts([gift, gift]).subscribe(() => {});


### PR DESCRIPTION
- Send donation status, effective status, rate, and donation row id to server for its validation and lookup of the donation
- In recurringGiftModel, lookup next-draw-date, recurring-day-of-month, and rate on parentDonation instead of copying them into the gift object
- Change Annually to Annual to match api