### PR TITLE
Show generic sign in error if returned error value is falsy

### DIFF
--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -32,13 +32,13 @@ class SignInFormController {
       .signIn( this.username, this.password )
       .subscribe( () => {
         this.onSuccess();
-      }, ( error ) => {
+      }, error => {
         this.isSigningIn = false;
-        if( angular.isUndefined( error.data ) || error.data === null ) {
+        if( error && error.data && error.data.error ) {
+          this.errorMessage = error.data.error;
+        } else {
           this.$log.error('Sign In Error', error);
           this.errorMessage = this.gettext( 'An error has occurred signing in. Please try again.' );
-        } else {
-          this.errorMessage = error.data.error;
         }
         this.onFailure();
       } );


### PR DESCRIPTION
I'm trying to fix https://jira.cru.org/browse/EP-1700. It seems that no error was ever displayed to the user. My thought is that `error.data.error` was something falsy like `''`. I'm not sure the old condition covered all the cases. Feel free to suggest other ways to do this. Idk what the server 500 error was in the jira ticket but the user should be shown an error regardless. I'm also not sure how to reproduce a 500 to test this.