### PR TITLE
Suggested recipients

### DIFF
--- a/src/common/services/api/donations.service.js
+++ b/src/common/services/api/donations.service.js
@@ -166,7 +166,7 @@ function DonationsService( cortexApiService, profileService, commonService ) {
           return {
             'designation-name':   recipient.definition['display-name'],
             'designation-number': recipient.code['product-code']
-          }
+          };
         } );
       } );
   }

--- a/src/common/services/api/donations.service.js
+++ b/src/common/services/api/donations.service.js
@@ -7,6 +7,7 @@ import flatten from 'lodash/flatten';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/operator/pluck';
+import 'rxjs/add/operator/map';
 
 import cortexApiService from '../cortexApi.service';
 import profileService from './profile.service';
@@ -153,15 +154,33 @@ function DonationsService( cortexApiService, profileService, commonService ) {
     } );
   }
 
+  function getSuggestedRecipients() {
+    return cortexApiService.get( {
+      path: ['donations', 'historical', cortexApiService.scope, 'recipient', 'suggested'],
+      zoom: {
+        recipients: 'element[],element:definition,element:code'
+      }
+    } )
+      .map( ( response ) => {
+        return map( response.recipients, ( recipient ) => {
+          return {
+            'designation-name':   recipient.definition['display-name'],
+            'designation-number': recipient.code['product-code']
+          }
+        } );
+      } );
+  }
+
   return {
-    getHistoricalGifts:   getHistoricalGifts,
-    getRecipients:        getRecipients,
-    getRecipientDetails:  getRecipientDetails,
-    getReceipts:          getReceipts,
-    getRecentRecipients:  getRecentRecipients,
-    getRecurringGifts:    getRecurringGifts,
-    updateRecurringGifts: updateRecurringGifts,
-    addRecurringGifts:    addRecurringGifts
+    getHistoricalGifts:     getHistoricalGifts,
+    getRecipients:          getRecipients,
+    getRecipientDetails:    getRecipientDetails,
+    getReceipts:            getReceipts,
+    getRecentRecipients:    getRecentRecipients,
+    getRecurringGifts:      getRecurringGifts,
+    updateRecurringGifts:   updateRecurringGifts,
+    addRecurringGifts:      addRecurringGifts,
+    getSuggestedRecipients: getSuggestedRecipients
   };
 }
 

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -15,6 +15,7 @@ import activeRecurringGiftsResponse from './fixtures/cortex-donations-recurring-
 import cancelledRecurringGiftsResponse from './fixtures/cortex-donations-recurring-gifts-cancelled.fixture';
 import multipleRecurringGiftsResponse from './fixtures/cortex-donations-recurring-gifts-multiple.fixture';
 import recentRecipientsResponse from './fixtures/cortex-donations-recent-recipients.fixture';
+import suggestedRecipientsResponse from './fixtures/cortex-donations-suggested.fixture';
 
 describe( 'donations service', () => {
   beforeEach( angular.mock.module( module.name ) );
@@ -365,4 +366,38 @@ describe( 'donations service', () => {
       $httpBackend.flush();
     });
   } );
+
+  describe('getSuggestedRecipients', () => {
+    it( 'should load suggested recipients', () => {
+      $httpBackend
+        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/suggested?zoom=element,element:definition,element:code' )
+        .respond( 200, suggestedRecipientsResponse );
+      donationsService.getSuggestedRecipients()
+        .subscribe( ( suggestedRecipients ) => {
+          expect( suggestedRecipients ).toEqual( [
+            jasmine.objectContaining( {
+              "designation-name": "Steve and Cheryl Bratton",
+              "designation-number": "0478064"
+            } ),
+            jasmine.objectContaining( {
+              "designation-name": "Matthew and Katie Watts",
+              "designation-number": "0449995"
+            } ),
+            jasmine.objectContaining( {
+              "designation-name": "James and Gail Rohland",
+              "designation-number": "0138072"
+            } ),
+            jasmine.objectContaining( {
+              "designation-name": "Aaron and Connie Thomson",
+              "designation-number": "0774533"
+            } ),
+            jasmine.objectContaining( {
+              "designation-name": "Red River Region Bridges",
+              "designation-number": "2781843"
+            } )
+          ]);
+        } );
+      $httpBackend.flush();
+    } );
+  });
 } );

--- a/src/common/services/api/fixtures/cortex-donations-suggested.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-suggested.fixture.js
@@ -1,0 +1,699 @@
+export default {
+  "self":     {
+    "type": "elasticpath.collections.links",
+    "uri":  "/donations/historical/crugive/recipient/suggested?zoom=element,element:code,element:definition",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/suggested?zoom=element,element:code,element:definition"
+  },
+  "links":    [{
+    "rel":  "element",
+    "rev":  "list",
+    "type": "elasticpath.items.item",
+    "uri":  "/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+  }, {
+    "rel":  "element",
+    "rev":  "list",
+    "type": "elasticpath.items.item",
+    "uri":  "/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+  }, {
+    "rel":  "element",
+    "rev":  "list",
+    "type": "elasticpath.items.item",
+    "uri":  "/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+  }, {
+    "rel":  "element",
+    "rev":  "list",
+    "type": "elasticpath.items.item",
+    "uri":  "/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+  }, {
+    "rel":  "element",
+    "rev":  "list",
+    "type": "elasticpath.items.item",
+    "uri":  "/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+    "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+  }],
+  "_element": [{
+    "self":        {
+      "type": "elasticpath.items.item",
+      "uri":  "/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    },
+    "links":       [{
+      "rel":  "availability",
+      "rev":  "item",
+      "type": "elasticpath.availabilities.availability",
+      "uri":  "/availabilities/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/availabilities/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "addtocartform",
+      "type": "elasticpath.carts.line-item",
+      "uri":  "/carts/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form"
+    }, {
+      "rel":  "cartmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/carts/memberships/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/memberships/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "definition",
+      "rev":  "item",
+      "type": "elasticpath.itemdefinitions.item-definition",
+      "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "addtocartwithfieldsform",
+      "type": "elasticpath.itemfieldslineitem.item-fields-line-item",
+      "uri":  "/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form"
+    }, {
+      "rel":  "code",
+      "rev":  "item",
+      "type": "elasticpath.lookups.code",
+      "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "price",
+      "rev":  "item",
+      "type": "elasticpath.prices.item-price",
+      "uri":  "/prices/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/prices/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "appliedpromotions",
+      "type": "elasticpath.collections.links",
+      "uri":  "/promotions/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/applied",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/applied"
+    }, {
+      "rel":  "recommendations",
+      "type": "elasticpath.collections.links",
+      "uri":  "/recommendations/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/recommendations/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "wishlistmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+    }, {
+      "rel":  "addtowishlistform",
+      "type": "elasticpath.wishlists.line-item",
+      "uri":  "/wishlists/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/form"
+    }],
+    "_code":       [{
+      "self":         {
+        "type": "elasticpath.extlookups.product-code",
+        "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "code",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      }],
+      "code":         "0478064",
+      "product-code": "0478064"
+    }],
+    "_definition": [{
+      "self":         {
+        "type": "elasticpath.itemdefinitions.item-definition",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "definition",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      }, {
+        "rel":  "options",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/options",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=/options"
+      }, {
+        "rel":  "assets",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      }, {
+        "rel":  "fromprice",
+        "rev":  "definition",
+        "type": "elasticpath.prices.price-range",
+        "uri":  "/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvslvatckwcvrcq="
+      }],
+      "details":      [{
+        "display-name":  "Designation Type",
+        "display-value": "Staff",
+        "name":          "designation_type",
+        "value":         "Staff"
+      }, {
+        "display-name":  "Org ID",
+        "display-value": "STAFF",
+        "name":          "org_id",
+        "value":         "STAFF"
+      }, {
+        "display-name":  "Secure Designation Flag",
+        "display-value": "false",
+        "name":          "secure_flag",
+        "value":         "false"
+      }, {"display-name": "Status", "display-value": "Active", "name": "status", "value": "Active"}],
+      "display-name": "Steve and Cheryl Bratton"
+    }]
+  }, {
+    "self":        {
+      "type": "elasticpath.items.item",
+      "uri":  "/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    },
+    "links":       [{
+      "rel":  "availability",
+      "rev":  "item",
+      "type": "elasticpath.availabilities.availability",
+      "uri":  "/availabilities/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/availabilities/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "addtocartform",
+      "type": "elasticpath.carts.line-item",
+      "uri":  "/carts/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form"
+    }, {
+      "rel":  "cartmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/carts/memberships/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/memberships/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "definition",
+      "rev":  "item",
+      "type": "elasticpath.itemdefinitions.item-definition",
+      "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "addtocartwithfieldsform",
+      "type": "elasticpath.itemfieldslineitem.item-fields-line-item",
+      "uri":  "/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form"
+    }, {
+      "rel":  "code",
+      "rev":  "item",
+      "type": "elasticpath.lookups.code",
+      "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "price",
+      "rev":  "item",
+      "type": "elasticpath.prices.item-price",
+      "uri":  "/prices/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/prices/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "appliedpromotions",
+      "type": "elasticpath.collections.links",
+      "uri":  "/promotions/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/applied",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/applied"
+    }, {
+      "rel":  "recommendations",
+      "type": "elasticpath.collections.links",
+      "uri":  "/recommendations/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/recommendations/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "wishlistmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+    }, {
+      "rel":  "addtowishlistform",
+      "type": "elasticpath.wishlists.line-item",
+      "uri":  "/wishlists/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=/form"
+    }],
+    "_code":       [{
+      "self":         {
+        "type": "elasticpath.extlookups.product-code",
+        "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "code",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      }],
+      "code":         "0449995",
+      "product-code": "0449995"
+    }],
+    "_definition": [{
+      "self":         {
+        "type": "elasticpath.itemdefinitions.item-definition",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "definition",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      }, {
+        "rel":  "options",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=/options",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=/options"
+      }, {
+        "rel":  "assets",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      }, {
+        "rel":  "fromprice",
+        "rev":  "definition",
+        "type": "elasticpath.prices.price-range",
+        "uri":  "/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvslfaxktbyju="
+      }],
+      "details":      [{
+        "display-name":  "Designation Type",
+        "display-value": "Staff",
+        "name":          "designation_type",
+        "value":         "Staff"
+      }, {
+        "display-name":  "Org ID",
+        "display-value": "STAFF",
+        "name":          "org_id",
+        "value":         "STAFF"
+      }, {
+        "display-name":  "Secure Designation Flag",
+        "display-value": "false",
+        "name":          "secure_flag",
+        "value":         "false"
+      }, {"display-name": "Status", "display-value": "Active", "name": "status", "value": "Active"}],
+      "display-name": "Matthew and Katie Watts"
+    }]
+  }, {
+    "self":        {
+      "type": "elasticpath.items.item",
+      "uri":  "/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    },
+    "links":       [{
+      "rel":  "availability",
+      "rev":  "item",
+      "type": "elasticpath.availabilities.availability",
+      "uri":  "/availabilities/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/availabilities/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "addtocartform",
+      "type": "elasticpath.carts.line-item",
+      "uri":  "/carts/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form"
+    }, {
+      "rel":  "cartmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/carts/memberships/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/memberships/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "definition",
+      "rev":  "item",
+      "type": "elasticpath.itemdefinitions.item-definition",
+      "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "addtocartwithfieldsform",
+      "type": "elasticpath.itemfieldslineitem.item-fields-line-item",
+      "uri":  "/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form"
+    }, {
+      "rel":  "code",
+      "rev":  "item",
+      "type": "elasticpath.lookups.code",
+      "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "price",
+      "rev":  "item",
+      "type": "elasticpath.prices.item-price",
+      "uri":  "/prices/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/prices/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "appliedpromotions",
+      "type": "elasticpath.collections.links",
+      "uri":  "/promotions/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/applied",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/applied"
+    }, {
+      "rel":  "recommendations",
+      "type": "elasticpath.collections.links",
+      "uri":  "/recommendations/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/recommendations/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "wishlistmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/memberships/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+    }, {
+      "rel":  "addtowishlistform",
+      "type": "elasticpath.wishlists.line-item",
+      "uri":  "/wishlists/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/form"
+    }],
+    "_code":       [{
+      "self":         {
+        "type": "elasticpath.extlookups.product-code",
+        "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "code",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      }],
+      "code":         "0138072",
+      "product-code": "0138072"
+    }],
+    "_definition": [{
+      "self":         {
+        "type": "elasticpath.itemdefinitions.item-definition",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "definition",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      }, {
+        "rel":  "options",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/options",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=/options"
+      }, {
+        "rel":  "assets",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/assets/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      }, {
+        "rel":  "fromprice",
+        "rev":  "definition",
+        "type": "elasticpath.prices.price-range",
+        "uri":  "/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/prices/itemdefinitions/crugive/a5t4fmspmfpwpqvllbatckwdqi2q="
+      }],
+      "details":      [{
+        "display-name":  "Designation Type",
+        "display-value": "Staff",
+        "name":          "designation_type",
+        "value":         "Staff"
+      }, {
+        "display-name":  "Org ID",
+        "display-value": "STAFF",
+        "name":          "org_id",
+        "value":         "STAFF"
+      }, {
+        "display-name":  "Secure Designation Flag",
+        "display-value": "false",
+        "name":          "secure_flag",
+        "value":         "false"
+      }, {"display-name": "Status", "display-value": "Active", "name": "status", "value": "Active"}],
+      "display-name": "James and Gail Rohland"
+    }]
+  }, {
+    "self":        {
+      "type": "elasticpath.items.item",
+      "uri":  "/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    },
+    "links":       [{
+      "rel":  "availability",
+      "rev":  "item",
+      "type": "elasticpath.availabilities.availability",
+      "uri":  "/availabilities/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/availabilities/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "addtocartform",
+      "type": "elasticpath.carts.line-item",
+      "uri":  "/carts/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form"
+    }, {
+      "rel":  "cartmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/carts/memberships/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/memberships/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "definition",
+      "rev":  "item",
+      "type": "elasticpath.itemdefinitions.item-definition",
+      "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "addtocartwithfieldsform",
+      "type": "elasticpath.itemfieldslineitem.item-fields-line-item",
+      "uri":  "/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemfieldslineitem/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form"
+    }, {
+      "rel":  "code",
+      "rev":  "item",
+      "type": "elasticpath.lookups.code",
+      "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "price",
+      "rev":  "item",
+      "type": "elasticpath.prices.item-price",
+      "uri":  "/prices/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/prices/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "appliedpromotions",
+      "type": "elasticpath.collections.links",
+      "uri":  "/promotions/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/applied",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/applied"
+    }, {
+      "rel":  "recommendations",
+      "type": "elasticpath.collections.links",
+      "uri":  "/recommendations/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/recommendations/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "wishlistmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/wishlists/memberships/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/memberships/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+    }, {
+      "rel":  "addtowishlistform",
+      "type": "elasticpath.wishlists.line-item",
+      "uri":  "/wishlists/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/form"
+    }],
+    "_code":       [{
+      "self":         {
+        "type": "elasticpath.extlookups.product-code",
+        "uri":  "/lookups/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "code",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      }],
+      "code":         "0774533",
+      "product-code": "0774533"
+    }],
+    "_definition": [{
+      "self":         {
+        "type": "elasticpath.itemdefinitions.item-definition",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "definition",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      }, {
+        "rel":  "options",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/options",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=/options"
+      }, {
+        "rel":  "assets",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/assets/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/assets/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      }, {
+        "rel":  "fromprice",
+        "rev":  "definition",
+        "type": "elasticpath.prices.price-range",
+        "uri":  "/prices/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/prices/itemdefinitions/crugive/a5t4fmspmfpwpqv5lu7tes2yhu="
+      }],
+      "details":      [{
+        "display-name":  "Designation Type",
+        "display-value": "Staff",
+        "name":          "designation_type",
+        "value":         "Staff"
+      }, {
+        "display-name":  "Org ID",
+        "display-value": "STAFF",
+        "name":          "org_id",
+        "value":         "STAFF"
+      }, {
+        "display-name":  "Secure Designation Flag",
+        "display-value": "false",
+        "name":          "secure_flag",
+        "value":         "false"
+      }, {"display-name": "Status", "display-value": "Active", "name": "status", "value": "Active"}],
+      "display-name": "Aaron and Connie Thomson"
+    }]
+  }, {
+    "self":        {
+      "type": "elasticpath.items.item",
+      "uri":  "/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    },
+    "links":       [{
+      "rel":  "availability",
+      "rev":  "item",
+      "type": "elasticpath.availabilities.availability",
+      "uri":  "/availabilities/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/availabilities/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "addtocartform",
+      "type": "elasticpath.carts.line-item",
+      "uri":  "/carts/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form"
+    }, {
+      "rel":  "cartmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/carts/memberships/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/carts/memberships/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "definition",
+      "rev":  "item",
+      "type": "elasticpath.itemdefinitions.item-definition",
+      "uri":  "/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "addtocartwithfieldsform",
+      "type": "elasticpath.itemfieldslineitem.item-fields-line-item",
+      "uri":  "/itemfieldslineitem/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/itemfieldslineitem/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form"
+    }, {
+      "rel":  "code",
+      "rev":  "item",
+      "type": "elasticpath.lookups.code",
+      "uri":  "/lookups/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "price",
+      "rev":  "item",
+      "type": "elasticpath.prices.item-price",
+      "uri":  "/prices/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/prices/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "appliedpromotions",
+      "type": "elasticpath.collections.links",
+      "uri":  "/promotions/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/applied",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/promotions/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/applied"
+    }, {
+      "rel":  "recommendations",
+      "type": "elasticpath.collections.links",
+      "uri":  "/recommendations/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/recommendations/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "wishlistmemberships",
+      "type": "elasticpath.collections.links",
+      "uri":  "/wishlists/memberships/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/memberships/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+    }, {
+      "rel":  "addtowishlistform",
+      "type": "elasticpath.wishlists.line-item",
+      "uri":  "/wishlists/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form",
+      "href": "https://cortex-gateway-stage.cru.org/cortex/wishlists/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/form"
+    }],
+    "_code":       [{
+      "self":         {
+        "type": "elasticpath.extlookups.product-code",
+        "uri":  "/lookups/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/lookups/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "code",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      }],
+      "code":         "2781843",
+      "product-code": "2781843"
+    }],
+    "_definition": [{
+      "self":         {
+        "type": "elasticpath.itemdefinitions.item-definition",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      },
+      "links":        [{
+        "rel":  "item",
+        "rev":  "definition",
+        "type": "elasticpath.items.item",
+        "uri":  "/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/items/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      }, {
+        "rel":  "options",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/options",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=/options"
+      }, {
+        "rel":  "assets",
+        "rev":  "definition",
+        "type": "elasticpath.collections.links",
+        "uri":  "/assets/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/assets/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      }, {
+        "rel":  "fromprice",
+        "rev":  "definition",
+        "type": "elasticpath.prices.price-range",
+        "uri":  "/prices/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu=",
+        "href": "https://cortex-gateway-stage.cru.org/cortex/prices/itemdefinitions/crugive/a5t4fmspmfpw7qv5ly6xkktkhu="
+      }],
+      "details":      [{
+        "display-name":  "Designation Type",
+        "display-value": "Project",
+        "name":          "designation_type",
+        "value":         "Project"
+      }, {
+        "display-name":  "Org ID",
+        "display-value": "BRIDGE",
+        "name":          "org_id",
+        "value":         "BRIDGE"
+      }, {
+        "display-name":  "Replacement Designation ID",
+        "display-value": "2781843",
+        "name":          "replacement_designation_id",
+        "value":         "2781843"
+      }, {
+        "display-name":  "Secure Designation Flag",
+        "display-value": "false",
+        "name":          "secure_flag",
+        "value":         "false"
+      }, {"display-name": "Status", "display-value": "Active", "name": "status", "value": "Active"}],
+      "display-name": "Red River Region Bridges"
+    }]
+  }]
+};


### PR DESCRIPTION
Adds a getSuggestedRecipients endpoint to donationsService. This gets a suggested list of donors based off of recent recipients who the donor isn't currently giving to. Path is hardcoded since zoom would of had to go through managerecurringdonations (active donations) and we don't require fetching that. 