### PR TITLE
Implement edit recurring gifts modal steps 2 and 3…

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
@@ -1,13 +1,24 @@
 import angular from 'angular';
+import moment from 'moment';
 import filter from 'lodash/filter';
+import map from 'lodash/map';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/operator/map';
 
 import loadingComponent from 'common/components/loading/loading.component';
 import step0AddUpdatePaymentMethod from './step0/addUpdatePaymentMethod.component';
 import step0paymentMethodList from './step0/paymentMethodList.component';
 import step1EditRecurringGifts from './step1/editRecurringGifts.component';
+import step2AddRecentRecipients from './step2/addRecentRecipients.component';
+import step3ConfigureRecentRecipients from './step3/configureRecentRecipients.component';
 import step4ConfirmRecurringGifts from './step4/confirmRecurringGifts.component';
 
+import RecurringGiftModel from 'common/models/recurringGift.model';
+
 import profileService from 'common/services/api/profile.service';
+import donationsService from 'common/services/api/donations.service';
+import commonService from 'common/services/api/common.service';
 
 import template from './editRecurringGifts.modal.tpl';
 
@@ -16,30 +27,64 @@ let componentName = 'editRecurringGiftsModal';
 class EditRecurringGiftsModalController {
 
   /* @ngInject */
-  constructor($log, profileService) {
+  constructor($log, profileService, donationsService, commonService) {
     this.$log = $log;
     this.profileService = profileService;
+    this.donationsService = donationsService;
+    this.commonService = commonService;
   }
 
   $onInit(){
+    this.loadData();
+  }
+
+  loadData(){
     this.loadPaymentMethods();
+    this.loadRecentRecipients();
   }
 
   loadPaymentMethods(){
     this.state = 'loading';
-    this.profileService.getPaymentMethods()
-      .subscribe((data) => {
-        this.paymentMethods = data;
-        this.hasPaymentMethods = this.paymentMethods && this.paymentMethods.length > 0;
-        this.validPaymentMethods = filter(this.paymentMethods, (paymentMethod) => {
-          return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || ( parseInt(paymentMethod['expiry-month']) > (new Date()).getMonth() && parseInt(paymentMethod['expiry-year']) >= (new Date()).getFullYear() );
+    this.paymentMethodsObservable = Observable.forkJoin([
+        this.profileService.getPaymentMethods(),
+        this.commonService.getNextDrawDate()
+      ])
+      .map(([paymentMethods, nextDrawDate]) => {
+        let validPaymentMethods = filter(paymentMethods, (paymentMethod) => {
+          return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1}).isSameOrAfter(moment(), 'month');
         });
-        this.hasValidPaymentMethods = this.validPaymentMethods && this.validPaymentMethods.length > 0;
-        this.next();
-      }, (error) => {
-        this.state = 'error';
-        this.$log.error('Error loading payment methods', error);
+        return {
+          paymentMethods: paymentMethods,
+          nextDrawDate: nextDrawDate,
+          hasPaymentMethods: paymentMethods && paymentMethods.length > 0,
+          validPaymentMethods: validPaymentMethods,
+          hasValidPaymentMethods: validPaymentMethods && validPaymentMethods.length > 0
+        };
       });
+    this.paymentMethodsObservable.subscribe(data => {
+      this.paymentMethods = data.paymentMethods;
+      this.nextDrawDate = data.nextDrawDate;
+      this.hasPaymentMethods = data.hasPaymentMethods;
+      this.validPaymentMethods = data.validPaymentMethods;
+      this.hasValidPaymentMethods = data.hasValidPaymentMethods;
+      this.next();
+    }, (error) => {
+      this.state = 'error';
+      this.$log.error('Error loading payment methods', error);
+    });
+  }
+
+  loadRecentRecipients(){
+    this.recentRecipientsObservable = this.recentRecipientsObservable || this.donationsService.getRecentRecipients();
+    Observable.forkJoin(
+      this.recentRecipientsObservable,
+      this.paymentMethodsObservable
+    ).subscribe(([recentRecipients, paymentRequestObj]) => {
+      this.recentRecipients = map(recentRecipients, gift => (new RecurringGiftModel(gift, null, paymentRequestObj.nextDrawDate, paymentRequestObj.paymentMethods)).setDefaults());
+      this.hasRecentRecipients = this.recentRecipients && this.recentRecipients.length > 0;
+    }, (error) => {
+      this.$log.error('Error loading recent recipients', error);
+    });
   }
 
   next(paymentMethod, recurringGifts, additions){
@@ -61,7 +106,7 @@ class EditRecurringGiftsModalController {
         this.state = 'step0AddUpdatePaymentMethod';
         break;
       case 'step0AddUpdatePaymentMethod':
-        this.loadPaymentMethods();
+        this.loadData();
         break;
       case 'step1EditRecurringGifts':
         this.recurringGifts = recurringGifts;
@@ -122,8 +167,12 @@ export default angular
     step0AddUpdatePaymentMethod.name,
     step0paymentMethodList.name,
     step1EditRecurringGifts.name,
+    step2AddRecentRecipients.name,
+    step3ConfigureRecentRecipients.name,
     step4ConfirmRecurringGifts.name,
-    profileService.name
+    profileService.name,
+    donationsService.name,
+    commonService.name
   ])
   .component(componentName, {
     controller: EditRecurringGiftsModalController,

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
@@ -4,6 +4,8 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 
+import RecurringGiftModel from 'common/models/recurringGift.model';
+
 import module from './editRecurringGifts.modal.component';
 
 describe('edit recurring gifts modal', () => {
@@ -18,10 +20,20 @@ describe('edit recurring gifts modal', () => {
   }));
 
   describe('$onInit', () => {
-    it('should call loadPaymentMethods', () => {
+    it('should call loadData', () => {
       spyOn(self.controller, 'loadPaymentMethods');
+      spyOn(self.controller, 'loadRecentRecipients');
       self.controller.$onInit();
       expect(self.controller.loadPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.loadRecentRecipients).toHaveBeenCalled();
+    });
+  });
+
+  describe('loadData', () => {
+    it('should call loadData', () => {
+      spyOn(self.controller, 'loadData');
+      self.controller.$onInit();
+      expect(self.controller.loadData).toHaveBeenCalled();
     });
   });
 
@@ -36,12 +48,16 @@ describe('edit recurring gifts modal', () => {
         }
       }];
       spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.of(paymentMethods));
+      spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2015-02-04'));
       spyOn(self.controller, 'next');
       self.controller.loadPaymentMethods();
       expect(self.controller.state).toEqual('loading');
       expect(self.controller.profileService.getPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.commonService.getNextDrawDate).toHaveBeenCalled();
       expect(self.controller.paymentMethods).toEqual(paymentMethods);
+      expect(self.controller.nextDrawDate).toEqual('2015-02-04');
       expect(self.controller.hasPaymentMethods).toEqual(true);
+      expect(self.controller.validPaymentMethods).toEqual(paymentMethods);
       expect(self.controller.hasValidPaymentMethods).toEqual(true);
       expect(self.controller.next).toHaveBeenCalled();
     });
@@ -54,12 +70,16 @@ describe('edit recurring gifts modal', () => {
         'expiry-year': '2015'
       }];
       spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.of(paymentMethods));
+      spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2015-02-04'));
       spyOn(self.controller, 'next');
       self.controller.loadPaymentMethods();
       expect(self.controller.state).toEqual('loading');
       expect(self.controller.profileService.getPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.commonService.getNextDrawDate).toHaveBeenCalled();
       expect(self.controller.paymentMethods).toEqual(paymentMethods);
+      expect(self.controller.nextDrawDate).toEqual('2015-02-04');
       expect(self.controller.hasPaymentMethods).toEqual(true);
+      expect(self.controller.validPaymentMethods).toEqual(paymentMethods);
       expect(self.controller.hasValidPaymentMethods).toEqual(true);
       expect(self.controller.next).toHaveBeenCalled();
     });
@@ -72,38 +92,73 @@ describe('edit recurring gifts modal', () => {
         'expiry-year': '2014'
       }];
       spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.of(paymentMethods));
+      spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2015-02-04'));
       spyOn(self.controller, 'next');
       self.controller.loadPaymentMethods();
       expect(self.controller.state).toEqual('loading');
       expect(self.controller.profileService.getPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.commonService.getNextDrawDate).toHaveBeenCalled();
       expect(self.controller.paymentMethods).toEqual(paymentMethods);
+      expect(self.controller.nextDrawDate).toEqual('2015-02-04');
       expect(self.controller.hasPaymentMethods).toEqual(true);
+      expect(self.controller.validPaymentMethods).toEqual([]);
       expect(self.controller.hasValidPaymentMethods).toEqual(false);
       expect(self.controller.next).toHaveBeenCalled();
     });
     it('should handle no payment methods', () => {
       let paymentMethods = [];
       spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.of(paymentMethods));
+      spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2015-02-04'));
       spyOn(self.controller, 'next');
       self.controller.loadPaymentMethods();
       expect(self.controller.state).toEqual('loading');
       expect(self.controller.profileService.getPaymentMethods).toHaveBeenCalled();
-      expect(self.controller.paymentMethods).toEqual(paymentMethods);
+      expect(self.controller.commonService.getNextDrawDate).toHaveBeenCalled();
+      expect(self.controller.paymentMethods).toEqual([]);
+      expect(self.controller.nextDrawDate).toEqual('2015-02-04');
       expect(self.controller.hasPaymentMethods).toEqual(false);
+      expect(self.controller.validPaymentMethods).toEqual([]);
       expect(self.controller.hasValidPaymentMethods).toEqual(false);
       expect(self.controller.next).toHaveBeenCalled();
     });
     it('should handle an error loading payment methods', () => {
-      spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.throw('some error'));
+      spyOn(self.controller.profileService, 'getPaymentMethods').and.returnValue(Observable.throw('some payment method error'));
+      spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.throw('next draw date error'));
       spyOn(self.controller, 'next');
       self.controller.loadPaymentMethods();
       expect(self.controller.state).toEqual('error');
       expect(self.controller.profileService.getPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.commonService.getNextDrawDate).toHaveBeenCalled();
       expect(self.controller.paymentMethods).toBeUndefined();
       expect(self.controller.hasPaymentMethods).toBeUndefined();
       expect(self.controller.hasValidPaymentMethods).toBeUndefined();
       expect(self.controller.next).not.toHaveBeenCalled();
-      expect(self.controller.$log.error.logs[0]).toEqual(['Error loading payment methods', 'some error']);
+      expect(self.controller.$log.error.logs[0]).toEqual(['Error loading payment methods', 'some payment method error']);
+    });
+  });
+
+  describe('loadRecentRecipients', () => {
+    it('should load recent recipients after paymentMethods are loaded', () => {
+      self.controller.recentRecipientsObservable = Observable.of([ { 'designation-name': 'Staff Member' } ]);
+      self.controller.paymentMethodsObservable = Observable.of({
+        paymentMethods: [ { self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' } } ],
+        nextDrawDate: '2015-03-25'
+      });
+      self.controller.loadRecentRecipients();
+      expect(self.controller.recentRecipients).toEqual([ (new RecurringGiftModel(
+        { 'designation-name': 'Staff Member' },
+        null,
+        '2015-03-25',
+        [ { self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' } } ]
+      )).setDefaults() ] );
+      expect(self.controller.hasRecentRecipients).toEqual(true);
+    });
+    it('should handle an error loading recent recipients', () => {
+      self.controller.recentRecipientsObservable = Observable.throw('some error');
+      self.controller.paymentMethodsObservable = Observable.of({});
+      self.controller.loadRecentRecipients();
+      expect(self.controller.recentRecipients).toBeUndefined();
+      expect(self.controller.$log.error.logs[0]).toEqual( [ 'Error loading recent recipients', 'some error' ] );
     });
   });
 
@@ -142,10 +197,10 @@ describe('edit recurring gifts modal', () => {
     });
 
     it('should transition from step0AddUpdatePaymentMethod to step1EditRecurringGifts by reloading the payment methods', () => {
-      spyOn(self.controller, 'loadPaymentMethods');
+      spyOn(self.controller, 'loadData');
       self.controller.state = 'step0AddUpdatePaymentMethod';
       self.controller.next();
-      expect(self.controller.loadPaymentMethods).toHaveBeenCalled();
+      expect(self.controller.loadData).toHaveBeenCalled();
     });
 
     it('should transition from step1EditRecurringGifts to step2AddRecentRecipients', () => {

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -77,13 +77,15 @@
     ng-switch-when="step1EditRecurringGifts"
     payment-methods="$ctrl.validPaymentMethods"
     recurring-gifts="$ctrl.recurringGifts"
+    next-draw-date="$ctrl.nextDrawDate"
+    has-recent-recipients="$ctrl.hasRecentRecipients"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(null, recurringGifts)">
   </step-1-edit-recurring-gifts>
 
   <step-2-add-recent-recipients
     ng-switch-when="step2AddRecentRecipients"
-    additions="$ctrl.additions"
+    recent-recipients="$ctrl.recentRecipients"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)">
@@ -92,6 +94,7 @@
   <step-3-configure-recent-recipients
     ng-switch-when="step3ConfigureRecentRecipients"
     payment-methods="$ctrl.paymentMethods"
+    next-draw-date="$ctrl.nextDrawDate"
     additions="$ctrl.additions"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -1,13 +1,10 @@
 import angular from 'angular';
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/observable/forkJoin';
 
 import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
 import giftUpdateView from 'common/components/giftViews/giftUpdateView/giftUpdateView.component';
 import loading from 'common/components/loading/loading.component';
 
 import donationsService from 'common/services/api/donations.service';
-import commonService from 'common/services/api/common.service';
 
 import template from './editRecurringGifts.tpl';
 
@@ -16,10 +13,9 @@ let componentName = 'step1EditRecurringGifts';
 class EditRecurringGiftsController {
 
   /* @ngInject */
-  constructor($log, donationsService, commonService) {
+  constructor($log, donationsService) {
     this.$log = $log;
     this.donationsService = donationsService;
-    this.commonService = commonService;
   }
 
   $onInit(){
@@ -30,14 +26,13 @@ class EditRecurringGiftsController {
     if(!this.recurringGifts){
       this.loading = true;
       this.loadingError = false;
-      Observable.forkJoin(this.donationsService.getRecurringGifts(), this.commonService.getNextDrawDate())
-        .subscribe(([gifts, nextDrawDate]) => {
+      this.donationsService.getRecurringGifts()
+        .subscribe(gifts => {
             this.recurringGifts = gifts;
-            this.nextDrawDate = nextDrawDate;
             this.loading = false;
           },
-          (error) => {
-            this.$log.error('Error loading recurring gifts or nextDrawDate', error);
+          error => {
+            this.$log.error('Error loading recurring gifts', error);
             this.loading = false;
             this.loadingError = true;
           });
@@ -51,8 +46,7 @@ export default angular
     giftListItem.name,
     giftUpdateView.name,
     loading.name,
-    donationsService.name,
-    commonService.name
+    donationsService.name
   ])
   .component(componentName, {
     controller: EditRecurringGiftsController,
@@ -60,6 +54,8 @@ export default angular
     bindings: {
       recurringGifts: '<',
       paymentMethods: '<',
+      nextDrawDate: '<',
+      hasRecentRecipients: '<',
       dismiss: '&',
       next: '&'
     }

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
@@ -28,22 +28,19 @@ describe('editRecurringGiftsModal', () => {
     describe('loadGifts', () => {
       it('should load gifts', () => {
         spyOn(self.controller.donationsService, 'getRecurringGifts').and.returnValue(Observable.of('gifts response'));
-        spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.of('nextDrawDate response'));
         self.controller.loadGifts();
         expect(self.controller.loading).toEqual(false);
         expect(self.controller.loadingError).toEqual(false);
         expect(self.controller.recurringGifts).toEqual('gifts response');
-        expect(self.controller.nextDrawDate).toEqual('nextDrawDate response');
       });
       it('should handle an error loading gifts', () => {
         spyOn(self.controller.donationsService, 'getRecurringGifts').and.returnValue(Observable.throw('gifts error'));
-        spyOn(self.controller.commonService, 'getNextDrawDate').and.returnValue(Observable.throw('nextDrawDate error'));
         self.controller.loadGifts();
         expect(self.controller.loading).toEqual(false);
         expect(self.controller.loadingError).toEqual(true);
         expect(self.controller.recurringGifts).toBeUndefined();
         expect(self.controller.nextDrawDate).toBeUndefined();
-        expect(self.controller.$log.error.logs[0]).toEqual(['Error loading recurring gifts or nextDrawDate', 'gifts error']);
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error loading recurring gifts', 'gifts error']);
       });
     });
   });

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
@@ -23,7 +23,10 @@
           <p translate>There was an error loading your recurring gifts. You can use the retry button to try loading them again. If you continue to see this message, please contact support</p>
         </div>
         <div class="alert alert-warning" role="alert" ng-if="!$ctrl.loading && !$ctrl.loadingError && (!$ctrl.recurringGifts || $ctrl.recurringGifts.length === 0)">
-          <p translate>You don't seem to have any recurring gifts. You may click continue to set up a new recurring gift for a person or ministry you have given to recently.</p>
+          <p>
+            <span translate>You don't seem to have any recurring gifts to edit.</span>
+            <span ng-if="$ctrl.hasRecentRecipients" translate>You may click continue to set up a new recurring gift for a person or ministry you have given to recently.</span>
+          </p>
         </div>
         <div ng-repeat="gift in $ctrl.recurringGifts" class="row repeating-row user-profile">
           <gift-list-item gift="gift">
@@ -46,7 +49,11 @@
     </div>
     <div class="col-xs-6 text-right">
       <a class="btn btn-primary" ng-if="$ctrl.loadingError" ng-click="$ctrl.loadGifts()">Retry</a>
-      <a class="btn btn-primary" ng-if="!$ctrl.loadingError" ng-click="$ctrl.next({ recurringGifts: $ctrl.recurringGifts })">Continue</a>
+      <a class="btn btn-primary" ng-if="!$ctrl.loadingError"
+         ng-click="$ctrl.next({ recurringGifts: $ctrl.recurringGifts })"
+         ng-disabled="(!$ctrl.recurringGifts || $ctrl.recurringGifts.length === 0) && !$ctrl.hasRecentRecipients">
+        Continue
+      </a>
     </div>
   </div>
 </div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.js
@@ -1,0 +1,40 @@
+import angular from 'angular';
+import filter from 'lodash/filter';
+
+import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
+
+import template from './addRecentRecipients.tpl';
+
+let componentName = 'step2AddRecentRecipients';
+
+class AddRecentRecipientsController {
+
+  /* @ngInject */
+  constructor() {
+
+  }
+
+  $onInit(){
+
+  }
+
+  gatherSelections(){
+    this.next({ additions: filter(this.recentRecipients, {_selectedGift: true}) });
+  }
+}
+
+export default angular
+  .module(componentName, [
+    template.name,
+    giftListItem.name
+  ])
+  .component(componentName, {
+    controller: AddRecentRecipientsController,
+    templateUrl: template.name,
+    bindings: {
+      recentRecipients: '<',
+      dismiss: '&',
+      previous: '&',
+      next: '&'
+    }
+  });

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.spec.js
@@ -1,0 +1,25 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+import module from './addRecentRecipients.component';
+
+describe('editRecurringGiftsModal', () => {
+  describe('step 2 addRecentRecipients', () => {
+    beforeEach(angular.mock.module(module.name));
+    var self = {};
+
+    beforeEach(inject(($componentController) => {
+      self.controller = $componentController(module.name, {}, {
+        next: jasmine.createSpy('next')
+      });
+    }));
+
+    describe('gatherSelections', () => {
+      it('should get all selected gifts and pass them to the next step', () => {
+        self.controller.recentRecipients = [ {}, {_selectedGift: true} ];
+        self.controller.gatherSelections();
+        expect(self.controller.next).toHaveBeenCalledWith({ additions: [{_selectedGift: true}] });
+      });
+    });
+  });
+});

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.tpl.html
@@ -1,0 +1,40 @@
+<div class="modal-header">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <div class="border-bottom-small">
+          <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()"><span aria-hidden="true">&times;</span></button>
+          <h3 translate>You've also given to these recipients recently.</h3>
+          <p translate>Would you like to add them to your recurring gifts?</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-body">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 col-xs-12">
+        <div ng-repeat="gift in $ctrl.recentRecipients" class="row repeating-row user-profile">
+          <gift-list-item gift="gift" selectable="checkbox"></gift-list-item>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <div class="row row-no-spacing">
+    <div class="col-xs-6">
+      <a class="btn btn-default"
+         ng-click="$ctrl.previous()"
+         translate>
+        Back
+      </a>
+    </div>
+    <div class="col-xs-6 text-right">
+      <button class="btn btn-primary" ng-click="$ctrl.gatherSelections()" translate>Continue</button>
+    </div>
+  </div>
+</div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
@@ -1,0 +1,35 @@
+import angular from 'angular';
+
+import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
+import giftUpdateView from 'common/components/giftViews/giftUpdateView/giftUpdateView.component';
+
+import template from './configureRecentRecipients.tpl';
+
+let componentName = 'step3ConfigureRecentRecipients';
+
+class ConfigureRecentRecipientsController {
+
+  /* @ngInject */
+  constructor() {
+
+  }
+}
+
+export default angular
+  .module(componentName, [
+    template.name,
+    giftListItem.name,
+    giftUpdateView.name
+  ])
+  .component(componentName, {
+    controller: ConfigureRecentRecipientsController,
+    templateUrl: template.name,
+    bindings: {
+      paymentMethods: '<',
+      nextDrawDate: '<',
+      additions: '<',
+      dismiss: '&',
+      previous: '&',
+      next: '&'
+    }
+  });

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.spec.js
@@ -1,0 +1,21 @@
+import angular from 'angular';
+import 'angular-mocks';
+
+import module from './configureRecentRecipients.component';
+
+describe('editRecurringGiftsModal', () => {
+  describe('step 3 configureRecentRecipients', () => {
+    beforeEach(angular.mock.module(module.name));
+    var self = {};
+
+    beforeEach(inject(($componentController) => {
+      self.controller = $componentController(module.name, {}, {
+        next: jasmine.createSpy('next')
+      });
+    }));
+
+    it('should get all selected gifts and pass them to the next step', () => {
+      expect(self.controller).toBeDefined();
+    });
+  });
+});

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
@@ -1,0 +1,42 @@
+<div class="modal-header">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <div class="border-bottom-small">
+          <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()"><span aria-hidden="true">&times;</span></button>
+          <h3 translate>You've also given to these recipients recently.</h3>
+          <p translate>Would you like to add them to your recurring gifts?</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-body">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 col-xs-12">
+        <div ng-repeat="gift in $ctrl.additions" class="row repeating-row user-profile">
+          <gift-list-item gift="gift">
+            <gift-update-view gift="gift" payment-methods="$ctrl.paymentMethods" next-draw-date="$ctrl.nextDrawDate"></gift-update-view>
+          </gift-list-item>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <div class="row row-no-spacing">
+    <div class="col-xs-6">
+      <a class="btn btn-default"
+         ng-click="$ctrl.previous()"
+         translate>
+        Back
+      </a>
+    </div>
+    <div class="col-xs-6 text-right">
+      <button class="btn btn-primary" ng-click="$ctrl.next({ additions: $ctrl.additions })" translate>Continue</button>
+    </div>
+  </div>
+</div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
@@ -1,5 +1,9 @@
 import angular from 'angular';
 import filter from 'lodash/filter';
+import isEmpty from 'lodash/isEmpty';
+import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/observable/empty';
 
 import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
 import giftDetailsView from 'common/components/giftViews/giftDetailsView/giftDetailsView.component';
@@ -21,20 +25,24 @@ class ConfirmRecurringGiftsController {
 
   $onInit(){
     this.recurringGiftChanges = filter(this.recurringGifts, gift => gift.hasChanges());
+    this.hasChanges = !isEmpty(this.recurringGiftChanges) || !isEmpty(this.additions);
   }
 
   saveChanges(){
     this.saving = true;
     this.savingError = '';
-    this.donationsService.updateRecurringGifts(this.recurringGiftChanges)
+    let requests = [];
+    !isEmpty(this.recurringGiftChanges) && requests.push(this.donationsService.updateRecurringGifts(this.recurringGiftChanges));
+    !isEmpty(this.additions) && requests.push(this.donationsService.addRecurringGifts(this.additions));
+    Observable.forkJoin(requests)
       .subscribe(() => {
-        this.next();
-      },
-      error => {
-        this.saving = false;
-        this.savingError = error.data ? error.data : 'unknown';
-        this.$log.error('Error updating recurring gifts', error);
-      });
+          this.next();
+        },
+        error => {
+          this.saving = false;
+          this.savingError = error.data || 'unknown';
+          this.$log.error('Error updating/adding recurring gifts', error);
+        });
   }
 }
 

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.spec.js
@@ -31,30 +31,45 @@ describe('editRecurringGiftsModal', () => {
         ];
         self.controller.$onInit();
         expect(self.controller.recurringGiftChanges).toEqual([ self.controller.recurringGifts[0] ]);
+        expect(self.controller.hasChanges).toEqual(true);
+      });
+      it('should set hasChanges to true if there are additions', () => {
+        self.controller.additions = ['addition 1'];
+        self.controller.$onInit();
+        expect(self.controller.hasChanges).toEqual(true);
+      });
+      it('should set hasChanges to false if there are no recurring gift changes or additions', () => {
+        self.controller.$onInit();
+        expect(self.controller.hasChanges).toEqual(false);
       });
     });
 
     describe('saveChanges', () => {
       it('should update gifts', () => {
         self.controller.recurringGiftChanges = [{ testGift: 3 }];
-        spyOn(self.controller.donationsService, 'updateRecurringGifts').and.returnValue(Observable.of('gifts response'));
+        self.controller.additions = [{ testGift: 4 }];
+        spyOn(self.controller.donationsService, 'updateRecurringGifts').and.returnValue(Observable.of('update gifts response'));
+        spyOn(self.controller.donationsService, 'addRecurringGifts').and.returnValue(Observable.of('add gifts response'));
         self.controller.saveChanges();
         expect(self.controller.donationsService.updateRecurringGifts).toHaveBeenCalledWith([{ testGift: 3 }]);
+        expect(self.controller.donationsService.addRecurringGifts).toHaveBeenCalledWith([{ testGift: 4 }]);
         expect(self.controller.next).toHaveBeenCalled();
         expect(self.controller.savingError).toEqual('');
       });
       it('should handle an error updating gifts', () => {
-        spyOn(self.controller.donationsService, 'updateRecurringGifts').and.returnValue(Observable.throw({ data: 'gifts error' }));
+        self.controller.recurringGiftChanges = [ {} ];
+        spyOn(self.controller.donationsService, 'updateRecurringGifts').and.returnValue(Observable.throw({ data: 'update gifts error' }));
         self.controller.saveChanges();
-        expect(self.controller.savingError).toEqual('gifts error');
-        expect(self.controller.$log.error.logs[0]).toEqual(['Error updating recurring gifts', { data: 'gifts error' }]);
+        expect(self.controller.savingError).toEqual('update gifts error');
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error updating/adding recurring gifts', { data: 'update gifts error' }]);
         expect(self.controller.saving).toEqual(false);
       });
       it('should handle an unknown error updating gifts', () => {
-        spyOn(self.controller.donationsService, 'updateRecurringGifts').and.returnValue(Observable.throw({}));
+        self.controller.additions = [ {} ];
+        spyOn(self.controller.donationsService, 'addRecurringGifts').and.returnValue(Observable.throw({}));
         self.controller.saveChanges();
         expect(self.controller.savingError).toEqual('unknown');
-        expect(self.controller.$log.error.logs[0]).toEqual(['Error updating recurring gifts', {}]);
+        expect(self.controller.$log.error.logs[0]).toEqual(['Error updating/adding recurring gifts', {}]);
         expect(self.controller.saving).toEqual(false);
       });
     });

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.tpl.html
@@ -19,7 +19,15 @@
           <p ng-switch-when="Only Active recurring donations can be modified." translate>One of the gifts you are modifying is no longer an active gift. We may have accidentally shown you an inactive gift in a previous step. You may try only editing one gift at a time to determine which gift cannot be changed. If you continue to experience problems, please contact support.</p>
           <p ng-switch-default translate>There was an error saving your gifts. Please check that all the entered information is valid and that you have a good internet connection. If you continue to see this message, please contact support.</p>
         </div>
+        <div class="alert alert-warning" role="alert" ng-if="!$ctrl.hasChanges">
+          <p translate>You don't appear to have made any changes to your recurring gifts. Feel free to go back and make some changes.</p>
+        </div>
         <div ng-repeat="gift in $ctrl.recurringGiftChanges" class="row repeating-row user-profile">
+          <gift-list-item gift="gift">
+            <gift-details-view gift="gift"></gift-details-view>
+          </gift-list-item>
+        </div>
+        <div ng-repeat="gift in $ctrl.additions" class="row repeating-row user-profile">
           <gift-list-item gift="gift">
             <gift-details-view gift="gift"></gift-details-view>
           </gift-list-item>
@@ -39,7 +47,7 @@
       </a>
     </div>
     <div class="col-xs-6 text-right">
-      <button class="btn btn-primary" ng-click="$ctrl.saveChanges()" ng-disabled="$ctrl.saving">
+      <button class="btn btn-primary" ng-click="$ctrl.saveChanges()" ng-disabled="$ctrl.saving || !$ctrl.hasChanges">
         <span ng-if="!$ctrl.saving" translate>Confirm Changes</span>
         <span ng-if="$ctrl.saving" translate>Saving...</span>
       </button>

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -10,6 +10,30 @@ export default class RecurringGiftModel {
     this.parentDonation = parentDonation;
     this.nextDrawDate = nextDrawDate;
     this.paymentMethods = paymentMethods;
+
+    this.initializeEmptyFields();
+  }
+
+  initializeEmptyFields(){
+    if(!this.gift['updated-rate']){
+      this.gift['updated-rate'] = {
+        recurrence: {
+          interval: ''
+        }
+      };
+    }
+    if(!this.parentDonation){
+      this.parentDonation = {
+        rate: {
+          recurrence: {
+            interval: ''
+          }
+        },
+        'next-draw-date': {
+          'display-value': ''
+        }
+      };
+    }
   }
 
   get designationName() {
@@ -47,8 +71,8 @@ export default class RecurringGiftModel {
 
   get paymentMethod(){
     return this._paymentMethod = this._paymentMethod || find( this.paymentMethods, ( paymentMethod ) => {
-      return this.paymentMethodId === paymentMethod.self.uri.split( '/' ).pop();
-    } );
+        return this.paymentMethodId === paymentMethod.self.uri.split( '/' ).pop();
+      } );
   }
 
   set donationLineStatus(value){
@@ -128,7 +152,8 @@ export default class RecurringGiftModel {
       this.gift['updated-recurring-day-of-month'] !== '' ||
       this.gift['updated-start-month'] !== '' ||
       this.gift['updated-start-year'] !== '' ||
-      this.gift['updated-donation-line-status'] !== '';
+      this.gift['updated-donation-line-status'] !== '' ||
+      this.gift['updated-designation-number'] !== '';
   }
 
   get toObject(){
@@ -137,5 +162,15 @@ export default class RecurringGiftModel {
 
   clone() {
     return angular.copy(this, Object.create(this));
+  }
+
+  setDefaults(){
+    this.gift['updated-designation-number'] = this.gift['designation-number'];
+    this.gift['updated-amount'] = 50;
+    this._paymentMethod = this.paymentMethods[0];
+    this.gift['updated-payment-method-id'] = this._paymentMethod.self.uri.split( '/' ).pop();
+    this.gift['updated-rate']['recurrence']['interval'] = 'Monthly';
+    this.gift['updated-recurring-day-of-month'] = startDate(null, this.nextDrawDate).format('DD');
+    return this;
   }
 }

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -20,7 +20,8 @@ describe('recurringGift model', () => {
         'updated-rate': {recurrence: {interval: ''}},
         'updated-recurring-day-of-month': '',
         'updated-start-month': '',
-        'updated-start-year': ''
+        'updated-start-year': '',
+        'updated-designation-number': ''
       },
       {
         'donation-row-id': '1-K0LPOL',
@@ -378,6 +379,10 @@ describe('recurringGift model', () => {
       giftModel.gift['updated-donation-line-status'] = 'Cancelled';
       expect(giftModel.hasChanges()).toEqual(true);
     });
+    it('should return true if designation number has been updated', () => {
+      giftModel.gift['updated-designation-number'] = '1234567';
+      expect(giftModel.hasChanges()).toEqual(true);
+    });
   });
 
   describe('toObject getter', () => {
@@ -395,6 +400,22 @@ describe('recurringGift model', () => {
       clone.donationLineStatus = 'Cancelled';
       expect(clone.amount).toEqual(giftModel.amount);
       expect(clone.donationLineStatus).not.toEqual(giftModel.donationLineStatus);
+    });
+  });
+
+  describe('setDefaults', () => {
+    it('should set default values for a new gift', () => {
+      expect(giftModel.setDefaults().toObject).toEqual(jasmine.objectContaining({
+        'updated-designation-number': giftModel.gift['designation-number'],
+        'updated-amount': 50,
+        'updated-payment-method-id': 'giydgnrxgm=',
+        'updated-rate': {
+          'recurrence': {
+            'interval': 'Monthly'
+          }
+        }
+      }));
+      expect(giftModel._paymentMethod).toEqual(giftModel.paymentMethods[0]);
     });
   });
 });

--- a/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
@@ -1,0 +1,119 @@
+export default {
+  "self": {
+    "type": "elasticpath.profiles.profile",
+    "uri": "/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=?zoom=givingdashboard:recentdonations:element",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=?zoom=givingdashboard:recentdonations:element"
+  },
+  "links": [{
+    "rel": "addresses",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/addresses/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/addresses/crugive"
+  }, {
+    "rel": "addspousedetails",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/donordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=/spousedetails",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/donordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=/spousedetails"
+  }, {
+    "rel": "donordetails",
+    "type": "elasticpath.donordetails.donor",
+    "uri": "/donordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/donordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi="
+  }, {
+    "rel": "emails",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/emails/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/emails/crugive"
+  }, {
+    "rel": "givingdashboard",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/giving/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/giving/crugive"
+  }, {
+    "rel": "paymentmethods",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/paymentmethods/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/paymentmethods/crugive"
+  }, {
+    "rel": "phonenumbers",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/phonenumbers/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/phonenumbers/crugive"
+  }, {
+    "rel": "purchases",
+    "type": "elasticpath.collections.links",
+    "uri": "/purchases/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/purchases/crugive"
+  }, {
+    "rel": "selfservicedonordetails",
+    "type": "cru.selfservicedonor.self-service-donor",
+    "uri": "/selfservicedonordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/selfservicedonordetails/profiles/crugive/gbrdemzygy2geljxg5rtoljugfsgmllbhfstqlldgy2dozddmjsdsmbwmi="
+  }, {
+    "rel": "selfservicepaymentmethods",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/selfservicepaymentmethods/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/selfservicepaymentmethods/crugive"
+  }, {
+    "rel": "wishlists",
+    "rev": "profile",
+    "type": "elasticpath.collections.links",
+    "uri": "/wishlists/crugive",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/crugive"
+  }],
+  "_givingdashboard": [{
+    "_recentdonations": [{
+      "_element": [{
+        "self": {
+          "type": "elasticpath.donations.recipient-donation-history",
+          "uri": "/donations/historical/crugive/recentrecipientsummary/a5ufc43nkb2htqvrlu6vg3lsmtbkkus5ijjh2ob2ykxuypjrjmsunqvjyk6v46kdkf6ta4ltyoavpqvbyk5x3q4co4=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recentrecipientsummary/a5ufc43nkb2htqvrlu6vg3lsmtbkkus5ijjh2ob2ykxuypjrjmsunqvjyk6v46kdkf6ta4ltyoavpqvbyk5x3q4co4="
+        },
+        "links": [{
+          "rel": "element",
+          "rev": "list",
+          "type": "elasticpath.donations.historical-donation",
+          "uri": "/donations/historical/crugive/gewuwmkmjjhfe=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/gewuwmkmjjhfe="
+        }, {
+          "rel": "mostrecentdonation",
+          "uri": "/donations/historical/crugive/gewuwmkmjjhfe=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/gewuwmkmjjhfe="
+        }],
+        "designation-active": false,
+        "designation-name": "Mike and Becky Crandall (0104878)",
+        "designation-number": "0104878",
+        "year-to-date-amount": 0
+      }, {
+        "self": {
+          "type": "elasticpath.donations.recipient-donation-history",
+          "uri": "/donations/historical/crugive/recentrecipientsummary/a5ufc43nkb2htqvrlu6vg3lsmtbkkus5ijjh2ob2ykxuypjrjmsu5qvoyk7v26kdkf6ta4ltyoavpqvbyk5x3q4co4=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recentrecipientsummary/a5ufc43nkb2htqvrlu6vg3lsmtbkkus5ijjh2ob2ykxuypjrjmsu5qvoyk7v26kdkf6ta4ltyoavpqvbyk5x3q4co4="
+        },
+        "links": [{
+          "rel": "mostrecentdonation",
+          "uri": "/donations/historical/crugive/gewusqkrizfuq=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/gewusqkrizfuq="
+        }, {
+          "rel": "giveagift",
+          "type": "elasticpath.items.item",
+          "uri": "/items/crugive/gaytanjzha3q=",
+          "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/gaytanjzha3q="
+        }],
+        "designation-active": true,
+        "designation-name": "David and Margo Neibling (0105987)",
+        "designation-number": "0105987",
+        "year-to-date-amount": 0
+      }]
+    }]
+  }],
+  "family-name": "Hewitt",
+  "given-name": "Robert"
+};


### PR DESCRIPTION
…and implement saving added recent recipients

- Move loading of nextDrawDate to modal component
- Load recent recipients when modal component is loaded but wait to process them until payment methods have been loaded
- Add initialize empty fields functionality to recurringGiftModel to prevent errors accessing nested objects
- Add setDefaults functionality to recurringGiftModel to default the updated fields to a monthly gift
- Add addRecurringGifts function to donations service

I have a few outstanding issues I need to fix and I'll ask about them tomorrow:
- [x] Saving recent recipients results in a null pointer exception on the server. Could do some more testing after that is resolved.
- [x] Whether the recent recipients endpoint automatically filters out recurring gifts or if I need to filter those on the front end.
- [ ] What to do if recent recipients still aren't loaded by the time the user continues past step 1. Do we skip adding recent recipients or do we make the user wait and show a loading indicator?
- [x] Saving observable doesn't work right when one of the sources is empty.
- [x] Add a "you have made no changes" message on the confirm page and disable confirm btn.