### PR TITLE
Enable updating credit cards during checkout

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -6,6 +6,7 @@ import paymentMethodDisplay from 'common/components/paymentMethods/paymentMethod
 import paymentMethodFormModal from 'common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.component';
 
 import orderService, {existingPaymentMethodFlag} from 'common/services/api/order.service';
+import {validPaymentMethod} from 'common/services/paymentHelpers/validPaymentMethods';
 import giveModalWindowTemplate from 'common/templates/giveModalWindow.tpl';
 
 import template from './existingPaymentMethods.tpl';
@@ -20,6 +21,7 @@ class ExistingPaymentMethodsController {
     this.orderService = orderService;
     this.$uibModal = $uibModal;
     this.paymentFormResolve = {};
+    this.validPaymentMethod = validPaymentMethod;
   }
 
   $onInit(){
@@ -71,16 +73,20 @@ class ExistingPaymentMethodsController {
     }
   }
 
-  openPaymentMethodFormModal(){
+  openPaymentMethodFormModal(existingPaymentMethod){
     this.paymentMethodFormModal = this.$uibModal.open({
       component: 'paymentMethodFormModal',
       backdrop: 'static', // Disables closing on click
       windowTemplateUrl: giveModalWindowTemplate.name,
       resolve: {
         paymentForm: this.paymentFormResolve,
+        paymentMethod: existingPaymentMethod,
+        disableCardNumber: !!existingPaymentMethod,
         mailingAddress: this.mailingAddress,
         onPaymentFormStateChange: () => param => {
           param.$event.stayOnStep = true;
+          param.$event.update = !!existingPaymentMethod;
+          param.$event.paymentMethodToUpdate = existingPaymentMethod;
           this.onPaymentFormStateChange(param);
         }
       }

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -165,7 +165,7 @@ describe('checkout', () => {
 
           // Test calling onSubmit
           self.controller.$uibModal.open.calls.first().args[0].resolve.onPaymentFormStateChange()({ $event: { state: 'loading', payload: 'some data' } });
-          expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: 'some data', stayOnStep: true } });
+          expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: 'some data', stayOnStep: true, update: false, paymentMethodToUpdate: undefined } });
         });
         it('should call onPaymentFormStateChange to clear submissionErrors when the modal closes', () => {
           spyOn(self.controller.$uibModal, 'open').and.returnValue({ result: Observable.throw('').toPromise() });

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -1,10 +1,11 @@
 <div class="panel panel-default tab-toggle">
   <div class="panel-title panel-heading" translate>Your Payment Methods</div>
   <div class="panel-body">
-    <div class="radio radio-method" ng-repeat="paymentMethod in $ctrl.paymentMethods">
+    <div class="radio radio-method" ng-repeat="paymentMethod in $ctrl.paymentMethods" ng-init="expired = !$ctrl.validPaymentMethod(paymentMethod)">
       <label>
-        <input type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" required>
-        <payment-method-display payment-method="paymentMethod"></payment-method-display>
+        <input ng-if="!expired" type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" required>
+        <button ng-if="expired" class="btn btn-xs btn-default" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)">Update</button>
+        <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
       </label>
     </div>
 

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -50,7 +50,10 @@ class Step2Controller{
   onPaymentFormStateChange($event){
     this.paymentFormState = $event.state;
     if($event.state === 'loading' && $event.payload){
-      this.orderService.addPaymentMethod($event.payload)
+      const request = $event.update ?
+        this.orderService.updatePaymentMethod($event.paymentMethodToUpdate, $event.payload) :
+        this.orderService.addPaymentMethod($event.payload);
+      request
         .subscribe(() => {
           if($event.stayOnStep){
             this.paymentFormState = 'success';

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -99,6 +99,13 @@ describe('checkout', () => {
         self.controller.onPaymentFormStateChange({ state: 'loading' });
         expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'review' });
       });
+      it('should update payment data', () => {
+        spyOn(self.controller, 'changeStep');
+        spyOn(self.controller.orderService, 'updatePaymentMethod').and.returnValue(Observable.of(''));
+        self.controller.onPaymentFormStateChange({ state: 'loading', payload: {creditCard: {}}, update: true, paymentMethodToUpdate: 'selected payment method' });
+        expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'review' });
+        expect(self.controller.orderService.updatePaymentMethod).toHaveBeenCalledWith('selected payment method', {creditCard: {}});
+      });
     });
   });
 });

--- a/src/app/profile/payment-methods/payment-method/payment-method.component.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.component.js
@@ -7,6 +7,7 @@ import deletePaymentMethodModal from 'common/components/paymentMethods/deletePay
 import giveModalWindowTemplate from 'common/templates/giveModalWindow.tpl';
 import profileService from 'common/services/api/profile.service';
 import formatAddressForTemplate from 'common/services/addressHelpers/formatAddressForTemplate';
+import {validPaymentMethod} from 'common/services/paymentHelpers/validPaymentMethods';
 
 import analyticsFactory from 'app/analytics/analytics.factory';
 
@@ -23,6 +24,7 @@ class PaymentMethodController{
     this.imgDomain = envService.read('imgDomain');
     this.paymentFormResolve = {};
     this.analyticsFactory = analyticsFactory;
+    this.validPaymentMethod = validPaymentMethod;
   }
 
   getExpiration(){

--- a/src/app/profile/payment-methods/payment-method/payment-method.tpl.html
+++ b/src/app/profile/payment-methods/payment-method/payment-method.tpl.html
@@ -3,7 +3,7 @@
       <div ng-class="{'collapsed': $ctrl.isCollapsed}" class="payment-summary-link p- collapse-indicator-row" role="button">
         <div class="row">
           <div class="col-sm-9">
-            <payment-method-display payment-method="$ctrl.model"></payment-method-display>
+            <payment-method-display payment-method="$ctrl.model" expired="!$ctrl.validPaymentMethod($ctrl.model)"></payment-method-display>
           </div>
           <div class="col-sm-3 text-right payment-details-link">
             <button class="btn trigger">Details</button>
@@ -18,7 +18,7 @@
           <div class="row">
 
             <div ng-if="$ctrl.isCard()" class="col-sm-6 col-md-4">
-              <p class="section-title mb0">Name of card</p>
+              <p class="section-title mb0">Name on card</p>
               <p>{{$ctrl.model['cardholder-name']}}</p>
             </div>
 

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.js
@@ -16,7 +16,7 @@ import RecurringGiftModel from 'common/models/recurringGift.model';
 import profileService from 'common/services/api/profile.service';
 import donationsService from 'common/services/api/donations.service';
 import commonService from 'common/services/api/common.service';
-import validPaymentMethods from 'common/services/paymentHelpers/validPaymentMethods';
+import {validPaymentMethods} from 'common/services/paymentHelpers/validPaymentMethods';
 import {scrollModalToTop} from 'common/services/modalState.service';
 
 import template from './editRecurringGifts.modal.tpl';

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.component.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.component.js
@@ -19,7 +19,7 @@ import suggestedRecipients from './step1/suggestedRecipients/suggestedRecipients
 import redirectGiftStep2 from '../redirectGift/step2/redirectGiftStep2.component';
 import configureGifts from './step2/configureGifts/configureGifts.component';
 import confirmGifts from './step3/confirmGifts/confirmGifts.component';
-import validPaymentMethods from 'common/services/paymentHelpers/validPaymentMethods';
+import {validPaymentMethods} from 'common/services/paymentHelpers/validPaymentMethods';
 import addUpdatePaymentMethod from 'src/app/profile/yourGiving/editRecurringGifts/step0/addUpdatePaymentMethod.component';
 import step0PaymentMethodList from 'src/app/profile/yourGiving/editRecurringGifts/step0/paymentMethodList.component';
 

--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -488,8 +488,6 @@ hr.vertical-divider {
     color: red;
   }
   img {
-    width: 40px;
-    height: auto;
     margin-right: $gutter*.5;
     display: inline-block;
     vertical-align: middle;

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -163,6 +163,7 @@ export default angular
     bindings: {
       paymentFormState: '<',
       paymentMethod: '<',
+      disableCardNumber: '<',
       mailingAddress: '<',
       onPaymentFormStateChange: '&'
     }

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -8,7 +8,13 @@
       <div class="col-sm-6">
         <div class="form-group is-required" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.cardNumber | showErrors)}">
           <label translate>Card #</label>
-          <input type="text" name="cardNumber" class="form-control  form-control-subtle" ng-model="$ctrl.creditCardPayment.cardNumber" ng-attr-placeholder="************{{$ctrl.creditCardPayment.cardNumberPlaceholder}}" ng-required="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber">
+          <input type="text"
+                 name="cardNumber"
+                 class="form-control  form-control-subtle"
+                 ng-model="$ctrl.creditCardPayment.cardNumber"
+                 ng-attr-placeholder="************{{$ctrl.creditCardPayment.cardNumberPlaceholder}}"
+                 ng-required="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber"
+                 ng-disabled="$ctrl.disableCardNumber">
           <div ng-messages="$ctrl.creditCardPaymentForm.cardNumber.$error" role="alert" ng-if="($ctrl.creditCardPaymentForm.cardNumber | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter a card number</div>
             <div class="help-block" ng-message="minlength" translate>This card number must contain at least 13 digits</div>

--- a/src/common/components/paymentMethods/paymentMethodDisplay.component.js
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.component.js
@@ -22,6 +22,7 @@ export default angular
     controller: PaymentMethodDisplayController,
     templateUrl: template.name,
     bindings: {
-      paymentMethod: '<'
+      paymentMethod: '<',
+      expired: '<'
     }
   });

--- a/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
@@ -1,6 +1,7 @@
 <span ng-switch="$ctrl.paymentMethod.self.type" class="account-management">
   <span ng-switch-when="cru.creditcards.named-credit-card">
     <span ng-switch="$ctrl.paymentMethod['card-type']">
+      &nbsp;
       <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/american-express-curved-128px.png" ng-switch-when="American Express"/>
       <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/discover-curved-128px.png" ng-switch-when="Discover"/>
       <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/mastercard-curved-128px.png" ng-switch-when="MasterCard"/>
@@ -9,8 +10,10 @@
     </span>
     <strong>{{$ctrl.paymentMethod['card-type']}}</strong>
     <span translate>ends in ****{{$ctrl.paymentMethod['card-number']}}</span>
-    <small class="number" translate>
-      EXP<span class="hidden-xs">IRES</span>
+    <small class="number" ng-class="{'text-danger': $ctrl.expired}">
+      <span class="hidden-xs" ng-if="!$ctrl.expired" translate>EXPIRES</span>
+      <span class="hidden-xs" ng-if="$ctrl.expired" translate>EXPIRED</span>
+      <span class="visible-xs-inline">EXP</span>
       {{$ctrl.paymentMethod['expiry-month']}}/<span class="hidden-xs">{{$ctrl.paymentMethod['expiry-year'] | limitTo : 2}}</span>{{$ctrl.paymentMethod['expiry-year'] | limitTo : 2 : 2}}
     </small>
   </span>

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -48,6 +48,7 @@ export default angular
       paymentFormState: '<',
       paymentFormError: '<',
       paymentMethod: '<',
+      disableCardNumber: '<',
       mailingAddress: '<',
       onPaymentFormStateChange: '&'
     }

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
@@ -24,7 +24,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
-        <payment-method-form payment-form-state="$ctrl.resolve.paymentForm.state" payment-form-error="$ctrl.resolve.paymentForm.error" on-payment-form-state-change="$ctrl.resolve.onPaymentFormStateChange({$event: $event})" payment-method="$ctrl.resolve.paymentMethod" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
+        <payment-method-form payment-form-state="$ctrl.resolve.paymentForm.state" payment-form-error="$ctrl.resolve.paymentForm.error" on-payment-form-state-change="$ctrl.resolve.onPaymentFormStateChange({$event: $event})" payment-method="$ctrl.resolve.paymentMethod" disable-card-number="$ctrl.resolve.disableCardNumber" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
       </div>
     </div>
 

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
@@ -47,6 +47,6 @@
 </div>
 <div class="tab-org cart-tab show" ng-if="$ctrl.paymentType === 'creditCard'">
 
-  <credit-card-form payment-form-state="$ctrl.paymentFormState" on-payment-form-state-change="$ctrl.onPaymentFormStateChange({ $event: $event })" payment-method="$ctrl.paymentMethod" mailing-address="$ctrl.mailingAddress"></credit-card-form>
+  <credit-card-form payment-form-state="$ctrl.paymentFormState" on-payment-form-state-change="$ctrl.onPaymentFormStateChange({ $event: $event })" payment-method="$ctrl.paymentMethod" disable-card-number="$ctrl.disableCardNumber" mailing-address="$ctrl.mailingAddress"></credit-card-form>
 
 </div>

--- a/src/common/services/paymentHelpers/validPaymentMethods.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.js
@@ -2,10 +2,10 @@ import filter from 'lodash/filter';
 import moment from 'moment';
 
 // Filter out expired credit cards
-function validPaymentMethods(paymentMethods){
-  return filter(paymentMethods, (paymentMethod) => {
-    return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1}).isSameOrAfter(moment(), 'month');
-  });
+export function validPaymentMethods(paymentMethods){
+  return filter(paymentMethods, validPaymentMethod);
 }
 
-export default validPaymentMethods;
+export function validPaymentMethod(paymentMethod){
+    return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1}).isSameOrAfter(moment(), 'month');
+}

--- a/src/common/services/paymentHelpers/validPaymentMethods.spec.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.spec.js
@@ -1,4 +1,4 @@
-import validPaymentMethods from './validPaymentMethods';
+import {validPaymentMethods, validPaymentMethod} from './validPaymentMethods';
 
 describe('validPaymentMethods', () => {
   beforeEach(() => {
@@ -91,5 +91,39 @@ describe('validPaymentMethods', () => {
       paymentMethods[4],
       paymentMethods[6]
     ]);
+  });
+});
+
+describe('validPaymentMethod', () => {
+  beforeEach(() => {
+    jasmine.clock().mockDate(new Date(2015, 0, 10));
+  });
+  it('should consider bank accounts valid', () => {
+    let paymentMethod = {
+      self: {
+        type: 'elasticpath.bankaccounts.bank-account'
+      }
+    };
+    expect(validPaymentMethod(paymentMethod)).toEqual(true);
+  });
+  it('should consider unexpired credit cards valid', () => {
+    let paymentMethod = {
+      self: {
+        type: 'cru.creditcards.named-credit-card'
+      },
+      'expiry-month': '01',
+      'expiry-year': '2015'
+    };
+    expect(validPaymentMethod(paymentMethod)).toEqual(true);
+  });
+  it('should consider expired credit cards invalid', () => {
+    let paymentMethod = {
+      self: {
+        type: 'cru.creditcards.named-credit-card'
+      },
+      'expiry-month': '12',
+      'expiry-year': '2014'
+    };
+    expect(validPaymentMethod(paymentMethod)).toEqual(false);
   });
 });


### PR DESCRIPTION
- Add update handling to step 2 and existingPaymentMethod components
- Use different styling for displaying past expiry date
- Allow disabling card number input in creditCardForm
- Add updatePaymentMethod to order service
- Format address when loading existing payment methods
- Seperate validatePaymentMethods to a single payment method validator and a filter function