### PR TITLE
Reload cart after deleting item to refresh rate totals

### DIFF
--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -59,6 +59,7 @@ class CartController {
     this.cartService.deleteItem( item.uri )
       .subscribe( () => {
           pull(this.cartData.items, item);
+          this.loadCart(true);
         },
         error => {
           this.$log.error('Error deleting item from cart', error);

--- a/src/app/cart/cart.component.spec.js
+++ b/src/app/cart/cart.component.spec.js
@@ -96,7 +96,7 @@ describe('cart', () => {
       self.controller.cartService.deleteItem.and.returnValue( Observable.of( 'data' ) );
       self.controller.removeItem(self.controller.cartData.items[0]);
       expect(self.controller.cartService.deleteItem).toHaveBeenCalledWith('uri1');
-      expect(self.controller.loadCart).not.toHaveBeenCalled();
+      expect(self.controller.loadCart).toHaveBeenCalledWith(true);
       expect(self.controller.cartData.items).toEqual([{uri: 'uri2'}]);
     });
     it('should handle an error removing an item', () => {


### PR DESCRIPTION
https://jira.cru.org/browse/EP-1561

We could avoid this request if we subtract the gift value from the rate totals. Seems like we are using the string version and not the number version for displaying the rate totals which makes it more complicated. We could switch that. What do you guys think?