### PR TITLE
Fix card number validation. Code was changed to use an inline functio…

### DIFF
--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -81,7 +81,7 @@ class CreditCardController {
     this.creditCardPaymentForm.cardNumber.$parsers.push(this.paymentValidationService.stripNonDigits);
     this.creditCardPaymentForm.cardNumber.$validators.minlength = number => this.paymentMethod && !number || toString(number).length >= 13;
     this.creditCardPaymentForm.cardNumber.$validators.maxlength = number => toString(number).length <= 16;
-    this.creditCardPaymentForm.cardNumber.$validators.cardNumber = number => this.paymentMethod && !number || this.paymentValidationService.validateCardNumber();
+    this.creditCardPaymentForm.cardNumber.$validators.cardNumber = number => this.paymentMethod && !number || this.paymentValidationService.validateCardNumber()(number);
 
     this.creditCardPaymentForm.expiryMonth.$validators.expired = expiryMonth => {
       let currentDate = new Date();

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -284,11 +284,15 @@ describe('credit card form', () => {
         expect(self.formController.cardNumber.$error.required).toBeUndefined();
         expect(self.formController.cardNumber.$error.minlength).toEqual(true);
       });
-      it('should not be valid if the input is too lond',  () => {
+      it('should not be valid if the input is too long',  () => {
         self.formController.cardNumber.$setViewValue('12345678901234567');
         expect(self.formController.cardNumber.$valid).toEqual(false);
         expect(self.formController.cardNumber.$error.required).toBeUndefined();
         expect(self.formController.cardNumber.$error.maxlength).toEqual(true);
+      });
+      it('should not be valid if it contains an invalid card number',  () => {
+        self.formController.cardNumber.$setViewValue('411111111111111'); // Missing 1 digit
+        expect(self.formController.cardNumber.$valid).toEqual(false);
       });
       it('should be valid if it contains a valid card number',  () => {
         self.formController.cardNumber.$setViewValue('4111111111111111');


### PR DESCRIPTION
…n with additional validation but the original function was not called in the changes.

I broke this when allowing it to edit payment methods. Angular expects a function which is what it was using before but I never called the validator function in my new inline function.