### PR TITLE
Added host whitelisting to rollbar.

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -15,7 +15,8 @@ function rollbarConfig(envServiceProvider, $provide) {
     captureUnhandledRejections: true,
     environment: envServiceProvider.get(),
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
-    transform: transformRollbarPayload
+    transform: transformRollbarPayload,
+    hostWhiteList: ['give.cru.org', 'give-stage2.cru.org', 'stage.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org']
   };
   Rollbar = rollbar.init(rollbarConfig);
 


### PR DESCRIPTION
https://rollbar.com/docs/notifier/rollbar.js/configuration/#context-1

I'm not sure I implemented this correctly. Host might refer to the host the script file came from, or the host the page is on. I implemented the latter.