### PR TITLE
Add other amount input to suggested amounts in productConfigModal

### DIFF
--- a/src/app/productConfig/productConfig.component.js
+++ b/src/app/productConfig/productConfig.component.js
@@ -31,7 +31,6 @@ class ProductConfigController {
     this.error = false;
     let modalInstance = this.productModalService
       .configureProduct( this.productCode, {
-        amount: 50,
         'campaign-code': this.campaignCode,
         'campaign-page': this.campaignPage
       }, false );
@@ -81,7 +80,7 @@ export default angular
       function ( $location, productModalService ) {
         let params = $location.search();
         if ( params.hasOwnProperty( giveGiftParams.designation ) ) {
-          productModalService.configureProduct( params[giveGiftParams.designation], {amount: 50}, false );
+          productModalService.configureProduct( params[giveGiftParams.designation], null, false );
         }
       } );
   } );

--- a/src/app/productConfig/productConfig.component.spec.js
+++ b/src/app/productConfig/productConfig.component.spec.js
@@ -41,7 +41,7 @@ describe( 'productConfig', function () {
 
     it( 'opens productConfig modal', () => {
       $ctrl.configModal();
-      expect( productModalService.configureProduct ).toHaveBeenCalledWith( '0123456', {amount: 50, 'campaign-code': 'test123', 'campaign-page': undefined}, false );
+      expect( productModalService.configureProduct ).toHaveBeenCalledWith( '0123456', {'campaign-code': 'test123', 'campaign-page': undefined}, false );
     } );
 
     it( 'updates after modal rendered', () => {

--- a/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
@@ -38,24 +38,53 @@
             Gift Amount
           </h4>
           <div class="panel-body pt0">
-            <div ng-if="$ctrl.suggestedAmounts">
-              <div class="radio radio-custom-amount" ng-repeat="suggested in $ctrl.suggestedAmounts | orderBy:'order'">
+            <div ng-if="$ctrl.useSuggestedAmounts">
+              <div class="radio radio-custom-amount"
+                   ng-repeat="suggested in $ctrl.suggestedAmounts | orderBy:'order'">
                 <label>
-                  <input name="amount"
-                         ng-model="$ctrl.customAmount"
-                         ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
+                  <input name="suggestedAmount"
                          type="radio"
-                         ng-value="suggested.amount"
-                         required>{{suggested.amount | currency:'$':2}} {{suggested.label}}
+                         ng-click="$ctrl.changeAmount(suggested.amount)"
+                         ng-checked="!$ctrl.customInputActive && $ctrl.itemConfig.amount === suggested.amount">
+                  {{suggested.amount | currency:'$':2}} {{suggested.label}}
                 </label>
+              </div>
+              <div class="radio radio-custom-amount form-inline" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">
+                <div class="form-group">
+                  <label>
+                    <input name="suggestedAmount"
+                           type="radio"
+                           ng-checked="$ctrl.customInputActive">
+                    <input class="form-control form-control-subtle"
+                           name="amount"
+                           type="text"
+                           step="1"
+                           tabindex="-1"
+                           ng-model="$ctrl.customAmount"
+                           ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
+                           ng-focus="$ctrl.customInputActive = true;"
+                           ng-required="$ctrl.customInputActive"
+                           placeholder="{{'Other' | translate}}">
+                  </label>
+                  <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
+                       ng-if="($ctrl.itemConfigForm.amount | showErrors)">
+                    <div class="help-block" ng-message="pattern" translate>Your gift must be a valid dollar amount</div>
+                    <div class="help-block" ng-message="required" translate>Amount must be not empty</div>
+                    <div class="help-block" ng-message="minimum" translate>Amount must be at least {{ 1 | currency }}</div>
+                    <div class="help-block" ng-message="maximum" translate>
+                      Amount must be less than {{ 10000000 | currency }}
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
 
-            <div data-toggle="buttons" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}"
-                 ng-if="$ctrl.showDefaultAmounts()">
+            <div data-toggle="buttons"
+                 ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}"
+                 ng-if="!$ctrl.useSuggestedAmounts">
               <label class="btn btn-radio"
                      ng-click="$ctrl.changeAmount(a)"
-                     ng-class="{'active': $ctrl.itemConfig.amount == a && !$ctrl.customInputActive}"
+                     ng-class="{'active': $ctrl.itemConfig.amount === a && !$ctrl.customInputActive}"
                      ng-repeat-start="a in $ctrl.selectableAmounts">
                 <span class="number">${{a}}</span>
               </label>
@@ -73,7 +102,7 @@
                          ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
                          ng-focus="$ctrl.customInputActive = true;"
                          tabindex="-1"
-                         placeholder="{{'Other'|translate}}"
+                         placeholder="{{'Other' | translate}}"
                          required>
                 </div>
               </label>

--- a/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.js
+++ b/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.js
@@ -13,7 +13,7 @@ class HistoricalGift {
   }
 
   giveNewGift() {
-    this.productModalService.configureProduct( this.gift['historical-donation-line']['designation-number'], {amount: 50} );
+    this.productModalService.configureProduct( this.gift['historical-donation-line']['designation-number'] );
   }
 
   manageGift() {

--- a/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.spec.js
+++ b/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.spec.js
@@ -3,7 +3,7 @@ import 'angular-mocks';
 import module from './historicalGift.component';
 
 describe( 'your giving', function () {
-  describe( 'recipient view', () => {
+  describe( 'historical view', () => {
     describe( 'recipient gift', () => {
       beforeEach( angular.mock.module( module.name ) );
       let $ctrl;
@@ -35,7 +35,7 @@ describe( 'your giving', function () {
         it( 'displays productConfig modal', () => {
           $ctrl.gift = {'historical-donation-line': {'designation-number': '01234567'}};
           $ctrl.giveNewGift();
-          expect( $ctrl.productModalService.configureProduct ).toHaveBeenCalledWith( '01234567', jasmine.any( Object ) );
+          expect( $ctrl.productModalService.configureProduct ).toHaveBeenCalledWith( '01234567' );
         } );
       } );
     } );

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
@@ -51,7 +51,7 @@ class RecipientGift {
   }
 
   giveNewGift() {
-    this.productModalService.configureProduct( this.recipient['designation-number'], {amount: 50} );
+    this.productModalService.configureProduct( this.recipient['designation-number'] );
   }
 
   recurringGift(recurring) {

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.spec.js
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.spec.js
@@ -91,7 +91,7 @@ describe( 'your giving', function () {
         it( 'displays productConfig modal', () => {
           $ctrl.recipient = {'designation-number': '01234567'};
           $ctrl.giveNewGift();
-          expect( $ctrl.productModalService.configureProduct ).toHaveBeenCalledWith( '01234567', jasmine.any(Object) );
+          expect( $ctrl.productModalService.configureProduct ).toHaveBeenCalledWith( '01234567' );
         } );
       } );
 

--- a/src/common/services/productModal.service.js
+++ b/src/common/services/productModal.service.js
@@ -19,6 +19,7 @@ function ProductModalService( $uibModal, $location, designationsService, commonS
     if ( modalOpen ) {
       return;
     }
+    config = config || {};
     modalOpen = true;
     isEdit = !!isEdit;
     let modalInstance = $uibModal


### PR DESCRIPTION
- Default gift amounts inside product modal and remove explicit calls to pass in a default amount of $50
- Default amount to first suggested amount or first selectable amount
- Call changeCustomAmount if loaded amount is not a suggested amount or selectable amount
- Set useSuggestedAmounts during initialization to pick between suggested amounts or selectable amounts view and remove showDefaultAmounts
- Cleanup $onInit and refactor into multiple functions
- Refactor query param updates into updateQueryParam to reduce duplicated calls to isEdit
- Refactor isEdit tests to reduce duplicate code

https://jira.cru.org/browse/EP-1754