### PR TITLE
[#EP-1572] Sign Out spinner

### DIFF
--- a/src/common/components/nav/desktopNav.tpl.html
+++ b/src/common/components/nav/desktopNav.tpl.html
@@ -54,7 +54,7 @@
           <ul class="pull-right" uib-dropdown-menu>
             <span class="triangle"></span>
             <li class="nav-edit-profile"><a href="profile.html" translate>Edit Profile</a></li>
-            <li class="nav-sign-out"><a href="" ng-click="$ctrl.signOut()" translate>Sign Out</a></li>
+            <li class="nav-sign-out"><a href ng-click="$ctrl.signOut()" translate>Sign Out</a></li>
           </ul>
         </div>
       </div>

--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -8,6 +8,7 @@ import find from 'lodash/find';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 
+import loading from 'common/components/loading/loading.component';
 import sessionService, {SignOutEvent} from 'common/services/session/session.service';
 import sessionModalService from 'common/services/session/sessionModal.service';
 import mobileNavLevelComponent from './navMobileLevel.component';
@@ -19,6 +20,7 @@ import navCart, {cartUpdatedEvent} from 'common/components/nav/navCart/navCart.c
 
 import mobileTemplate from './mobileNav.tpl';
 import desktopTemplate from './desktopNav.tpl';
+import signOutTemplate from './signOut.modal.tpl';
 
 let componentName = 'cruNav';
 
@@ -127,7 +129,15 @@ class NavController{
   }
 
   signOut() {
-    this.sessionService.downgradeToGuest().subscribe(angular.noop);
+    let modal = this.$uibModal.open({
+      templateUrl: signOutTemplate.name,
+      backdrop: 'static',
+      keyboard: false,
+      size: 'sm'
+    });
+    this.sessionService.downgradeToGuest().subscribe(() => {
+      modal.close();
+    }, angular.noop);
   }
 
   signedOut( event ) {
@@ -223,13 +233,15 @@ export default angular
     'environment',
     mobileTemplate.name,
     desktopTemplate.name,
+    signOutTemplate.name,
     sessionService.name,
     sessionModalService.name,
     mobileNavLevelComponent.name,
     subNavDirective.name,
     globalWebsitesModal.name,
     globalWebsitesModalWindowTemplate.name,
-    navCart.name
+    navCart.name,
+    loading.name
   ])
   .component(componentName, {
     controller: NavController,

--- a/src/common/components/nav/nav.component.spec.js
+++ b/src/common/components/nav/nav.component.spec.js
@@ -251,9 +251,13 @@ describe( 'nav signInButton', function () {
 
   describe( 'signOut', () => {
     it( 'calls downgradeToGuest()', () => {
+      let modalSpy = jasmine.createSpyObj('modal', ['close']);
       spyOn( $ctrl.sessionService, 'downgradeToGuest' ).and.returnValue( Observable.of( {} ) );
+      spyOn($ctrl.$uibModal, 'open').and.returnValue(modalSpy);
       $ctrl.signOut();
+      expect( $ctrl.$uibModal.open ).toHaveBeenCalled();
       expect( $ctrl.sessionService.downgradeToGuest ).toHaveBeenCalled();
+      expect( modalSpy.close ).toHaveBeenCalled();
     } );
   } );
 
@@ -277,20 +281,20 @@ describe( 'nav signInButton', function () {
         expect( $ctrl.$window.location.reload ).toHaveBeenCalled();
       } );
     } );
+  } );
 
-    describe( 'openGlobalWebsitesModal', () => {
-      it( 'should open the global websites modal', () => {
-        spyOn($ctrl.$uibModal, 'open');
-        $ctrl.openGlobalWebsitesModal();
-        expect( $ctrl.$uibModal.open ).toHaveBeenCalledWith( {
-          component: 'globalWebsitesModal',
-          backdrop: 'static',
-          windowTemplateUrl: jasmine.any(String),
-          windowClass: 'globalWebsites--is-open',
-          resolve: {
-            menuStructure: $ctrl.menuStructure
-          }
-        } );
+  describe( 'openGlobalWebsitesModal', () => {
+    it( 'should open the global websites modal', () => {
+      spyOn($ctrl.$uibModal, 'open');
+      $ctrl.openGlobalWebsitesModal();
+      expect( $ctrl.$uibModal.open ).toHaveBeenCalledWith( {
+        component: 'globalWebsitesModal',
+        backdrop: 'static',
+        windowTemplateUrl: jasmine.any(String),
+        windowClass: 'globalWebsites--is-open',
+        resolve: {
+          menuStructure: $ctrl.menuStructure
+        }
       } );
     } );
   } );

--- a/src/common/components/nav/signOut.modal.tpl.html
+++ b/src/common/components/nav/signOut.modal.tpl.html
@@ -1,0 +1,5 @@
+<div style="height: 100px;">
+  <loading type="centered" inline="false">
+    <translate>Signing Out&hellip;</translate>
+  </loading>
+</div>


### PR DESCRIPTION
This adds a simple modal to act as a spinner during the sign-out / downgrade process. This blocks interactions with the page while signing out and will be removed after sign-out, although most sign-out actions either reload or navigate to another page.