### PR TITLE
Ep 1692

### DIFF
--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -203,7 +203,6 @@ export default class RecurringGiftModel {
 
   setDefaultsSingleGift(){
     this.gift['updated-designation-number'] = this.gift['designation-number'];
-    this.gift['updated-amount'] = 50;
     return this;
   }
 }

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -465,7 +465,6 @@ describe('recurringGift model', () => {
     it('should set default values for a new gift', () => {
       expect(giftModel.setDefaults().toObject).toEqual(jasmine.objectContaining({
         'updated-designation-number': giftModel.gift['designation-number'],
-        'updated-amount': 50,
         'updated-rate': {
           'recurrence': {
             'interval': 'Monthly'


### PR DESCRIPTION
When setting up a bulk 1-time gift, the form is prefilled with a default amount of $50, which is lower than we want to suggest for one-time gifts. ($50 is appropriate for recurring gifts, but we ask at least $100 for single). It would be better to not suggest an amount here but to leave it open-ended.