### PR TITLE
Add designationName and designationNumber setters

### DIFF
--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -16,8 +16,16 @@ export default class RecurringGiftModel {
     return this.gift['designation-name'];
   }
 
+  set designationName(value) {
+    this.gift['designation-name'] = value;
+  }
+
   get designationNumber() {
     return this.gift['designation-number'];
+  }
+
+  set designationNumber(value) {
+    this.gift['designation-number'] = value;
   }
 
   get amount(){

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -46,9 +46,23 @@ describe('recurringGift model', () => {
     });
   });
 
+  describe('designationName setter', () => {
+    it('should set the name', () => {
+      giftModel.designationName = 'Lex Luthor';
+      expect(giftModel.gift['designation-name']).toEqual('Lex Luthor');
+    });
+  });
+
   describe('designationNumber getter', () => {
     it('should return the designation number', () => {
       expect(giftModel.designationNumber).toEqual('0105987');
+    });
+  });
+
+  describe('designationNumber setter', () => {
+    it('should set the designation number', () => {
+      giftModel.designationNumber = '0123456';
+      expect(giftModel.gift['designation-number']).toEqual('0123456');
     });
   });
 


### PR DESCRIPTION
Redirecting a gift required changing the current name and number on a cloned RecurringGiftModel.