### PR TITLE
Fix cart reloading on edit and productConfigModal error handling

### DIFF
--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -74,11 +74,9 @@ class CartController {
     this.productModalService
       .configureProduct( item.code, item.config, true, item.uri )
       .result
-      .then( ( result ) => {
-        if ( result.isUpdated ) {
-          pull(this.cartData.items, item);
-          this.loadCart(true);
-        }
+      .then( () => {
+        pull(this.cartData.items, item);
+        this.loadCart(true);
       } );
   }
 

--- a/src/app/productConfig/productConfig.component.js
+++ b/src/app/productConfig/productConfig.component.js
@@ -35,9 +35,9 @@ class ProductConfigController {
     modalInstance.result.then( () => {
         this.$window.location = '/cart.html';
       },
-      error => {
-        if(error){
-          this.$log.error('Error opening product config modal', error);
+      reason => {
+        if(reason && reason !== 'backdrop click'){ // Avoid labeling normal closes or backdrop clicks as errors
+          this.$log.error('Error opening product config modal', reason);
           this.error = true;
         }
         this.loadingModal = false;

--- a/src/app/productConfig/productConfig.component.spec.js
+++ b/src/app/productConfig/productConfig.component.spec.js
@@ -75,6 +75,24 @@ describe( 'productConfig', function () {
       expect( $ctrl.loadingModal ).toEqual( false );
       expect( $ctrl.$log.error.logs[0] ).toEqual( ['Error opening product config modal', 'some error'] );
     } );
+
+    it( 'should not throw an error when the modal gets dismissed normally', () => {
+      $ctrl.configModal();
+      resultDeferred.reject();
+      $rootScope.$digest();
+      expect( $ctrl.error ).toEqual( false );
+      expect( $ctrl.loadingModal ).toEqual( false );
+      expect( $ctrl.$log.error.logs[0] ).toBeUndefined();
+    } );
+
+    it( 'should not throw an error when the modal gets dismissed by a background click', () => {
+      $ctrl.configModal();
+      resultDeferred.reject('backdrop click');
+      $rootScope.$digest();
+      expect( $ctrl.error ).toEqual( false );
+      expect( $ctrl.loadingModal ).toEqual( false );
+      expect( $ctrl.$log.error.logs[0] ).toBeUndefined();
+    } );
   } );
 } );
 

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.js
@@ -193,7 +193,7 @@ class ProductConfigModalController {
     savingObservable.subscribe( () => {
       if ( this.isEdit ) {
         this.$scope.$emit( cartUpdatedEvent );
-        this.close( {isUpdated: true} );
+        this.close();
       } else {
         this.$scope.$emit( giftAddedEvent );
         this.dismiss();

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
@@ -448,7 +448,7 @@ describe( 'product config modal', function () {
           'recurring-day-of-month': '01'
         } );
         expect( $ctrl.$scope.$emit ).toHaveBeenCalledWith( cartUpdatedEvent );
-        expect( $ctrl.close ).toHaveBeenCalledWith( {isUpdated: true} );
+        expect( $ctrl.close ).toHaveBeenCalledWith();
         expect( $ctrl.errorAlreadyInCart).toEqual(false);
         expect( $ctrl.errorSavingGeneric).toEqual(false);
       } );
@@ -460,7 +460,7 @@ describe( 'product config modal', function () {
         expect( $ctrl.submittingGift ).toEqual( false );
         expect( $ctrl.cartService.editItem ).toHaveBeenCalledWith( 'uri', 'items/crugive/<some id>', {amount: 85} );
         expect( $ctrl.$scope.$emit ).toHaveBeenCalledWith( cartUpdatedEvent );
-        expect( $ctrl.close ).toHaveBeenCalledWith( {isUpdated: true} );
+        expect( $ctrl.close ).toHaveBeenCalledWith();
         expect( $ctrl.errorAlreadyInCart).toEqual(false);
         expect( $ctrl.errorSavingGeneric).toEqual(false);
       } );


### PR DESCRIPTION
-  Remove isUpdated event since there’s no other way for the modal to close with success. Changing productConfigModal to a component broke it as the callback reasons have different syntax
- Avoid throwing error if productConfigModal closes with no reason or a backdrop click

Fixes https://jira.cru.org/browse/EP-1609 and https://rollbar.com/Cru/give-web/items/133/