### PR TITLE
[#EP-1769] Reset session when items added to a public, empty cart.

### DIFF
--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -105,18 +105,19 @@ class Cart {
           this.$cookies.remove(Sessions.give, {path: '/', domain: '.cru.org'});
           // Defer til next digest so $cookie.remove propagates.
           return Observable.from(this.$timeout(angular.noop, 10)).mergeMap(() => {
-            return this.cortexApiService.post({
-              path: ['itemfieldslineitem', uri],
-              data: data
-            });
+            return this._addItem(uri, data);
           });
         }
-        return this.cortexApiService.post({
-          path: ['itemfieldslineitem', uri],
-          data: data
-        });
+        return this._addItem(uri, data);
       });
     }
+    return this._addItem(uri, data);
+  }
+
+  /**
+   * @private
+   */
+  _addItem(uri, data) {
     return this.cortexApiService.post({
       path: ['itemfieldslineitem', uri],
       data: data

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -4,7 +4,7 @@ import 'angular-mocks';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/empty';
-import {Roles, Sessions} from 'common/services/session/session.service';
+import {Roles} from 'common/services/session/session.service';
 
 import module from './cart.service';
 
@@ -88,7 +88,7 @@ describe('cart service', () => {
         .respond(200, cartResponse);
 
       self.cartService.getTotalQuantity().subscribe((total) => {
-        expect(total).toEqual(3)
+        expect(total).toEqual(3);
       });
       self.$httpBackend.flush();
     });
@@ -115,7 +115,7 @@ describe('cart service', () => {
     describe('as a public user', () => {
       beforeEach(() => {
         self.cartService.sessionService.getRole.and.returnValue(Roles.public);
-        spyOn(self.cartService.$cookies, 'remove')
+        spyOn(self.cartService.$cookies, 'remove');
       });
 
       describe('with existing cart', () => {


### PR DESCRIPTION
This will reset a session anytime an item is added to a public, empty cart. This prevents saved address/payments from being used across guest checkout.

Fixes https://jira.cru.org/browse/EP-1769