### PR TITLE
Take current date and a gift's existing start date into account when …

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-rename": "^1.2.2",
     "jasmine-core": "^2.5.2",
     "jasmine-promise-matchers": "^2.2.0",
-    "jspm": "^0.16.42",
+    "jspm": "^0.16.47",
     "karma": "^1.2.0",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chrome-launcher": "^2.0.0",
@@ -55,7 +55,6 @@
     "require-dir": "^0.3.0",
     "rsvp": "^3.2.1",
     "run-sequence": "^1.1.5",
-    "systemjs": "^0.19.27",
     "systemjs-plugin-babel": "^0.0.13",
     "vinyl-paths": "^2.1.0",
     "proxy-middleware": "^0.15.0"

--- a/src/app/productConfig/productConfig.modal.spec.js
+++ b/src/app/productConfig/productConfig.modal.spec.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import 'angular-mocks';
 import module, {giftAddedEvent} from './productConfig.modal';
+import moment from 'moment';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/of';
@@ -16,6 +17,7 @@ describe( 'product config modal', function () {
     uibModalInstance = jasmine.createSpyObj( 'uibModalInstance', ['close', 'dismiss'] );
     productData = {};
     nextDrawDate = '2016-10-01';
+    jasmine.clock().mockDate( moment.utc('2016-10-01').toDate() );
     itemConfig = {
       amount: 85
     };

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -29,6 +29,9 @@ export default class RecurringGiftModel {
         },
         'next-draw-date': {
           'display-value': ''
+        },
+        'start-date': {
+          'display-value': ''
         }
       };
     }
@@ -140,7 +143,7 @@ export default class RecurringGiftModel {
   }
 
   set startMonth(value){
-    let updatedStartDate = moment(startMonth(this.transactionDay, value, this.nextDrawDate));
+    let updatedStartDate = moment(startMonth(this.transactionDay, value, this.nextDrawDate, 0, this.parentDonation['start-date']['display-value']));
     if(updatedStartDate.isSame(this.parentDonation['next-draw-date']['display-value'], 'month') || this.gift['updated-rate']['recurrence']['interval'] === '' && this.gift['updated-recurring-day-of-month'] === '' && moment(this.parentDonation['next-draw-date']['display-value']).format('M') === updatedStartDate.format('M')){
       this.clearStartDate(); // Don't need to update start date if draw date year and month are still correct, or if frequency, transaction day, and start month are unchanged
     }else {
@@ -155,7 +158,7 @@ export default class RecurringGiftModel {
       giftDate = moment({ year: this.gift['updated-start-year'], month: parseInt(this.gift['updated-start-month']) - 1, day: this.transactionDay });
     }else if(this.gift['updated-recurring-day-of-month'] !== ''){
       // We have to take transactionDay into account here when it is modified for monthly gifts since they don't set the updated-start-month/year fields
-      giftDate = startDate(this.transactionDay, this.nextDrawDate);
+      giftDate = startDate(this.transactionDay, this.nextDrawDate, 0, this.parentDonation['start-date']['display-value']);
     }else{
       giftDate = moment(this.parentDonation['next-draw-date']['display-value']);
     }
@@ -163,7 +166,7 @@ export default class RecurringGiftModel {
   }
 
   initStartMonth(){
-    this.startMonth = startDate(this.transactionDay, this.nextDrawDate).format('MM');
+    this.startMonth = startDate(this.transactionDay, this.nextDrawDate, 0, this.parentDonation['start-date']['display-value']).format('MM');
   }
 
   clearStartDate(){

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -29,7 +29,8 @@ describe('recurringGift model', () => {
         'effective-status': "Active",
         rate: {recurrence: {interval: 'Monthly'}},
         'recurring-day-of-month': '15',
-        'next-draw-date': {'display-value': '2015-05-06', value: 1430895600}
+        'next-draw-date': {'display-value': '2015-05-06', value: 1430895600},
+        'start-date': {'display-value': '2015-04-06', value: 1428303600}
       }
     );
     RecurringGiftModel.nextDrawDate = '2015-05-20';
@@ -39,6 +40,7 @@ describe('recurringGift model', () => {
         'account-type': 'Savings'
       }
     ];
+    jasmine.clock().mockDate(moment('2015-05-07').toDate());
   });
 
   describe('constructor', () => {
@@ -66,6 +68,9 @@ describe('recurringGift model', () => {
           }
         },
         'next-draw-date': {
+          'display-value': ''
+        },
+        'start-date': {
           'display-value': ''
         }
       });

--- a/src/common/services/giftHelpers/giftDates.service.js
+++ b/src/common/services/giftHelpers/giftDates.service.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import range from 'lodash/range';
 import map from 'lodash/map';
+import reduce from 'lodash/reduce';
 
 export function possibleTransactionDays() {
   return range( 1, 29 ).map((i) => (`0${i}`).slice(-2));
@@ -9,7 +10,7 @@ export function possibleTransactionDays() {
 // Generate a string of 4 months based on transactionDay and nextDrawDate
 export function quarterlyMonths(transactionDay, nextDrawDate, monthOffset){
   monthOffset = monthOffset || 0;
-  nextDrawDate = startDate(transactionDay, nextDrawDate).add(monthOffset, 'months');
+  nextDrawDate = startDate(transactionDay, nextDrawDate, monthOffset);
   let months = map(range(4), index => {
     return nextDrawDate.clone().add(index, 'quarters').format('MMMM');
   });
@@ -17,25 +18,40 @@ export function quarterlyMonths(transactionDay, nextDrawDate, monthOffset){
   return months.join(', ');
 }
 
-// Given a transactionDay, find the next occurrence of that day on or after nextDrawDate
-export function startDate(transactionDay, nextDrawDate, monthOffset){
+// Given a transactionDay, find the next occurrence of that day on or after nextDrawDate and startDate
+export function startDate(transactionDay, nextDrawDate, monthOffset, startDate){
   monthOffset = monthOffset || 0;
-  let transactionDate = moment(nextDrawDate);
+  let earliestValidDate = _earliestValidDate(nextDrawDate, startDate);
+  let transactionDate = earliestValidDate.clone();
   if(transactionDay){
     transactionDate.date(transactionDay);
   }
-  if(transactionDate.isBefore(nextDrawDate)){
+  if(transactionDate.isBefore(earliestValidDate)){
     monthOffset++;
   }
   return transactionDate.add(monthOffset, 'months');
 }
 
-// Given a transactionDay and month, find the next occurrence of that month and day on or after nextDrawDate
-export function startMonth(transactionDay, month, nextDrawDate, monthOffset){
+// Given a transactionDay and month, find the next occurrence of that month and day on or after nextDrawDate or startDate
+export function startMonth(transactionDay, month, nextDrawDate, monthOffset, startDate){
   monthOffset = monthOffset || 0;
-  let transactionDate = moment(nextDrawDate).month(parseInt(month) - 1).date(transactionDay);
-  if(transactionDate.isBefore(nextDrawDate)){
+  let earliestValidDate = _earliestValidDate(nextDrawDate, startDate);
+  let transactionDate = earliestValidDate.clone().month(parseInt(month) - 1).date(transactionDay);
+  if(transactionDate.isBefore(earliestValidDate)){
     transactionDate.add(1, 'years');
   }
   return transactionDate.add(monthOffset, 'months');
+}
+
+export function _earliestValidDate(nextDrawDate, startDate){
+  // Find greatest of today's date, nextDrawDate, and startDate
+  let utcGreatest = reduce([nextDrawDate, startDate], (result, date) => {
+    let utcDate = moment.utc(date); // Compare all dates in UTC
+    return result.isBefore(utcDate) ? utcDate : result;
+  }, moment.utc()); // Use today's date in UTC as the starting value to compare with nextDrawDate and startDate
+
+  // Toss all timezone info and pretend the date is at midnight in the browser's timezone
+  // like the rest of the dates in the app that are used for display only.
+  // The date shown this way is really the UTC date.
+  return moment(utcGreatest.format('YYYY-MM-DD'));
 }

--- a/system.config.js
+++ b/system.config.js
@@ -23,12 +23,12 @@ System.config({
     "angular-animate": "github:angular/bower-angular-animate@1.5.8",
     "angular-cookies": "github:angular/bower-angular-cookies@1.5.8",
     "angular-environment": "npm:angular-environment@1.0.4",
-    "angular-gettext": "github:rubenv/angular-gettext@2.3.6",
+    "angular-gettext": "github:rubenv/angular-gettext@2.3.8",
     "angular-messages": "github:angular/bower-angular-messages@1.5.8",
     "angular-mocks": "github:angular/bower-angular-mocks@1.5.8",
     "angular-ordinal": "npm:angular-ordinal@2.1.3",
     "angular-sanitize": "github:angular/bower-angular-sanitize@1.5.8",
-    "angular-ui-bootstrap": "npm:angular-ui-bootstrap@2.1.3",
+    "angular-ui-bootstrap": "npm:angular-ui-bootstrap@2.2.0",
     "angular-ui-router": "github:angular-ui/ui-router@0.3.1",
     "angular-upload": "npm:angular-upload@1.0.13",
     "babel": "npm:babel-core@5.8.38",
@@ -36,12 +36,12 @@ System.config({
     "core-js": "npm:core-js@1.2.7",
     "jsencrypt": "npm:jsencrypt@2.3.1",
     "jwt-decode": "github:auth0/jwt-decode@2.1.0",
-    "lodash": "npm:lodash@4.15.0",
+    "lodash": "npm:lodash@4.16.6",
     "mobile-detect": "npm:mobile-detect@1.3.3",
-    "moment": "npm:moment@2.15.1",
+    "moment": "npm:moment@2.15.2",
     "plugin-babel": "npm:systemjs-plugin-babel@0.0.13",
     "plugin-babel-runtime": "npm:babel-runtime@5.8.38",
-    "rollbar-browser": "npm:rollbar-browser@1.9.1",
+    "rollbar-browser": "npm:rollbar-browser@1.9.2",
     "rxjs": "npm:rxjs@5.0.0-rc.3",
     "stacktrace-js": "npm:stacktrace-js@1.3.1",
     "systemjs-babel-build": "npm:systemjs-plugin-babel@0.0.13/systemjs-babel-browser.js",
@@ -97,7 +97,7 @@ System.config({
     "npm:align-text@0.1.4": {
       "kind-of": "npm:kind-of@3.0.4",
       "longest": "npm:longest@1.0.1",
-      "repeat-string": "npm:repeat-string@1.5.4"
+      "repeat-string": "npm:repeat-string@1.6.1"
     },
     "npm:angular-ordinal@2.1.3": {
       "ordinal-number-suffix": "npm:ordinal-number-suffix@0.1.1"
@@ -155,10 +155,12 @@ System.config({
       "wordwrap": "npm:wordwrap@0.0.2"
     },
     "npm:clone-stats@0.0.1": {
-      "fs": "github:jspm/nodelibs-fs@0.1.2"
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:clone@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "vm": "github:jspm/nodelibs-vm@0.1.0"
     },
     "npm:constants-browserify@0.0.1": {
@@ -174,7 +176,7 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:currently-unhandled@0.4.1": {
-      "array-find-index": "npm:array-find-index@1.0.1",
+      "array-find-index": "npm:array-find-index@1.0.2",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:dateformat@1.0.12": {
@@ -182,7 +184,8 @@ System.config({
       "meow": "npm:meow@3.7.0"
     },
     "npm:duplexer2@0.0.2": {
-      "readable-stream": "npm:readable-stream@1.1.14"
+      "readable-stream": "npm:readable-stream@1.1.14",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:error-ex@1.3.0": {
       "is-arrayish": "npm:is-arrayish@0.2.1",
@@ -212,7 +215,7 @@ System.config({
       "sparkles": "npm:sparkles@1.0.0",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:graceful-fs@4.1.6": {
+    "npm:graceful-fs@4.1.10": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "constants": "github:jspm/nodelibs-constants@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -283,8 +286,8 @@ System.config({
     "npm:is-builtin-module@1.0.0": {
       "builtin-modules": "npm:builtin-modules@1.1.1"
     },
-    "npm:is-finite@1.0.1": {
-      "number-is-nan": "npm:number-is-nan@1.0.0"
+    "npm:is-finite@1.0.2": {
+      "number-is-nan": "npm:number-is-nan@1.0.1"
     },
     "npm:isarray@1.0.0": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
@@ -306,7 +309,7 @@ System.config({
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:load-json-file@1.1.0": {
-      "graceful-fs": "npm:graceful-fs@4.1.6",
+      "graceful-fs": "npm:graceful-fs@4.1.10",
       "parse-json": "npm:parse-json@2.2.0",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "pify": "npm:pify@2.3.0",
@@ -344,7 +347,8 @@ System.config({
     "npm:loud-rejection@1.6.0": {
       "currently-unhandled": "npm:currently-unhandled@0.4.1",
       "process": "github:jspm/nodelibs-process@0.1.2",
-      "signal-exit": "npm:signal-exit@3.0.0",
+      "signal-exit": "npm:signal-exit@3.0.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:meow@3.7.0": {
@@ -390,7 +394,7 @@ System.config({
       "pinkie-promise": "npm:pinkie-promise@2.0.1"
     },
     "npm:path-type@1.1.0": {
-      "graceful-fs": "npm:graceful-fs@4.1.6",
+      "graceful-fs": "npm:graceful-fs@4.1.10",
       "pify": "npm:pify@2.3.0",
       "pinkie-promise": "npm:pinkie-promise@2.0.1"
     },
@@ -401,7 +405,8 @@ System.config({
       "pinkie": "npm:pinkie@2.0.4"
     },
     "npm:process-nextick-args@1.0.7": {
-      "process": "github:jspm/nodelibs-process@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:process@0.11.9": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
@@ -447,7 +452,7 @@ System.config({
       "strip-indent": "npm:strip-indent@1.0.1"
     },
     "npm:repeating@2.0.1": {
-      "is-finite": "npm:is-finite@1.0.1"
+      "is-finite": "npm:is-finite@1.0.2"
     },
     "npm:replace-ext@0.0.1": {
       "path": "github:jspm/nodelibs-path@0.1.0"
@@ -455,7 +460,7 @@ System.config({
     "npm:right-align@0.1.3": {
       "align-text": "npm:align-text@0.1.4"
     },
-    "npm:rollbar-browser@1.9.1": {
+    "npm:rollbar-browser@1.9.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "console-polyfill": "npm:console-polyfill@0.2.2",
       "error-stack-parser": "npm:error-stack-parser@1.3.3",
@@ -474,7 +479,7 @@ System.config({
     "npm:semver@5.3.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:signal-exit@3.0.0": {
+    "npm:signal-exit@3.0.1": {
       "assert": "github:jspm/nodelibs-assert@0.1.0",
       "events": "github:jspm/nodelibs-events@0.1.1",
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -488,9 +493,10 @@ System.config({
     "npm:spdx-correct@1.0.2": {
       "spdx-license-ids": "npm:spdx-license-ids@1.2.2"
     },
-    "npm:spdx-expression-parse@1.0.2": {
-      "spdx-exceptions": "npm:spdx-exceptions@1.0.5",
-      "spdx-license-ids": "npm:spdx-license-ids@1.2.2"
+    "npm:spdx-expression-parse@1.0.4": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:spdx-license-ids@1.2.2": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
@@ -579,7 +585,7 @@ System.config({
     },
     "npm:validate-npm-package-license@3.0.1": {
       "spdx-correct": "npm:spdx-correct@1.0.2",
-      "spdx-expression-parse": "npm:spdx-expression-parse@1.0.2"
+      "spdx-expression-parse": "npm:spdx-expression-parse@1.0.4"
     },
     "npm:vinyl-sourcemaps-apply@0.2.1": {
       "source-map": "npm:source-map@0.5.6"


### PR DESCRIPTION
…determining when a gift should start

- Add _earliestValidDate function to determine the greatest of nextDrawDate, startDate, and the current date
- Add moment timezone
- Remove explicit systemjs dependency as jspm includes the version it wants
- Update some packages

@Omicron7 @adammeyer @wrandall22 This still needs some tests, but could you look over it? I added moment-timezone but it seems like a little overkill just to convert to Florida server time (or AWS East, wherever the server is). It does need to take into account DST though... Maybe I could figure out how to import just the America/New_York timezone.

I'm still a little unclear on how we want to handle dates. No one has expressed that having dates off by a day for users in other timezones matters (except for sometimes/somewhere using Pacific Time to handle end of the year gifts that are given before midnight on the west coast). So this converts the browser's current date to Eastern Time for comparison with the other values. Hopefully the values coming from the api are in Eastern Time (which is what I was told) but the `value`s (not the `display-value`s) seem to be at midnight UTC unless I'm reading them wrong. We've been using the `display-values` everywhere as if they were in the user's current timezone.

This is https://jira.cru.org/browse/EP-1412. Thanks :)