### PR TITLE
[#EP-1601] Update call to recent historical donations

### DIFF
--- a/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.tpl.html
+++ b/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.tpl.html
@@ -17,7 +17,7 @@
                 <li>
                   <h4>
                     {{$ctrl.gift['historical-donation-line']['amount'] | currency:'$'}}
-                    <span ng-if="$ctrl.gift['recurringdonationelement']"> &mdash; {{$ctrl.gift['recurringdonationelement']['rate']['recurrence']['interval']}}</span>
+                    <span ng-if="$ctrl.gift['recurringdonations']['donations'].length"> &mdash; {{$ctrl.gift['recurringdonations']['donations'][0]['rate']['recurrence']['interval']}}</span>
                   </h4>
                   <span class="meta">{{$ctrl.gift['historical-donation-line']['transaction-date']['display-value'] | date:'mediumDate'}}</span>
                 </li>
@@ -38,7 +38,7 @@
         </button>
         <button type="button"
                 class="btn btn-subtle btn-block mt- split-col-right"
-                ng-if="$ctrl.gift['recurringdonationelement']"
+                ng-if="$ctrl.gift['recurringdonations']['donations'].length"
                 ng-click="$ctrl.manageGift()"
                 translate>Manage Recurring Gift
         </button>

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.tpl.html
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.tpl.html
@@ -34,10 +34,10 @@
             </div>
           </div>
           <div class="col-sm-4 col-md-4">
-            <div class="form-group mb0" ng-if="$ctrl.recipient['mostrecentdonationRecurringdonationelement']">
+            <div class="form-group mb0" ng-if="$ctrl.recipient['recurringdonations']['donations'].length">
               <label translate>Recurring Gifts:</label>
               <ul class="list-unstyled list-recurring">
-                <li ng-repeat="recurring in $ctrl.recipient['mostrecentdonationRecurringdonationelement']">
+                <li ng-repeat="recurring in $ctrl.recipient['recurringdonations']['donations']">
                   <h4 translate>{{recurring['donation-lines'][0].amount | currency:'$'}} {{recurring.rate.recurrence.interval}}</h4>
                   <span class="meta" ng-if="recurring['next-draw-date']" translate>Next Gift: {{recurring['next-draw-date']['display-value'] | date:'mediumDate'}}</span>
                 </li>

--- a/src/common/services/api/donations.service.js
+++ b/src/common/services/api/donations.service.js
@@ -38,7 +38,7 @@ function DonationsService( cortexApiService, profileService, commonService ) {
       .get( {
         path: path,
         zoom: {
-          recipients: 'element[],element:mostrecentdonation,element:mostrecentdonation:recurringdonationelement[]'
+          recipients: 'element[],element:mostrecentdonation,element:recurringdonations'
         }
       } )
       .pluck( 'recipients' );

--- a/src/common/services/api/donations.service.js
+++ b/src/common/services/api/donations.service.js
@@ -60,7 +60,7 @@ function DonationsService( cortexApiService, profileService, commonService ) {
       .get( {
         path: ['donations', 'historical', cortexApiService.scope, year, month],
         zoom: {
-          gifts: 'element[],element:paymentmethod,element:recurringdonationelement'
+          gifts: 'element[],element:paymentmethod,element:recurringdonations'
         }
       } )
       .pluck( 'gifts' );

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -70,7 +70,7 @@ describe( 'donations service', () => {
   describe( 'getHistoricalGifts( year, month )', () => {
     it( 'should load historical gifts by year and month', () => {
       $httpBackend
-        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/2016/9?zoom=element,element:paymentmethod,element:recurringdonationelement' )
+        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/2016/9?zoom=element,element:paymentmethod,element:recurringdonations' )
         .respond( 200, historicalResponse );
       donationsService.getHistoricalGifts( 2016, 9 ).subscribe( ( historicalGifts ) => {
         expect( historicalGifts ).toEqual( jasmine.any( Array ) );

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -36,7 +36,7 @@ describe( 'donations service', () => {
   describe( 'getRecipients( year )', () => {
     it( 'should load recent when missing year', () => {
       $httpBackend
-        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/recent?zoom=element,element:mostrecentdonation,element:mostrecentdonation:recurringdonationelement' )
+        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/recent?zoom=element,element:mostrecentdonation,element:recurringdonations' )
         .respond( 200, recipientResponse );
       donationsService.getRecipients().subscribe( ( recipients ) => {
         expect( recipients ).toEqual( jasmine.any( Array ) );
@@ -46,7 +46,7 @@ describe( 'donations service', () => {
 
     it( 'should load recipients by year', () => {
       $httpBackend
-        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/2015?zoom=element,element:mostrecentdonation,element:mostrecentdonation:recurringdonationelement' )
+        .expectGET( 'https://cortex-gateway-stage.cru.org/cortex/donations/historical/crugive/recipient/2015?zoom=element,element:mostrecentdonation,element:recurringdonations' )
         .respond( 200, recipientResponse );
       donationsService.getRecipients( 2015 ).subscribe( ( recipients ) => {
         expect( recipients ).toEqual( jasmine.any( Array ) );


### PR DESCRIPTION
Decided to leave the zoom to recurringdonations as it's needed in the initial view and it will take just as much time to load each donation individually as to zoom them all.

UI may need to be re-thought if including the recurring donation information in the initial list is too slow.

This PR needs to be coordinated with backend PR for https://jira.cru.org/browse/EP-1601