### PR TITLE
Fix double loading indicators on signing in with registerAccountModal…

### DIFF
--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -11,6 +11,8 @@ import forgotPasswordModal from 'common/components/forgotPasswordModal/forgotPas
 import userMatchModal from 'common/components/userMatchModal/userMatchModal.component';
 import contactInfoModal from 'common/components/contactInfoModal/contactInfoModal.component';
 
+import loading from 'common/components/loading/loading.component';
+
 let componentName = 'registerAccountModal';
 
 class RegisterAccountModalController {
@@ -22,10 +24,11 @@ class RegisterAccountModalController {
   // 5. Complete User Match
 
   /* @ngInject */
-  constructor( orderService, sessionService, verificationService ) {
+  constructor( orderService, sessionService, verificationService, gettext ) {
     this.orderService = orderService;
     this.sessionService = sessionService;
     this.verificationService = verificationService;
+    this.gettext = gettext;
   }
 
   $onInit() {
@@ -41,6 +44,10 @@ class RegisterAccountModalController {
   }
 
   onIdentitySuccess() {
+    // Show loading state
+    this.modalTitle = this.gettext( 'Checking your donor account' );
+    this.stateChanged( 'loading' );
+
     // Success Sign-In/Up, Proceed to Step 2.
     this.getDonorDetails();
   }
@@ -56,7 +63,6 @@ class RegisterAccountModalController {
   }
 
   getDonorDetails() {
-    this.setLoading( {loading: true} );
 
     // Step 2. Fetch Donor Details
     this.orderService.getDonorDetails().subscribe( ( donorDetails ) => {
@@ -120,7 +126,8 @@ export default angular
     signUpModal.name,
     template.name,
     userMatchModal.name,
-    verificationService.name
+    verificationService.name,
+    loading.name
   ] )
   .component( componentName, {
     controller:  RegisterAccountModalController,

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -67,8 +67,12 @@ describe( 'registerAccountModal', function () {
   describe( 'onIdentitySuccess()', () => {
     it( 'calls getDonorDetails', () => {
       spyOn( $ctrl, 'getDonorDetails' );
+      spyOn( $ctrl, 'stateChanged' );
       $ctrl.onIdentitySuccess();
       expect( $ctrl.getDonorDetails ).toHaveBeenCalled();
+      expect( $ctrl.modalTitle ).toEqual('Checking your donor account');
+      expect( $ctrl.stateChanged ).toHaveBeenCalledWith('loading');
+
     } );
   } );
 
@@ -97,7 +101,6 @@ describe( 'registerAccountModal', function () {
         it( 'changes state to \'contact-info\'', () => {
           $ctrl.orderService.getDonorDetails.and.callFake( () => Observable.of( {'registration-state': 'COMPLETED'} ) );
           $ctrl.getDonorDetails();
-          expect( $ctrl.setLoading ).toHaveBeenCalledWith( {loading: true} );
           expect( $ctrl.orderService.getDonorDetails ).toHaveBeenCalled();
           expect( $ctrl.stateChanged ).not.toHaveBeenCalled();
           expect( $ctrl.onSuccess ).toHaveBeenCalled();
@@ -108,7 +111,6 @@ describe( 'registerAccountModal', function () {
         it( 'changes state to \'contact-info\'', () => {
           $ctrl.orderService.getDonorDetails.and.callFake( () => Observable.of( {'registration-state': 'NEW'} ) );
           $ctrl.getDonorDetails();
-          expect( $ctrl.setLoading ).toHaveBeenCalledWith( {loading: true} );
           expect( $ctrl.orderService.getDonorDetails ).toHaveBeenCalled();
           expect( $ctrl.stateChanged ).toHaveBeenCalledWith( 'contact-info' );
         } );
@@ -119,7 +121,6 @@ describe( 'registerAccountModal', function () {
       it( 'changes state to \'contact-info\'', () => {
         $ctrl.orderService.getDonorDetails.and.callFake( () => Observable.throw( {} ) );
         $ctrl.getDonorDetails();
-        expect( $ctrl.setLoading ).toHaveBeenCalledWith( {loading: true} );
         expect( $ctrl.orderService.getDonorDetails ).toHaveBeenCalled();
         expect( $ctrl.stateChanged ).toHaveBeenCalledWith( 'contact-info' );
       } );

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -13,6 +13,7 @@
                          modal-title="$ctrl.modalTitle"
                          on-state-change="$ctrl.stateChanged(state)">
   </forgot-password-modal>
+  <loading ng-switch-when="loading" inline="true"></loading>
   <contact-info-modal ng-switch-when="contact-info"
                       modal-title="$ctrl.modalTitle"
                       on-success="$ctrl.onContactInfoSuccess()"


### PR DESCRIPTION
… by adding a loading state and corresponding view with title

Now instead of showing the user 2 loading indicators:
<img width="530" alt="screen shot 2016-11-30 at 12 32 17 pm" src="https://cloud.githubusercontent.com/assets/756501/20770018/1c1dbf46-b6f9-11e6-9f76-a2051fc66f69.png">
We let them know what we are doing:
<img width="538" alt="screen shot 2016-11-30 at 12 30 27 pm" src="https://cloud.githubusercontent.com/assets/756501/20770019/1d760862-b6f9-11e6-91cd-de300ec58b05.png">

@Omicron7 let me know what you think of this since you did the work for this flow. Is there any other place where doing this would look good?
