### PR TITLE
Recurring gift model static payment methods next draw date

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
@@ -29,14 +29,6 @@ describe('edit recurring gifts modal', () => {
     });
   });
 
-  describe('loadData', () => {
-    it('should call loadData', () => {
-      spyOn(self.controller, 'loadData');
-      self.controller.$onInit();
-      expect(self.controller.loadData).toHaveBeenCalled();
-    });
-  });
-
   describe('loadPaymentMethods', () => {
     beforeEach(() => {
       jasmine.clock().mockDate(new Date(2015, 0, 10));
@@ -138,24 +130,16 @@ describe('edit recurring gifts modal', () => {
   });
 
   describe('loadRecentRecipients', () => {
-    it('should load recent recipients after paymentMethods are loaded', () => {
-      self.controller.recentRecipientsObservable = Observable.of([ { 'designation-name': 'Staff Member' } ]);
-      self.controller.paymentMethodsObservable = Observable.of({
-        paymentMethods: [ { self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' } } ],
-        nextDrawDate: '2015-03-25'
-      });
+    it('should load recent recipients', () => {
+      spyOn(self.controller.donationsService, 'getRecentRecipients').and.returnValue(Observable.of([ { 'designation-name': 'Staff Member' } ]));
       self.controller.loadRecentRecipients();
       expect(self.controller.recentRecipients).toEqual([ (new RecurringGiftModel(
-        { 'designation-name': 'Staff Member' },
-        null,
-        '2015-03-25',
-        [ { self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' } } ]
+        { 'designation-name': 'Staff Member' }
       )).setDefaults() ] );
       expect(self.controller.hasRecentRecipients).toEqual(true);
     });
     it('should handle an error loading recent recipients', () => {
-      self.controller.recentRecipientsObservable = Observable.throw('some error');
-      self.controller.paymentMethodsObservable = Observable.of({});
+      spyOn(self.controller.donationsService, 'getRecentRecipients').and.returnValue(Observable.throw('some error'));
       self.controller.loadRecentRecipients();
       expect(self.controller.recentRecipients).toBeUndefined();
       expect(self.controller.$log.error.logs[0]).toEqual( [ 'Error loading recent recipients', 'some error' ] );
@@ -197,10 +181,10 @@ describe('edit recurring gifts modal', () => {
     });
 
     it('should transition from step0AddUpdatePaymentMethod to step1EditRecurringGifts by reloading the payment methods', () => {
-      spyOn(self.controller, 'loadData');
+      spyOn(self.controller, 'loadPaymentMethods');
       self.controller.state = 'step0AddUpdatePaymentMethod';
       self.controller.next();
-      expect(self.controller.loadData).toHaveBeenCalled();
+      expect(self.controller.loadPaymentMethods).toHaveBeenCalled();
     });
 
     it('should transition from step1EditRecurringGifts to step2AddRecentRecipients', () => {

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -75,9 +75,7 @@
 
   <step-1-edit-recurring-gifts
     ng-switch-when="step1EditRecurringGifts"
-    payment-methods="$ctrl.validPaymentMethods"
     recurring-gifts="$ctrl.recurringGifts"
-    next-draw-date="$ctrl.nextDrawDate"
     has-recent-recipients="$ctrl.hasRecentRecipients"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(null, recurringGifts)">
@@ -93,8 +91,6 @@
 
   <step-3-configure-recent-recipients
     ng-switch-when="step3ConfigureRecentRecipients"
-    payment-methods="$ctrl.paymentMethods"
-    next-draw-date="$ctrl.nextDrawDate"
     additions="$ctrl.additions"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -53,8 +53,6 @@ export default angular
     templateUrl: template.name,
     bindings: {
       recurringGifts: '<',
-      paymentMethods: '<',
-      nextDrawDate: '<',
       hasRecentRecipients: '<',
       dismiss: '&',
       next: '&'

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -26,7 +26,7 @@ class EditRecurringGiftsController {
     if(!this.recurringGifts){
       this.loading = true;
       this.loadingError = false;
-      this.donationsService.getRecurringGifts()
+      this.donationsService.getRecurringGifts(undefined, true)
         .subscribe(gifts => {
             this.recurringGifts = gifts;
             this.loading = false;

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
@@ -30,7 +30,7 @@
         </div>
         <div ng-repeat="gift in $ctrl.recurringGifts" class="row repeating-row user-profile">
           <gift-list-item gift="gift">
-            <gift-update-view gift="gift" payment-methods="$ctrl.paymentMethods" next-draw-date="$ctrl.nextDrawDate"></gift-update-view>
+            <gift-update-view gift="gift"></gift-update-view>
           </gift-list-item>
         </div>
       </div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
@@ -25,8 +25,6 @@ export default angular
     controller: ConfigureRecentRecipientsController,
     templateUrl: template.name,
     bindings: {
-      paymentMethods: '<',
-      nextDrawDate: '<',
       additions: '<',
       dismiss: '&',
       previous: '&',

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
@@ -18,7 +18,7 @@
       <div class="col-md-12 col-xs-12">
         <div ng-repeat="gift in $ctrl.additions" class="row repeating-row user-profile">
           <gift-list-item gift="gift">
-            <gift-update-view gift="gift" payment-methods="$ctrl.paymentMethods" next-draw-date="$ctrl.nextDrawDate"></gift-update-view>
+            <gift-update-view gift="gift"></gift-update-view>
           </gift-list-item>
         </div>
       </div>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.js
@@ -18,18 +18,6 @@ class RedirectGiftStep3Controller {
     this.state = 'update';
   }
 
-  $onInit() {
-    this.setLoading( {loading: true} );
-    this.loadNextDrawDate();
-  }
-
-  loadNextDrawDate() {
-    this.commonService.getNextDrawDate().subscribe( ( nextDrawDate ) => {
-      this.nextDrawDate = nextDrawDate;
-      this.setLoading( {loading: false} );
-    } );
-  }
-
   submitGift() {
     this.hasError = false;
     this.setLoading( {loading: true} );

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.spec.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.spec.js
@@ -24,24 +24,6 @@ describe( 'your giving', () => {
             expect( $ctrl.donationsService ).toBeDefined();
           } );
 
-          describe( '$onInit()', () => {
-            it( 'initializes the component', () => {
-              spyOn( $ctrl, 'loadNextDrawDate' );
-              $ctrl.$onInit();
-              expect( $ctrl.setLoading ).toHaveBeenCalledWith( {loading: true} );
-              expect( $ctrl.loadNextDrawDate ).toHaveBeenCalled();
-            } );
-          } );
-
-          describe( 'loadNextDrawDate()', () => {
-            it( 'loads next draw date and shows component', () => {
-              spyOn( $ctrl.commonService, 'getNextDrawDate' ).and.returnValue( Observable.of( '2020-01-01' ) );
-              $ctrl.loadNextDrawDate();
-              expect( $ctrl.nextDrawDate ).toEqual( '2020-01-01' );
-              expect( $ctrl.setLoading ).toHaveBeenCalledWith( {loading: false} );
-            } );
-          } );
-
           describe( 'submitGift', () => {
             beforeEach( () => {
               $ctrl.hasError = true;

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.tpl.html
@@ -22,9 +22,9 @@
       <div class="col-xs-12">
         <div class="alert alert-danger" role="alert" ng-if="$ctrl.hasError" translate>An error occurred saving changes. You may try again by clicking "Confirm Changes."</div>
         <form name="$ctrl.redirectForm" ng-switch="$ctrl.state">
-          <div class="repeating-row" ng-switch-when="update" ng-if="$ctrl.nextDrawDate">
+          <div class="repeating-row" ng-switch-when="update">
             <gift-list-item gift="$ctrl.gift">
-              <gift-update-view gift="$ctrl.gift" next-draw-date="$ctrl.nextDrawDate" payment-methods="$ctrl.gift.paymentMethods" />
+              <gift-update-view gift="$ctrl.gift" />
             </gift-list-item>
           </div>
           <div class="repeating-row" ng-switch-when="confirm">

--- a/src/common/components/giftViews/giftUpdateView/giftUpdateView.component.js
+++ b/src/common/components/giftViews/giftUpdateView/giftUpdateView.component.js
@@ -30,8 +30,6 @@ export default angular
     controller: GiftUpdateViewController,
     templateUrl: template.name,
     bindings: {
-      gift: '=',
-      paymentMethods: '<',
-      nextDrawDate: '<'
+      gift: '='
     }
   });

--- a/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
+++ b/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
@@ -16,7 +16,7 @@
         <label translate>Payment Method</label>
         <select class="form-control  form-control-subtle"
                 ng-model="$ctrl.gift.paymentMethodId"
-                ng-options="paymentMethod.self.uri.split('/').pop() as ((paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ****' + (paymentMethod['display-account-number'] || paymentMethod['card-number'])) for paymentMethod in $ctrl.paymentMethods" >
+                ng-options="paymentMethod.self.uri.split('/').pop() as ((paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ****' + (paymentMethod['display-account-number'] || paymentMethod['card-number'])) for paymentMethod in $ctrl.gift.paymentMethods" >
         </select>
       </div>
     </div>
@@ -51,16 +51,16 @@
 
     <div class="form-group">
       <label class="radio">
-        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.nextDrawDate).format('M')">
-        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.nextDrawDate) }}
+        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate).format('M')">
+        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate) }}
       </label>
       <label class="radio">
-        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.nextDrawDate, 1).format('M')">
-        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.nextDrawDate, 1) }}
+        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate, 1).format('M')">
+        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate, 1) }}
       </label>
       <label class="radio">
-        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.nextDrawDate, 2).format('M')">
-        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.nextDrawDate, 2) }}
+        <input type="radio" ng-model="$ctrl.gift.startMonth" ng-value="$ctrl.startDate($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate, 2).format('M')">
+        {{ $ctrl.quarterlyMonths($ctrl.gift.transactionDay, $ctrl.gift.nextDrawDate, 2) }}
       </label>
     </div>
   </div>

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -5,11 +5,9 @@ import {startMonth, startDate} from 'common/services/giftHelpers/giftDates.servi
 
 export default class RecurringGiftModel {
 
-  constructor(gift, parentDonation, nextDrawDate, paymentMethods) {
+  constructor(gift, parentDonation) {
     this.gift = gift;
     this.parentDonation = parentDonation;
-    this.nextDrawDate = nextDrawDate;
-    this.paymentMethods = paymentMethods;
 
     this.initializeEmptyFields();
   }
@@ -34,6 +32,30 @@ export default class RecurringGiftModel {
         }
       };
     }
+  }
+
+  get nextDrawDate(){
+    return this.constructor.nextDrawDate;
+  }
+
+  static get nextDrawDate(){
+    return this.constructor._nextDrawDate;
+  }
+
+  static set nextDrawDate(nextDrawDate){
+    this.constructor._nextDrawDate = nextDrawDate;
+  }
+
+  get paymentMethods(){
+    return this.constructor.paymentMethods;
+  }
+
+  static get paymentMethods(){
+    return this.constructor._paymentMethods;
+  }
+
+  static set paymentMethods(paymentMethods){
+    this.constructor._paymentMethods = paymentMethods;
   }
 
   get designationName() {
@@ -61,7 +83,7 @@ export default class RecurringGiftModel {
   }
 
   get paymentMethodId(){
-    return this.gift['updated-payment-method-id'] || this.gift['payment-method-id'];
+    return this.gift['updated-payment-method-id'] || this.gift['payment-method-id'] || this.paymentMethods && this.paymentMethods[0].self.uri.split( '/' ).pop();
   }
 
   set paymentMethodId(value){
@@ -167,8 +189,6 @@ export default class RecurringGiftModel {
   setDefaults(){
     this.gift['updated-designation-number'] = this.gift['designation-number'];
     this.gift['updated-amount'] = 50;
-    this._paymentMethod = this.paymentMethods[0];
-    this.gift['updated-payment-method-id'] = this._paymentMethod.self.uri.split( '/' ).pop();
     this.gift['updated-rate']['recurrence']['interval'] = 'Monthly';
     this.gift['updated-recurring-day-of-month'] = startDate(null, this.nextDrawDate).format('DD');
     return this;

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -30,15 +30,15 @@ describe('recurringGift model', () => {
         rate: {recurrence: {interval: 'Monthly'}},
         'recurring-day-of-month': '15',
         'next-draw-date': {'display-value': '2015-05-06', value: 1430895600}
-      },
-      '2015-05-20',
-      [
-        {
-          self: { uri: "/selfservicepaymentmethods/crugive/giydgnrxgm=" },
-          'account-type': 'Savings'
-        }
-      ]
+      }
     );
+    RecurringGiftModel.nextDrawDate = '2015-05-20';
+    RecurringGiftModel.paymentMethods = [
+      {
+        self: { uri: "/selfservicepaymentmethods/crugive/giydgnrxgm=" },
+        'account-type': 'Savings'
+      }
+    ];
   });
 
   describe('designationName getter', () => {
@@ -97,6 +97,10 @@ describe('recurringGift model', () => {
     it('should load payment id if it has been updated', () => {
       giftModel.gift['updated-payment-method-id'] = 'new id';
       expect(giftModel.paymentMethodId).toEqual('new id');
+    });
+    it('should load the first payment method id if one is not set on the gift', () => {
+      giftModel.gift['payment-method-id'] = '';
+      expect(giftModel.paymentMethodId).toEqual('giydgnrxgm=');
     });
   });
 
@@ -330,10 +334,13 @@ describe('recurringGift model', () => {
 
   describe('initStartMonth', () => {
     it('should use transaction day and nextDrawDate to default updated start month and year', () => {
-      giftModel.gift['updated-recurring-day-of-month'] = '05';
-      giftModel.nextDrawDate = '2015-07-03';
+      giftModel.gift['updated-recurring-day-of-month'] = '20';
       giftModel.initStartMonth();
-      expect(giftModel.startMonth).toEqual('7');
+      expect(giftModel.startMonth).toEqual('5');
+
+      giftModel.gift['updated-recurring-day-of-month'] = '19';
+      giftModel.initStartMonth();
+      expect(giftModel.startMonth).toEqual('6');
     });
   });
 
@@ -408,14 +415,12 @@ describe('recurringGift model', () => {
       expect(giftModel.setDefaults().toObject).toEqual(jasmine.objectContaining({
         'updated-designation-number': giftModel.gift['designation-number'],
         'updated-amount': 50,
-        'updated-payment-method-id': 'giydgnrxgm=',
         'updated-rate': {
           'recurrence': {
             'interval': 'Monthly'
           }
         }
       }));
-      expect(giftModel._paymentMethod).toEqual(giftModel.paymentMethods[0]);
     });
   });
 });

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -91,8 +91,7 @@ class Profile {
         path: ['profiles', this.cortexApiService.scope, 'default'],
         zoom: {
           paymentMethods: 'selfservicepaymentmethods:element[]'
-        },
-        cache: true
+        }
       })
       .pluck('paymentMethods')
       .map((paymentMethods) => {


### PR DESCRIPTION
It might be easier to look at the 2 commits separately as the first makes it possible for nextDrawDate and paymentMethods to be stored only on the RecurringGiftModel and the second removes the old loading methods and bindings in the app for that data.

@Omicron7 Can you make sure I modified your start/stop components correctly?