### PR TITLE
[#EP-1613] Dont allow changing organization/individual for completed accounts

### DIFF
--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -7,7 +7,7 @@
   <loading type="overlay" ng-if="!$ctrl.donorDetails">
     <translate>Checking for existing information...</translate>
   </loading>
-  <div class="mb_x">
+  <div class="mb_x" ng-if="!$ctrl.nameFieldsDisabled">
     <div class="row">
       <div class="col-md-6">
         <a href="" class="tab-btn btn btn-default btn-block" ng-click="$ctrl.donorDetails['donor-type'] = 'Household'" ng-class="{'on': $ctrl.donorDetails['donor-type'] === 'Household'}" translate>Give as an Individual</a>


### PR DESCRIPTION
This fixes https://jira.cru.org/browse/EP-1613

This re-uses the nameFieldsDisabled flag to disable changing the account-type. This flag follows the exact same rules, basically, you can't change account type, first or last if donor account is COMPLETED.