### PR TITLE
Remove extra requests in payment-methods component

### DIFF
--- a/src/app/profile/payment-methods/payment-method/payment-method.component.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.component.js
@@ -21,23 +21,12 @@ class PaymentMethodController{
     this.submissionError = {error: ''};
   }
 
-  $onInit(){
-    this.loadDonorDetails();
-  }
-
-  loadDonorDetails() {
-    this.profileService.getDonorDetails()
-      .subscribe((data) => {
-        this.mailingAddress = data.mailingAddress;
-      });
-  }
-
   getExpiration(){
     return `${this.model['expiry-month']}/${this.model['expiry-year']}`;
   }
 
   isCard(){
-    return this.model['card-number'] ? true : false;
+    return !!this.model['card-number'];
   }
 
   editPaymentMethod() {
@@ -132,6 +121,7 @@ export default angular
       model: '<',
       successMessage: '=',
       paymentMethodsList: '<',
+      mailingAddress: '<',
       onDelete: '&'
     }
   });

--- a/src/app/profile/payment-methods/payment-method/payment-method.spec.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.spec.js
@@ -79,23 +79,6 @@ describe('PaymentMethodComponent', function () {
     expect(self.controller).toBeDefined();
   });
 
-  describe('$onInit()', () => {
-    it('should call loadDonorDetails', () => {
-      spyOn(self.controller, 'loadDonorDetails');
-      self.controller.$onInit();
-      expect(self.controller.loadDonorDetails).toHaveBeenCalled();
-    });
-  });
-
-  describe('loadDonorDetails()', () => {
-    it('should get donor details', () => {
-      spyOn(self.controller.profileService, 'getDonorDetails').and.returnValue(Observable.of({mailingAddress: 'address'}));
-      self.controller.loadDonorDetails();
-      expect(self.controller.mailingAddress).toBe('address');
-    });
-  });
-
-
   describe('getExpiration()', () => {
     it('should return expiration date', () => {
       self.controller.model = modelCC;
@@ -133,8 +116,6 @@ describe('PaymentMethodComponent', function () {
       expect(self.controller.$uibModal.open).toHaveBeenCalled();
 
       self.controller.onSubmit = () => 'hello';
-      spyOn(self.controller.profileService, 'getDonorDetails').and.returnValue(Observable.of({mailingAddress: 'address'}));
-      self.controller.$onInit();
       expect(self.controller.$uibModal.open.calls.first().args[0].resolve.onSubmit()()).toBe('hello');
     });
   });

--- a/src/app/profile/payment-methods/payment-method/payment-method.tpl.html
+++ b/src/app/profile/payment-methods/payment-method/payment-method.tpl.html
@@ -2,10 +2,10 @@
     <div ng-click="$ctrl.isCollapsed = !$ctrl.isCollapsed" class="panel-heading" role="tab">
       <div ng-class="{'collapsed': $ctrl.isCollapsed}" class="payment-summary-link p- collapse-indicator-row" role="button">
         <div class="row">
-          <div class="col-md-8">
+          <div class="col-sm-9">
             <payment-method-display payment-method="$ctrl.model"></payment-method-display>
           </div>
-          <div class="col-md-4 text-right payment-details-link">
+          <div class="col-sm-3 text-right payment-details-link">
             <button class="btn trigger">Details</button>
           </div>
         </div>

--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -15,7 +15,7 @@ class PaymentMethodsController {
 
   /* @ngInject */
   constructor($rootScope, $uibModal, profileService, sessionEnforcerService, $log, $timeout, $window, $location) {
-    this.log = $log;
+    this.$log = $log;
     this.$rootScope = $rootScope;
     this.$uibModal = $uibModal;
     this.paymentMethod = 'bankAccount';
@@ -54,14 +54,14 @@ class PaymentMethodsController {
     this.$rootScope.$on( SignOutEvent, ( event ) => this.signedOut( event ) );
 
     this.loading = true;
-    this.loadPaymentMethods();
-    this.loadDonorDetails();
   }
 
   loadDonorDetails() {
     this.profileService.getDonorDetails()
-      .subscribe((data) => {
+      .subscribe(data => {
         this.mailingAddress = data.mailingAddress;
+      }, error => {
+        this.$log.error('Error loading mailing address for use in profile payment method add payment method modals', error);
       });
   }
 
@@ -76,7 +76,7 @@ class PaymentMethodsController {
         error => {
           this.loading = false;
           this.submissionError.error = 'Failed retrieving payment methods.';
-          this.log.error(this.submissionError.error, error);
+          this.$log.error(this.submissionError.error, error);
         }
       );
   }
@@ -117,7 +117,7 @@ class PaymentMethodsController {
           (error) => {
             this.submissionError.loading = false;
             this.submissionError.error = error.data;
-            this.log.error('error.data',error);
+            this.$log.error('Error adding payment method',error);
           });
     } else {
       this.submissionError.loading = false;

--- a/src/app/profile/payment-methods/payment-methods.spec.js
+++ b/src/app/profile/payment-methods/payment-methods.spec.js
@@ -101,6 +101,11 @@ describe( 'PaymentMethodsComponent', function () {
       expect($ctrl.mailingAddress).toBe('address');
       expect($ctrl.profileService.getDonorDetails).toHaveBeenCalled();
     });
+    it('should log an error', () => {
+      spyOn($ctrl.profileService, 'getDonorDetails').and.returnValue(Observable.throw('some error'));
+      $ctrl.loadDonorDetails();
+      expect($ctrl.$log.error.logs[0]).toEqual(['Error loading mailing address for use in profile payment method add payment method modals', 'some error']);
+    });
   });
 
   describe('addPaymentMethod()', () => {

--- a/src/app/profile/payment-methods/payment-methods.tpl.html
+++ b/src/app/profile/payment-methods/payment-methods.tpl.html
@@ -22,7 +22,7 @@
               <translate>Loading payment methods...</translate>
             </loading>
             <div ng-if="$ctrl.paymentMethods" ng-repeat="paymentMethod in $ctrl.paymentMethods" class="panel-group panel-collapse">
-              <payment-method success-message="$ctrl.successMessage" model="paymentMethod" payment-methods-list="$ctrl.paymentMethods" on-delete="$ctrl.onDelete()"></payment-method>
+              <payment-method success-message="$ctrl.successMessage" model="paymentMethod" payment-methods-list="$ctrl.paymentMethods" mailing-address="$ctrl.mailingAddress" on-delete="$ctrl.onDelete()"></payment-method>
             </div>
           </div>
         </div>

--- a/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
+++ b/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
@@ -29,7 +29,7 @@
 
             <ng-switch on="$ctrl.view">
 
-              <div class="mb" ng-switch-when="manageDonations">
+              <div class="mb--" ng-switch-when="manageDonations">
                 <h4 class="border-bottom-small visible" translate>Recurring Gifts Using this Payment Method</h4>
 
                 <div ng-repeat="gift in $ctrl.buildGifts($ctrl.resolve.paymentMethod._recurringgifts[0].donations)" class="row repeating-row user-profile">
@@ -88,7 +88,7 @@
 
               </div>
 
-              <div class="mb" ng-switch-when="addPaymentMethod">
+              <div class="mb--" ng-switch-when="addPaymentMethod">
                 <payment-method-form mailing-address="$ctrl.resolve.mailingAddress" submission-error="$ctrl.submissionError" on-submit="$ctrl.savePaymentMethod(success, data)"></payment-method-form>
                 <div class="mb0">
                   <div class="row">
@@ -100,7 +100,7 @@
                 </div>
               </div>
 
-              <div class="mb-" ng-switch-when="confirm">
+              <div class="mb--" ng-switch-when="confirm">
                 <div class="row">
                   <div class="col-sm-12">
                     <ng-switch on="$ctrl.confirmText">


### PR DESCRIPTION
- Don’t load in $onInit since the EnforcerCallbacks call the load methods
- Load mailingAddress from donordetails once and pass it to subcomponents with a binding
- Don’t responsively wrap details button as soon
- Remove extra space from bottom of modals