### PR TITLE
EP-1654: Set cvv to existing payment method flag if the chosen paymen…

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -106,6 +106,9 @@ class ExistingPaymentMethodsController {
   selectPayment(){
     if(this.selectedPaymentMethod.chosen){
       this.onPaymentFormStateChange({ $event: { state: 'loading' } });
+      if(!this.orderService.retrieveCardSecurityCode()){
+        this.orderService.storeCardSecurityCode(existingPaymentMethodFlag);
+      }
     }else{
       this.orderService.selectPaymentMethod(this.selectedPaymentMethod.selectAction)
         .subscribe(() => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -203,6 +203,15 @@ describe('checkout', () => {
           self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account'}, chosen: true };
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
+          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(existingPaymentMethodFlag);
+          expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
+        });
+        it('should not send a request if the payment is already selected and should not modify the cvv if it is already set', () => {
+          spyOn(self.controller.orderService, 'retrieveCardSecurityCode').and.returnValue('cvv already stored');
+          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account'}, chosen: true };
+          self.controller.selectPayment();
+          expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
+          expect(self.controller.orderService.storeCardSecurityCode).not.toHaveBeenCalled();
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
         });
       });


### PR DESCRIPTION
…t method is selected and the cvv in session storage is empty

Also should fix https://jira.cru.org/browse/EP-1707