### PR TITLE
EP-1573: Fix forgot password modal error handling

### DIFF
--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.component.js
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.component.js
@@ -32,16 +32,16 @@ class ForgotPasswordModalController {
       .subscribe( () => {
         this.emailSent = true;
         this.isLoading = false;
-      }, ( error ) => {
+      }, error => {
         this.forgotError = true;
         this.isLoading = false;
-        switch ( error.data.error ) {
+        switch ( error.data && error.data.error ) {
           case 'user_not_found':
           case 'password_cant_change':
             this.errors[error.data.error] = true;
             break;
           default:
-            this.errors['unknown'] = true;
+            this.errors.unknown = true;
         }
       } );
   }

--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.component.spec.js
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.component.spec.js
@@ -81,6 +81,14 @@ describe( 'forgotPasswordModal', function () {
           expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {unknown: true} ) );
         } );
       } );
+      describe( 'no response body', () => {
+        it( 'sets \'unknown\' error', () => {
+          deferred.reject( {status: -1 } );
+          $rootScope.$digest();
+          expect( $ctrl.forgotError ).toEqual( true );
+          expect( $ctrl.errors ).toEqual( jasmine.objectContaining( {unknown: true} ) );
+        } );
+      } );
     } );
   } );
 

--- a/src/common/components/forgotPasswordModal/forgotPasswordModal.tpl.html
+++ b/src/common/components/forgotPasswordModal/forgotPasswordModal.tpl.html
@@ -7,16 +7,20 @@
   <div ng-if="!$ctrl.emailSent">
     <p translate>Enter your registered email address below and we'll send you a link to reset your password.</p>
     <div class="alert alert-danger" role="alert" ng-messages="$ctrl.errors" ng-if="$ctrl.forgotError">
-      <div ng-message="email_not_found" translate>Email Address not Found.<br />
-        Perhaps you've never <a ng-click="$ctrl.onStateChange({state: 'sign-up'})">Signed Up</a>? Questions,
-        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+      <div ng-message="user_not_found" translate>Email Address not Found.<br />
+        Perhaps you've never <a ng-click="$ctrl.onStateChange({state: 'sign-up'})">signed up</a>? Questions,
+        <a href="https://www.cru.org/about/contact-us.html">contact us</a>.
       </div>
       <div ng-message="password_cant_change" translate>You are not allowed to reset your password here.<br />Please
-        <a href="https://www.cru.org/about/contact-us.html">Contact Us</a>.
+        <a href="https://www.cru.org/about/contact-us.html">contact us</a>.
+      </div>
+      <div ng-message="unknown" translate>An error occurred resetting your password.<br />
+        You may try again or
+        <a href="https://www.cru.org/about/contact-us.html">contact us</a>
+        if you continue to experience issues.
       </div>
     </div>
     <form name="$ctrl.form" class="loading-overlay-parent">
-      <div class="alert alert-danger" role="alert" ng-if="$ctrl.forgotError" translate>An Error has Occurred.</div>
       <div class="form-group">
         <label for="email" translate>Email</label>
         <input type="email"


### PR DESCRIPTION
- Show errors when there is no data object returned
- Combine errors into a single alert by adding an unknown case
- Update email_not_found string