### PR TITLE
Show user friendly server error messages in contactInfo component

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
       "angular-upload": "npm:angular-upload@^1.0.13",
       "jsencrypt": "npm:jsencrypt@^2.3.1",
       "jwt-decode": "github:auth0/jwt-decode@^2.1.0",
+      "libphonenumber-js": "npm:libphonenumber-js@^0.3.7",
       "lodash": "npm:lodash@^4.17.2",
       "moment": "npm:moment@^2.17.1",
       "ng-resize": "npm:ng-resize@^1.2.0",

--- a/src/app/profile/profile.spec.js
+++ b/src/app/profile/profile.spec.js
@@ -79,10 +79,16 @@ describe( 'ProfileComponent', function () {
       spyOn( $ctrl, 'loadMailingAddress' );
       spyOn( $ctrl, 'loadEmail' );
       spyOn( $ctrl, 'loadPhoneNumbers' );
+      spyOn( $ctrl, 'syncPhoneValidators' );
       spyOn( $ctrl, 'sessionEnforcerService' );
       spyOn( $ctrl.$rootScope, '$on' );
       spyOn( $ctrl, 'signedOut' );
     } );
+
+    it('should call syncPhoneValidators', () =>{
+      $ctrl.$onInit();
+      expect( $ctrl.syncPhoneValidators ).toHaveBeenCalled();
+    });
 
     it( 'adds listener for sign-out event', () => {
       $ctrl.$onInit();
@@ -251,24 +257,6 @@ describe( 'ProfileComponent', function () {
     });
   });
 
-  describe('loadPhoneNumbers()', () => {
-    it('should load phone numbers on $onInit()', () => {
-      spyOn($ctrl.profileService, 'getPhoneNumbers').and.returnValue(Observable.of([{}]));
-      $ctrl.loadPhoneNumbers();
-      expect($ctrl.phoneNumbers).toEqual([{ ownerChanged: false }]);
-      expect($ctrl.profileService.getPhoneNumbers).toHaveBeenCalled();
-    });
-
-    it('should handle and error of loading phone numbers on $onInit()', () => {
-      spyOn($ctrl.profileService, 'getPhoneNumbers').and.returnValue(Observable.throw({
-        data: 'some error'
-      }));
-      $ctrl.loadPhoneNumbers();
-      expect($ctrl.phoneNumberError).toBe('Failed loading phone numbers.');
-      expect($ctrl.profileService.getPhoneNumbers).toHaveBeenCalled();
-    });
-  });
-
   describe('updateEmail()', () => {
     it('should update donor email', () => {
       spyOn($ctrl.profileService, 'updateEmail').and.returnValue(Observable.of({email: 'new email'}));
@@ -291,6 +279,41 @@ describe( 'ProfileComponent', function () {
       $ctrl.updateEmail();
       expect($ctrl.emailAddressError).toBe('Failed updating email address.');
       expect($ctrl.profileService.updateEmail).toHaveBeenCalled();
+    });
+  });
+
+  describe('syncPhoneValidators()', () => {
+    it('should add phone number validators to inputs', () => {
+      $ctrl.phoneNumberForms = {};
+      $ctrl.syncPhoneValidators();
+      $ctrl.$scope.$apply();
+      expect($ctrl.phoneNumberForms).toEqual({});
+      $ctrl.phoneNumberForms[0] = {
+        phoneNumber: {
+          $validators: {}
+        }
+      };
+      $ctrl.$scope.$apply();
+      expect( $ctrl.phoneNumberForms[0].phoneNumber.$validators.phone( '541-967-0010' ) ).toEqual( true );
+      expect( $ctrl.phoneNumberForms[0].phoneNumber.$validators.phone( '123-456-7890' ) ).toEqual( false );
+    });
+  });
+
+  describe('loadPhoneNumbers()', () => {
+    it('should load phone numbers on $onInit()', () => {
+      spyOn($ctrl.profileService, 'getPhoneNumbers').and.returnValue(Observable.of([{}]));
+      $ctrl.loadPhoneNumbers();
+      expect($ctrl.phoneNumbers).toEqual([{ ownerChanged: false }]);
+      expect($ctrl.profileService.getPhoneNumbers).toHaveBeenCalled();
+    });
+
+    it('should handle and error of loading phone numbers on $onInit()', () => {
+      spyOn($ctrl.profileService, 'getPhoneNumbers').and.returnValue(Observable.throw({
+        data: 'some error'
+      }));
+      $ctrl.loadPhoneNumbers();
+      expect($ctrl.phoneNumberError).toBe('Failed loading phone numbers.');
+      expect($ctrl.profileService.getPhoneNumbers).toHaveBeenCalled();
     });
   });
 

--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -161,12 +161,13 @@
                               <option translate>Work</option>
                               <option translate>Unknown</option>
                             </select>
-                            <input name="phoneNumber" type="tel" class="form-control form-control-subtle" ng-model="phone['phone-number']" required maxlength="20">
+                            <input name="phoneNumber" type="tel" class="form-control form-control-subtle" ng-model="phone['phone-number']" required>
                             <select name="spousePhoneNumber" ng-model="phone.spouse" ng-change="phone.ownerChanged = !phone.ownerChanged" ng-options="$ctrl.phoneOwner(spouse) for spouse in [true, false]" class="form-control form-control-subtle" ng-disabled="!$ctrl.hasSpouse"></select>
                             <a id="removeSpousePhoneNumberLink" href="" ng-click="$ctrl.deletePhoneNumber(phone, $index)"><i class="fa fa-minus-circle" aria-hidden="true"></i></a>
                           </form>
                           <div role="alert" ng-messages="$ctrl.phoneNumberForms[$index].phoneNumber.$error" ng-if="($ctrl.phoneNumberForms[$index].phoneNumber | showErrors)">
                             <div class="help-block" ng-message="required" translate>You must enter a phone number</div>
+                            <div class="help-block" ng-message="phone" translate>The phone number entered is invalid</div>
                           </div>
                         </div>
                       </div>

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -1,6 +1,19 @@
-
-<div class="alert alert-danger" role="alert" ng-if="$ctrl.submissionError">
-  <p>{{$ctrl.submissionError | translate}}</p>
+<div class="alert alert-danger" role="alert" ng-if="$ctrl.submissionError" ng-switch="$ctrl.submissionError">
+  <p ng-switch-when="Invalid title." translate>
+    There was an error saving the title you have chosen.
+  </p>
+  <p ng-switch-when="Invalid email address" translate>
+    There was an error saving your email address. Make sure it was entered correctly.
+  </p>
+  <p ng-switch-when="In order to add the spouse , [family-name] and [given-name] are required" translate>
+    There was an error saving your contact info. Make sure your spouse's first and last name are correct.
+  </p>
+  <p ng-switch-when="Access to the specified resource is forbidden." translate>
+    There was an error saving your contact info. Your session may have expired. If you continue to experience issues, try signing out and back in.
+  </p>
+  <p ng-switch-default translate>
+    There was an error saving your contact info. Please try again or contact support.
+  </p>
 </div>
 
 <div ng-if="$ctrl.donorDetails" class="loading-overlay-parent">
@@ -9,7 +22,7 @@
   </loading>
 
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingDonorDetailsError">
-    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, please contact support</p>
+    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, please contact support.</p>
     <p><button id="retryButton1" type="button" class="btn btn-primary" ng-click="$ctrl.loadDonorDetails()" translate>Retry</button></p>
   </div>
 
@@ -112,9 +125,9 @@
         <div class="col-sm-6">
           <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.phoneNumber | showErrors)}">
             <label translate>Phone</label>
-            <input type="text" class="form-control  form-control-subtle" name="phoneNumber" ng-model="$ctrl.donorDetails['phone-number']" ng-maxlength="100">
+            <input type="text" class="form-control  form-control-subtle" name="phoneNumber" ng-model="$ctrl.donorDetails['phone-number']">
             <div role="alert" ng-messages="$ctrl.detailsForm.phoneNumber.$error" ng-if="($ctrl.detailsForm.phoneNumber | showErrors)">
-              <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 100 characters</div>
+              <div class="help-block" ng-message="phone" translate>The phone number entered is invalid</div>
             </div>
           </div>
         </div>
@@ -225,9 +238,10 @@
         <div class="col-sm-12">
           <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.orgName | showErrors)}">
             <label translate>Organization Name</label>
-            <input type="text" class="form-control form-control-subtle" name="orgName" ng-model="$ctrl.donorDetails['organization-name']" required>
+            <input type="text" class="form-control form-control-subtle" name="orgName" ng-model="$ctrl.donorDetails['organization-name']" ng-maxlength="100" required>
             <div role="alert" ng-messages="$ctrl.detailsForm.orgName.$error" ng-if="($ctrl.detailsForm.orgName | showErrors)">
               <div class="help-block" ng-message="required" translate>You must enter an organization name</div>
+              <div class="help-block" ng-message="maxlength" translate>Organization name cannot be longer that 100 characters</div>
             </div>
           </div>
         </div>

--- a/system.config.js
+++ b/system.config.js
@@ -38,7 +38,8 @@ System.config({
     "core-js": "npm:core-js@1.2.7",
     "jsencrypt": "npm:jsencrypt@2.3.1",
     "jwt-decode": "github:auth0/jwt-decode@2.1.0",
-    "lodash": "npm:lodash@4.17.2",
+    "libphonenumber-js": "npm:libphonenumber-js@0.3.7",
+    "lodash": "npm:lodash@4.17.4",
     "moment": "npm:moment@2.17.1",
     "ng-resize": "npm:ng-resize@1.2.0",
     "plugin-babel": "npm:systemjs-plugin-babel@0.0.13",
@@ -75,6 +76,17 @@ System.config({
     "github:jspm/nodelibs-events@0.1.1": {
       "events": "npm:events@1.0.2"
     },
+    "github:jspm/nodelibs-http@1.7.1": {
+      "Base64": "npm:Base64@0.2.1",
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "inherits": "npm:inherits@2.0.1",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "url": "github:jspm/nodelibs-url@0.1.0",
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "github:jspm/nodelibs-https@0.1.0": {
+      "https-browserify": "npm:https-browserify@0.0.0"
+    },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
@@ -83,6 +95,12 @@ System.config({
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"
+    },
+    "github:jspm/nodelibs-string_decoder@0.1.0": {
+      "string_decoder": "npm:string_decoder@0.10.31"
+    },
+    "github:jspm/nodelibs-timers@0.1.0": {
+      "timers-browserify": "npm:timers-browserify@1.4.2"
     },
     "github:jspm/nodelibs-tty@0.1.0": {
       "tty-browserify": "npm:tty-browserify@0.0.0"
@@ -123,7 +141,14 @@ System.config({
     "npm:babel-runtime@5.8.38": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
+    "npm:babel-runtime@6.23.0": {
+      "core-js": "npm:core-js@2.4.1",
+      "regenerator-runtime": "npm:regenerator-runtime@0.10.3"
+    },
     "npm:beeper@1.1.1": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:bluebird@3.4.7": {
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:buffer-shims@1.0.0": {
@@ -173,6 +198,12 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"
     },
     "npm:core-js@1.2.7": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+    },
+    "npm:core-js@2.4.1": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
@@ -279,6 +310,9 @@ System.config({
     "npm:hosted-git-info@2.1.5": {
       "url": "github:jspm/nodelibs-url@0.1.0"
     },
+    "npm:https-browserify@0.0.0": {
+      "http": "github:jspm/nodelibs-http@1.7.1"
+    },
     "npm:indent-string@2.1.0": {
       "repeating": "npm:repeating@2.0.1"
     },
@@ -312,6 +346,18 @@ System.config({
     },
     "npm:lazy-cache@1.0.4": {
       "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:libphonenumber-js@0.3.7": {
+      "babel-runtime": "npm:babel-runtime@6.23.0",
+      "bluebird": "npm:bluebird@3.4.7",
+      "child_process": "github:jspm/nodelibs-child_process@0.1.0",
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "https": "github:jspm/nodelibs-https@0.1.0",
+      "minimist": "npm:minimist@1.2.0",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.2",
+      "xml2js": "npm:xml2js@0.4.17"
     },
     "npm:load-json-file@1.1.0": {
       "graceful-fs": "npm:graceful-fs@4.1.11",
@@ -453,6 +499,10 @@ System.config({
       "indent-string": "npm:indent-string@2.1.0",
       "strip-indent": "npm:strip-indent@1.0.1"
     },
+    "npm:regenerator-runtime@0.10.3": {
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
     "npm:repeating@2.0.1": {
       "is-finite": "npm:is-finite@1.0.2"
     },
@@ -477,6 +527,12 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",
       "symbol-observable": "npm:symbol-observable@1.0.4"
+    },
+    "npm:sax@1.2.2": {
+      "buffer": "github:jspm/nodelibs-buffer@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "stream": "github:jspm/nodelibs-stream@0.1.0",
+      "string_decoder": "github:jspm/nodelibs-string_decoder@0.1.0"
     },
     "npm:semver@5.3.0": {
       "process": "github:jspm/nodelibs-process@0.1.2"
@@ -559,6 +615,9 @@ System.config({
       "util": "github:jspm/nodelibs-util@0.1.0",
       "xtend": "npm:xtend@4.0.1"
     },
+    "npm:timers-browserify@1.4.2": {
+      "process": "npm:process@0.11.9"
+    },
     "npm:uglify-js@2.6.4": {
       "async": "npm:async@0.2.10",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
@@ -607,6 +666,17 @@ System.config({
     "npm:window-size@0.1.0": {
       "process": "github:jspm/nodelibs-process@0.1.2",
       "tty": "github:jspm/nodelibs-tty@0.1.0"
+    },
+    "npm:xml2js@0.4.17": {
+      "events": "github:jspm/nodelibs-events@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "sax": "npm:sax@1.2.2",
+      "timers": "github:jspm/nodelibs-timers@0.1.0",
+      "xmlbuilder": "npm:xmlbuilder@4.2.1"
+    },
+    "npm:xmlbuilder@4.2.1": {
+      "lodash": "npm:lodash@4.17.4",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:xtend@4.0.1": {
       "systemjs-json": "github:systemjs/plugin-json@0.1.2"


### PR DESCRIPTION
- Map server error messages to translated user friendly strings
- Add phone number validation to contactInfo form and profile using libphonenumber
- Cleanup Invalid email address server error message for easier template matching
- Add org name validation to cap it at 100 chars

https://jira.cru.org/browse/EP-1776

I looked through ['Error saving donor contact info' rollbar errors](https://rollbar.com/Cru/give-web/items/?query=Error%20saving%20donor%20contact%20info&sort=last_desc&status=active) to find the possible error messages. I added validators instead of a `ng-switch-when` cases for the phone number invalid and org length errors.