### PR TITLE
Remove rate totals from nav cart

### DIFF
--- a/src/common/components/nav/navCart/navCart.tpl.html
+++ b/src/common/components/nav/navCart/navCart.tpl.html
@@ -38,11 +38,8 @@
   </div>
 
   <div class="row repeating-row sub-total" ng-if="$ctrl.hasItems">
-    <div class="col-xs-4">
-      <p translate>{{$ctrl.cartData.items.length}} Items</p>
-    </div>
-    <div class="col-xs-8 text-right">
-      <p translate>Subtotal {{$ctrl.cartData.cartTotal | currency:'$'}}</p>
+    <div class="col-xs-12 text-right">
+      <p translate translate-n="$ctrl.cartData.items.length" translate-plural="{{$count}} Items">1 Item</p>
     </div>
   </div>
   <div class="row row-no-spacing" ng-if="$ctrl.hasItems || $ctrl.error"><!-- TODO: row-no-spacing not in nav css -->


### PR DESCRIPTION
@riceguitar or @riceguitar I'm just going to merge this when I get a review but do you guys have any thoughts on the white space that exists in the nav cart now? It looks a little weird to me. I moved the item count to the right. Idk if that makes anything better.

![screen shot 2016-12-14 at 3 27 40 pm](https://cloud.githubusercontent.com/assets/756501/21205630/2b14fbe4-c212-11e6-827e-35df2968424f.png)
See https://jira.cru.org/browse/EP-1618
