### PR TITLE
If current date is greater than the 28th, use the first of the next m…

### DIFF
--- a/src/common/services/giftHelpers/giftDates.service.js
+++ b/src/common/services/giftHelpers/giftDates.service.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import range from 'lodash/range';
 import map from 'lodash/map';
-import reduce from 'lodash/reduce';
 
 export function possibleTransactionDays() {
   return range( 1, 29 ).map((i) => (`0${i}`).slice(-2));
@@ -44,11 +43,19 @@ export function startMonth(transactionDay, month, nextDrawDate, monthOffset, sta
 }
 
 export function _earliestValidDate(nextDrawDate, startDate){
-  // Find greatest of today's date, nextDrawDate, and startDate
-  let utcGreatest = reduce([nextDrawDate, startDate], (result, date) => {
-    let utcDate = moment.utc(date); // Compare all dates in UTC
-    return result.isBefore(utcDate) ? utcDate : result;
-  }, moment.utc()); // Use today's date in UTC as the starting value to compare with nextDrawDate and startDate
+  let currentDate = moment.utc();
+  // If date is past the 28th of the month (which are invalid transaction days) use the first of the next month
+  if(currentDate.date() > 28){
+    currentDate.add(1, 'months');
+    currentDate.date(1);
+  }
+
+  // Find greatest of today's date, nextDrawDate, and startDate by comparing dates in UTC
+  let utcGreatest = moment.max(
+    currentDate,
+    moment.utc(nextDrawDate),
+    moment.utc(startDate)
+  );
 
   // Toss all timezone info and pretend the date is at midnight in the browser's timezone
   // like the rest of the dates in the app that are used for display only.

--- a/src/common/services/giftHelpers/giftDates.service.spec.js
+++ b/src/common/services/giftHelpers/giftDates.service.spec.js
@@ -98,14 +98,27 @@ describe('giftDates service', () => {
       expect(giftDates._earliestValidDate('2017-01-03', '2017-01-02').toString()).toEqual(moment('2017-01-04').toString());
     });
     it('should not use the current date if it is slightly before another date', () => {
-      jasmine.clock().mockDate( moment.utc('2017-01-02 11:59:59').local().toDate() );
+      jasmine.clock().mockDate( moment.utc('2017-01-02 23:59:59').local().toDate() );
       expect(giftDates._earliestValidDate('2017-01-02', '2017-01-03').toString()).toEqual(moment('2017-01-03').toString());
       expect(giftDates._earliestValidDate('2017-01-03', '2017-01-02').toString()).toEqual(moment('2017-01-03').toString());
     });
     it('should not use the next day if the current date is a second before midnight on the same day as another date', () => {
-      jasmine.clock().mockDate( moment.utc('2017-01-03 11:59:59').local().toDate() );
+      jasmine.clock().mockDate( moment.utc('2017-01-03 23:59:59').local().toDate() );
       expect(giftDates._earliestValidDate('2017-01-02', '2017-01-03').toString()).toEqual(moment('2017-01-03').toString());
       expect(giftDates._earliestValidDate('2017-01-03', '2017-01-02').toString()).toEqual(moment('2017-01-03').toString());
+    });
+    it('should move the current date to the next month if it is after the 28th', () => {
+      jasmine.clock().mockDate( moment.utc('2017-01-29 23:59:59').local().toDate() );
+      expect(giftDates._earliestValidDate('2017-01-28', '2017-01-27').toString()).toEqual(moment('2017-02-01').toString());
+      expect(giftDates._earliestValidDate('2017-02-01', '2017-01-02').toString()).toEqual(moment('2017-02-01').toString());
+
+      jasmine.clock().mockDate( moment.utc('2017-01-30 23:59:59').local().toDate() );
+      expect(giftDates._earliestValidDate('2017-01-28', '2017-01-27').toString()).toEqual(moment('2017-02-01').toString());
+      expect(giftDates._earliestValidDate('2017-02-01', '2017-01-02').toString()).toEqual(moment('2017-02-01').toString());
+
+      jasmine.clock().mockDate( moment.utc('2017-12-31 23:59:59').local().toDate() );
+      expect(giftDates._earliestValidDate('2017-12-28', '2017-12-27').toString()).toEqual(moment('2018-01-01').toString());
+      expect(giftDates._earliestValidDate('2017-12-01', '2017-12-02').toString()).toEqual(moment('2018-01-01').toString());
     });
   });
 });


### PR DESCRIPTION
…onth as the current date when finding the earliestValidDate

- Use moment.max

https://jira.cru.org/browse/EP-1548