### PR TITLE
[#EP-1433] Nav SignOut downgrades role to PUBLIC and keeps cart.

### DIFF
--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -24,11 +24,12 @@ let componentName = 'cruNav';
 class NavController{
 
   /* @ngInject */
-  constructor($rootScope, $http, $document, $window, envService, cartService, sessionService, sessionModalService){
+  constructor($rootScope, $http, $document, $window, $timeout, envService, cartService, sessionService, sessionModalService){
     this.$http = $http;
     this.$document = $document;
     this.$window = $window;
     this.$rootScope = $rootScope;
+    this.$timeout = $timeout;
 
     this.cartService = cartService;
     this.sessionService = sessionService;
@@ -94,16 +95,17 @@ class NavController{
     this.sessionModalService
       .signIn()
       .then( () => {
-        this.$window.location.reload();
+        // use $timeout here as workaround to Firefox bug
+        this.$timeout(this.$window.location.reload);
       } );
   }
 
   signOut() {
-    this.sessionService
-      .signOut()
-      .then( () => {
-        this.$window.location.reload();
-      } );
+    this.sessionService.downgradeToGuest().subscribe( () => {
+      this.$timeout(this.$window.location.reload);
+    }, () => {
+      this.$timeout(this.$window.location.reload);
+    } );
   }
 
   sessionChanged() {

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -126,7 +126,7 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
   }
 
   function downgradeToGuest() {
-    if ( currentRole() !== Roles.identified ) return Observable.throw( 'must be IDENTIFIED' );
+    if ( currentRole() == Roles.public ) return Observable.throw( 'must be IDENTIFIED' );
     return Observable
       .from( $http( {
         method:          'POST',

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -226,14 +226,7 @@ describe( 'session service', function () {
   } );
 
   describe( 'downgradeToGuest', () => {
-    describe( 'with \'REGISTERED\' role', () => {
-      beforeEach( () => {
-        $cookies.put( Sessions.cortex, cortexSession.registered );
-        $cookies.put( Sessions.give, giveSession );
-        // Force digest so scope session watchers pick up changes.
-        $rootScope.$digest();
-      } );
-
+    describe( 'with \'PUBLIC\' role', () => {
       it( 'throws error', () => {
         sessionService.downgradeToGuest().subscribe( angular.noop, ( error ) => {
           expect( error ).toBeDefined();


### PR DESCRIPTION
This PR changes the Nav signOut to use the downgrade functionality. This downgrades an IDENTIFIED/REGISTERED role to PUBLIC while keeping the contents of the cart. This should also fix the firefox issue of the page not reloading on role change.

This is based off #256 