### PR TITLE
[#EP-1525] Added skipEvent flag to downgradeToGuest

### DIFF
--- a/src/app/signIn/signIn.component.js
+++ b/src/app/signIn/signIn.component.js
@@ -31,7 +31,7 @@ class SignInController {
   }
 
   checkoutAsGuest() {
-    this.sessionService.downgradeToGuest().subscribe( {
+    this.sessionService.downgradeToGuest( true ).subscribe( {
       error:    () => {
         this.$window.location = '/checkout.html';
       },

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -129,7 +129,7 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
       .map( ( response ) => response.data );
   }
 
-  function downgradeToGuest() {
+  function downgradeToGuest( skipEvent = false ) {
     let observable = currentRole() == Roles.public ?
       Observable.throw( 'must be IDENTIFIED' ) :
       Observable
@@ -140,7 +140,7 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
           data:            {}
         } ) )
         .map( ( response ) => response.data );
-    return observable.finally( () => {
+    return skipEvent ? observable : observable.finally( () => {
       $rootScope.$broadcast( SignOutEvent );
     } );
   }

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -225,7 +225,7 @@ describe( 'session service', function () {
     } );
   } );
 
-  describe( 'downgradeToGuest', () => {
+  describe( 'downgradeToGuest( skipEvent )', () => {
     beforeEach( () => {
       spyOn( $rootScope, '$broadcast' );
     } );
@@ -256,6 +256,29 @@ describe( 'session service', function () {
         // eslint-disable-next-line angular/timeout-service
         setTimeout( () => {
           expect( $rootScope.$broadcast ).toHaveBeenCalledWith( SignOutEvent );
+          done();
+        } );
+        $httpBackend.flush();
+      } );
+    } );
+
+    describe( 'with skipEvent = true', () => {
+      beforeEach( () => {
+        $cookies.put( Sessions.cortex, cortexSession.identified );
+        // Force digest so scope session watchers pick up changes.
+        $rootScope.$digest();
+      } );
+
+      it( 'make http request to cas/downgrade', ( done ) => {
+        $httpBackend.expectPOST( 'https://cortex-gateway-stage.cru.org/cas/downgrade', {} ).respond( 204, {} );
+        sessionService.downgradeToGuest( true ).subscribe( ( data ) => {
+          expect( data ).toEqual( {} );
+        } );
+        $rootScope.$digest();
+        // Observable.finally is fired after the test, this defers until it's called.
+        // eslint-disable-next-line angular/timeout-service
+        setTimeout( () => {
+          expect( $rootScope.$broadcast ).not.toHaveBeenCalled();
           done();
         } );
         $httpBackend.flush();


### PR DESCRIPTION
This adds a skipEvent flag to the downgradeToGuest method. This method is used both in the global nav sign-out as well as the checkout as guest. Clicking Checkout as Guest was causing the nav to do a page reload when it saw the event.