### PR TITLE
Refactor validPaymentMethods out into its own helper

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
@@ -1,6 +1,4 @@
 import angular from 'angular';
-import moment from 'moment';
-import filter from 'lodash/filter';
 import map from 'lodash/map';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/forkJoin';
@@ -19,6 +17,7 @@ import RecurringGiftModel from 'common/models/recurringGift.model';
 import profileService from 'common/services/api/profile.service';
 import donationsService from 'common/services/api/donations.service';
 import commonService from 'common/services/api/common.service';
+import validPaymentMethods from 'common/services/paymentHelpers/validPaymentMethods';
 
 import template from './editRecurringGifts.modal.tpl';
 
@@ -49,9 +48,7 @@ class EditRecurringGiftsModalController {
         this.paymentMethods = paymentMethods;
         this.nextDrawDate = nextDrawDate;
         this.hasPaymentMethods = paymentMethods && paymentMethods.length > 0;
-        this.validPaymentMethods = filter(paymentMethods, (paymentMethod) => {
-          return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1}).isSameOrAfter(moment(), 'month');
-        });
+        this.validPaymentMethods = validPaymentMethods(paymentMethods);
         this.hasValidPaymentMethods = this.validPaymentMethods && this.validPaymentMethods.length > 0;
         RecurringGiftModel.paymentMethods = this.validPaymentMethods;
         RecurringGiftModel.nextDrawDate = this.nextDrawDate;

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -5,8 +5,8 @@
         <div class="col-xs-12">
           <div class="border-bottom-small">
             <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()"><span aria-hidden="true">&times;</span></button>
-            <h3>Checking Payment Methods</h3>
-            <p>You must have at least one valid payment method to continue</p>
+            <h3 translate>Checking Payment Methods</h3>
+            <p translate>You must have at least one valid payment method to continue</p>
           </div>
         </div>
       </div>
@@ -17,8 +17,8 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-md-12 col-xs-12">
-          <div class="text-center" translate>
-            Loading payment information...
+          <div class="text-center">
+            <translate>Loading payment information...</translate>
             <loading inline="true"></loading>
           </div>
         </div>

--- a/src/common/services/paymentHelpers/validPaymentMethods.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.js
@@ -1,0 +1,11 @@
+import filter from 'lodash/filter';
+import moment from 'moment';
+
+// Filter out expired credit cards
+function validPaymentMethods(paymentMethods){
+  return filter(paymentMethods, (paymentMethod) => {
+    return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1}).isSameOrAfter(moment(), 'month');
+  });
+}
+
+export default validPaymentMethods;

--- a/src/common/services/paymentHelpers/validPaymentMethods.spec.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.spec.js
@@ -1,0 +1,95 @@
+import validPaymentMethods from './validPaymentMethods';
+
+describe('validPaymentMethods', () => {
+  beforeEach(() => {
+    jasmine.clock().mockDate(new Date(2015, 0, 10));
+  });
+  it('should return bank accounts', () => {
+    let paymentMethods = [{
+      self: {
+        type: 'elasticpath.bankaccounts.bank-account'
+      }
+    }];
+    expect(validPaymentMethods(paymentMethods)).toEqual(paymentMethods);
+  });
+  it('should return active credit cards', () => {
+    let paymentMethods = [{
+      self: {
+        type: 'cru.creditcards.named-credit-card'
+      },
+      'expiry-month': '01',
+      'expiry-year': '2015'
+    }];
+    expect(validPaymentMethods(paymentMethods)).toEqual(paymentMethods);
+  });
+  it('should filter out inactive credit cards', () => {
+    let paymentMethods = [{
+      self: {
+        type: 'cru.creditcards.named-credit-card'
+      },
+      'expiry-month': '12',
+      'expiry-year': '2014'
+    }];
+    expect(validPaymentMethods(paymentMethods)).toEqual([]);
+  });
+  it('should handle no payment methods', () => {
+    let paymentMethods = [];
+    expect(validPaymentMethods(paymentMethods)).toEqual([]);
+  });
+  it('should handle several payment methods', () => {
+    let paymentMethods = [
+      {
+        self: {
+          type: 'elasticpath.bankaccounts.bank-account'
+        }
+      },
+      {
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        },
+        'expiry-month': '01',
+        'expiry-year': '2015'
+      },
+      {
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        },
+        'expiry-month': '12',
+        'expiry-year': '2014'
+      },
+      {
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        },
+        'expiry-month': '02',
+        'expiry-year': '2015'
+      },
+      {
+        self: {
+          type: 'elasticpath.bankaccounts.bank-account'
+        }
+      },
+      {
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        },
+        'expiry-month': '01',
+        'expiry-year': '2014'
+      },
+      {
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        },
+        'expiry-month': '01',
+        'expiry-year': '2016'
+      }
+    ];
+    expect(validPaymentMethods(paymentMethods)).toEqual([
+      paymentMethods[0],
+      paymentMethods[1],
+      paymentMethods[3],
+      paymentMethods[4],
+      paymentMethods[6]
+    ]);
+  });
+});


### PR DESCRIPTION
- Add translate tags

@denlight I moved these lines out to be more reusable. I figured I should get this merged since you were working with this code for your restarting gifts payment stuff.