### PR TITLE
Retry loading the nav once on failure and convert -1 status to rollba…

### DIFF
--- a/src/common/components/nav/nav.component.spec.js
+++ b/src/common/components/nav/nav.component.spec.js
@@ -147,6 +147,12 @@ describe( 'nav', function () {
       $ctrl.$onInit();
       expect($ctrl.$log.error.logs[0]).toEqual(['Error loading the nav.', 'some error']);
     });
+
+    it('should log a warning on a status of -1', () => {
+      $ctrl.getNav.and.returnValue( Observable.throw( { status: -1 } ) );
+      $ctrl.$onInit();
+      expect($ctrl.$log.warn.logs[0]).toEqual(['Aborted or timed out request while loading the nav.', { status: -1 }]);
+    });
   } );
 
   describe( 'giftAddedToCart()', () => {


### PR DESCRIPTION
…r warning

We are getting tons of these errors https://rollbar.com/Cru/give-web/items/?query=error%20loading%20the%20nav&sort=last_desc&status=active.

I can reproduce it by clicking the browser's stop button, navigating to a new page, or going offline while the site-nav.json request is in flight. With so many going to Rollbar, my guess is most of the production errors are due to the user navigating to a new page while the nav is still loading although I'm not sure. My assumption is that Rollbar is still able to fire a request in the time the browser is navigating away. Although I'm not sure why Rollbar requests are allowed to be initiated but other ones are aborted.

We can discuss my changes. I added retry functionality to catch any real errors loading and try loading the nav a second time. I also separated out the requests with a status of -1 and converted those to Rollbar warnings. Eventually we might not want to log those warnings at all as they are polluting Rollbar.

Let me know what your thoughts are and if there's anything else you want me to test/change.