### PR TITLE
Gracefully handle missing next-draw-date

### DIFF
--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -1,3 +1,4 @@
+import angular from 'angular';
 import moment from 'moment';
 import find from 'lodash/find';
 
@@ -160,7 +161,7 @@ export default class RecurringGiftModel {
       // We have to take transactionDay into account here when it is modified for monthly gifts since they don't set the updated-start-month/year fields
       giftDate = startDate(this.transactionDay, this.nextDrawDate, 0, this.parentDonation['start-date']['display-value']);
     }else{
-      giftDate = moment(this.parentDonation['next-draw-date']['display-value']);
+      giftDate = this.parentDonation['next-draw-date'] && moment(this.parentDonation['next-draw-date']['display-value']);
     }
     return giftDate;
   }

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -381,6 +381,10 @@ describe('recurringGift model', () => {
     it('should return the old draw date when start month and transaction day are unchanged', () => {
       expect(giftModel.nextGiftDate.toString()).toEqual(moment('2015-05-06').toString());
     });
+    it('should handle the case when the parent donation doesn\'t have a next draw date', () => {
+      delete giftModel.parentDonation['next-draw-date'];
+      expect(giftModel.nextGiftDate).toBeUndefined();
+    });
   });
 
   describe('initStartMonth', () => {


### PR DESCRIPTION
It seems that errored donations don't include a next-draw-date. This makes the frontend handle that case without throwing an error. Should fix https://rollbar.com/Cru/give-web/items/177 which I think was causing us to hit our rate limit.

I'm still not sure why we are showing errored donations to the user as they prevent payment methods from being deleted. That discussion is here https://jira.cru.org/browse/EP-1723.