### PR TITLE
Keep Mobile Scroll always on.

### DIFF
--- a/src/common/components/nav/subNav.tpl.html
+++ b/src/common/components/nav/subNav.tpl.html
@@ -9,7 +9,7 @@
       </li>
     </ul>
 
-    <ul class="sub-nav" ng-class="{'mobile-sub-nav': $ctrl.menuType === 'mobile'}">
+    <ul class="sub-nav mobile-sub-nav">
       <li>
         <a ng-href="{{$ctrl.subMenuStructure[$ctrl.subMenuStructure.length - 1].path}}"
            ng-class="{'active': $ctrl.menuPath.currentPage === ''}" translate>


### PR DESCRIPTION
Keeps Horizontal Mobile Scrolling always on. I know Jason already closed the issue, but this is still lingering and hanging out primarily when the Nav is being used on the rest of Cru.org with the long titles. 