### PR TITLE
Pads possibleTransactionDays to match recurringGift responses.

### DIFF
--- a/src/common/services/giftHelpers/giftDates.service.js
+++ b/src/common/services/giftHelpers/giftDates.service.js
@@ -1,10 +1,9 @@
 import moment from 'moment';
 import range from 'lodash/range';
 import map from 'lodash/map';
-import toString from 'lodash/toString';
 
 export function possibleTransactionDays() {
-  return range( 1, 29 ).map( toString );
+  return range( 1, 29 ).map((i) => (`0${i}`).slice(-2));
 }
 
 // Generate a string of 4 months based on transactionDay and nextDrawDate

--- a/src/common/services/giftHelpers/giftDates.service.spec.js
+++ b/src/common/services/giftHelpers/giftDates.service.spec.js
@@ -6,7 +6,7 @@ describe('giftDates service', () => {
   describe('possibleTransactionDays', () => {
     it('should calculate gift start date', () => {
       expect(giftDates.possibleTransactionDays()).toEqual([
-        '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+        '01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
         '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
         '21', '22', '23', '24', '25', '26', '27', '28'
       ]);


### PR DESCRIPTION
I was noticing that transactionDay's from the API are padded with the leading zero for single digit days. This was causing `<select>` to not match. This change pads the single digits while converting it to a string.