### PR TITLE
Create method to clone a RecurringGiftModel

### DIFF
--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -126,4 +126,8 @@ export default class RecurringGiftModel {
   get toObject(){
     return this.gift;
   }
+
+  clone() {
+    return angular.copy(this, Object.create(this));
+  }
 }

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -371,4 +371,16 @@ describe('recurringGift model', () => {
       expect(giftModel.toObject).toEqual(giftModel.gift);
     });
   });
+
+  describe('clone', () => {
+    it('creates a copy of the gift', () => {
+      giftModel.amount = 500;
+      let clone = giftModel.clone();
+      expect(clone instanceof RecurringGiftModel).toEqual(true);
+      expect(clone).toEqual(giftModel);
+      clone.donationLineStatus = 'Cancelled';
+      expect(clone.amount).toEqual(giftModel.amount);
+      expect(clone.donationLineStatus).not.toEqual(giftModel.donationLineStatus);
+    });
+  });
 });


### PR DESCRIPTION
This method creates a deep copy/clone of an existing recurring gift. I was finding the need for this in redirecting an existing gift without modifying the original.