### PR TITLE
Disable rollbar unhandled rejections

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -12,7 +12,7 @@ function rollbarConfig(envServiceProvider, $provide) {
   let rollbarConfig = {
     accessToken: rollbarAccessToken,
     captureUncaught: true,
-    captureUnhandledRejections: true,
+    captureUnhandledRejections: false,
     environment: envServiceProvider.get(),
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
     transform: transformRollbarPayload,


### PR DESCRIPTION
I don't really know what code is triggering this but this should disable rollbar from reporting all these errors and hitting our rate limit. https://rollbar.com/Cru/give-web/items/211/.

They are getting fired on all kinds of cru.org pages. Idk if AEM uses promises anywhere.