### PR TITLE
Cleanup payment method code and add encrypting state

### DIFF
--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -6,7 +6,7 @@
   </p>
 </div>
 <div class="loading-overlay-parent">
-  <loading type="overlay" ng-if="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading'"></loading>
+  <loading type="overlay" ng-if="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'"></loading>
   <div ng-if="!$ctrl.existingPaymentMethods">
     <payment-method-form payment-form-state="$ctrl.paymentFormState" payment-form-error="$ctrl.paymentFormError" on-payment-form-state-change="$ctrl.onPaymentFormStateChange($event)" mailing-address="$ctrl.mailingAddress"></payment-method-form>
   </div>
@@ -22,7 +22,7 @@
       <button id="previousStepButton1" class="btn btn-default" ng-click="$ctrl.changeStep({newStep: 'contact'})">Previous Step</button>
     </div>
     <div class="col-sm-5 col-sm-offset-2">
-      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.onPaymentFormStateChange({state: 'submitted'})" ng-disabled="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading'">Continue to Review &amp; Submit</button>
+      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.onPaymentFormStateChange({state: 'submitted'})" ng-disabled="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">Continue to Review &amp; Submit</button>
       <button id="previousStepButton2" class="btn btn-link btn-block visible-xs" ng-click="$ctrl.changeStep({newStep: 'contact'})"><i class="fa fa-angle-left"></i> Previous Step</button>
     </div>
   </div>

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -91,7 +91,7 @@
                 </div>
                 <div class="form-group">
                   <label class="" translate>Card Number</label>
-                  <p class="number">************{{$ctrl.creditCardPaymentDetails['card-number']}}</p>
+                  <p class="number">************{{$ctrl.creditCardPaymentDetails['last-four-digits']}}</p>
                 </div>
               </div>
               <div class="col-md-6">

--- a/src/app/profile/payment-methods/payment-method/payment-method.component.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.component.js
@@ -8,6 +8,7 @@ import giveModalWindowTemplate from 'common/templates/giveModalWindow.tpl';
 import profileService from 'common/services/api/profile.service';
 import formatAddressForTemplate from 'common/services/addressHelpers/formatAddressForTemplate';
 import {validPaymentMethod} from 'common/services/paymentHelpers/validPaymentMethods';
+import {scrollModalToTop} from 'common/services/modalState.service';
 
 import analyticsFactory from 'app/analytics/analytics.factory';
 
@@ -32,7 +33,7 @@ class PaymentMethodController{
   }
 
   isCard(){
-    return !!this.model['card-number'];
+    return this.model.self.type === 'cru.creditcards.named-credit-card';
   }
 
   editPaymentMethod() {
@@ -57,7 +58,7 @@ class PaymentMethodController{
             let editedData = {};
             if($event.payload.creditCard) {
               editedData = $event.payload.creditCard;
-              editedData['card-number'] = editedData['last-four-digits'];
+              editedData['last-four-digits'] = editedData['last-four-digits'];
               editedData.address = formatAddressForTemplate(editedData.address);
             } else {
               editedData = $event.payload.bankAccount;
@@ -77,6 +78,7 @@ class PaymentMethodController{
             this.$log.error('Error updating payment method', error);
             this.paymentFormResolve.state = 'error';
             this.paymentFormResolve.error = error.data;
+            scrollModalToTop();
           }
         );
     }

--- a/src/app/profile/payment-methods/payment-method/payment-method.spec.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.spec.js
@@ -40,6 +40,7 @@ describe('PaymentMethodComponent', function () {
         'donations': []
       },
       self: {
+        type: 'cru.creditcards.named-credit-card',
         uri: ''
       }
     },
@@ -50,6 +51,9 @@ describe('PaymentMethodComponent', function () {
       'routing-number': '021000021',
       'recurringgifts': {
         'donations': []
+      },
+      self: {
+        type: 'elasticpath.bankaccounts.bank-account'
       }
     },
     uibModal = jasmine.createSpyObj('$uibModal', ['open','close']);

--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -10,6 +10,7 @@ import sessionEnforcerService, {EnforcerCallbacks, EnforcerModes} from 'common/s
 import {Roles, SignOutEvent} from 'common/services/session/session.service';
 import commonModule from 'common/common.module';
 import formatAddressForTemplate from 'common/services/addressHelpers/formatAddressForTemplate';
+import {scrollModalToTop} from 'common/services/modalState.service';
 
 class PaymentMethodsController {
 
@@ -120,6 +121,7 @@ class PaymentMethodsController {
             this.$log.error('Error adding payment method',error);
             this.paymentFormResolve.state = 'error';
             this.paymentFormResolve.error = error.data;
+            scrollModalToTop();
           });
     }
   }
@@ -133,7 +135,7 @@ class PaymentMethodsController {
   }
 
   isCard(paymentMethod) {
-    return !!paymentMethod['card-number'];
+    return paymentMethod.self.type === 'cru.creditcards.named-credit-card';
   }
 
   signedOut( event ) {

--- a/src/app/profile/payment-methods/payment-methods.spec.js
+++ b/src/app/profile/payment-methods/payment-methods.spec.js
@@ -20,7 +20,7 @@ describe( 'PaymentMethodsComponent', function () {
       }
     };
   };
-  
+
   let uibModal = jasmine.createSpyObj('$uibModal', ['open','close']);
 
   uibModal.open.and.callFake(fakeModal);
@@ -169,8 +169,16 @@ describe( 'PaymentMethodsComponent', function () {
 
   describe('isCard()', () => {
     it('should return true if payment method is a card', () => {
-      expect($ctrl.isCard({'card-number': '2222'})).toBe(true);
-      expect($ctrl.isCard({'bank': '2222'})).toBe(false);
+      expect($ctrl.isCard({
+        self: {
+          type: 'cru.creditcards.named-credit-card'
+        }
+      })).toBe(true);
+      expect($ctrl.isCard({
+        self: {
+          type: 'elasticpath.bankaccounts.bank-account'
+        }
+      })).toBe(false);
     });
   });
 

--- a/src/app/profile/yourGiving/editRecurringGifts/step0/addUpdatePaymentMethod.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step0/addUpdatePaymentMethod.tpl.html
@@ -46,7 +46,7 @@
   <div class="col-xs-6 text-right">
     <button class="btn btn-primary"
             ng-click="$ctrl.onPaymentFormStateChange({state: 'submitted'})"
-            ng-disabled="$ctrl.paymentFormState === 'loading'">
+            ng-disabled="$ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
       <span ng-if="!$ctrl.paymentMethod" translate>Add and Continue</span>
       <span ng-if="$ctrl.paymentMethod" translate>Update and Continue</span>
     </button>

--- a/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
+++ b/src/common/components/giftViews/giftUpdateView/giftUpdateView.tpl.html
@@ -25,7 +25,7 @@
         <label translate>Payment Method</label>
         <select class="form-control  form-control-subtle"
                 ng-model="$ctrl.gift.paymentMethodId"
-                ng-options="paymentMethod.self.uri.split('/').pop() as ((paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ****' + (paymentMethod['display-account-number'] || paymentMethod['card-number'])) for paymentMethod in $ctrl.gift.paymentMethods" >
+                ng-options="paymentMethod.self.uri.split('/').pop() as ((paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ****' + (paymentMethod['display-account-number'] || paymentMethod['last-four-digits'])) for paymentMethod in $ctrl.gift.paymentMethods" >
         </select>
         <div role="alert" ng-if="!$ctrl.gift.paymentMethod">
           <div class="help-block" translate>You must choose a valid payment method</div>

--- a/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.component.js
+++ b/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.component.js
@@ -5,6 +5,7 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
 import showErrors from 'common/filters/showErrors.filter';
+import {scrollModalToTop} from 'common/services/modalState.service';
 
 import cruPayments from 'cru-payments/dist/cru-payments';
 import { ccpKey, ccpStagingKey } from 'common/app.constants';
@@ -84,6 +85,11 @@ class BankAccountController{
   savePayment(){
     this.bankPaymentForm.$setSubmitted();
     if(this.bankPaymentForm.$valid){
+      this.onPaymentFormStateChange({
+        $event: {
+          state: 'encrypting'
+        }
+      });
       cruPayments.bankAccount.init(this.envService.get(), this.envService.is('production') ? ccpKey : ccpStagingKey);
       let encryptObservable = this.paymentMethod && !this.bankPayment.accountNumber ?
         Observable.of('') :
@@ -111,7 +117,7 @@ class BankAccountController{
             error: error
           }
         });
-        this.$scope.$apply();
+        scrollModalToTop();
       });
     }else{
       this.onPaymentFormStateChange({

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -11,6 +11,7 @@ import displayAddressComponent from 'common/components/display-address/display-a
 import addressForm from 'common/components/addressForm/addressForm.component';
 
 import showErrors from 'common/filters/showErrors.filter';
+import {scrollModalToTop} from 'common/services/modalState.service';
 
 import cruPayments from 'cru-payments/dist/cru-payments';
 import tsys from 'common/services/api/tsys.service';
@@ -54,7 +55,7 @@ class CreditCardController {
     if(this.paymentMethod){
       this.creditCardPayment = {
         address: this.paymentMethod.address,
-        cardNumberPlaceholder: this.paymentMethod['card-number'],
+        cardNumberPlaceholder: this.paymentMethod['last-four-digits'],
         cardholderName: this.paymentMethod['cardholder-name'],
         expiryMonth: this.paymentMethod['expiry-month'],
         expiryYear: parseInt(this.paymentMethod['expiry-year'])
@@ -119,11 +120,16 @@ class CreditCardController {
   savePayment(){
     this.creditCardPaymentForm.$setSubmitted();
     if(this.creditCardPaymentForm.$valid){
+      this.onPaymentFormStateChange({
+        $event: {
+          state: 'encrypting'
+        }
+      });
       const tokenObservable =  this.paymentMethod && !this.creditCardPayment.cardNumber ?
-        Observable.of({ tsepToken: this.paymentMethod['card-number'], maskedCardNumber: this.paymentMethod['card-number'] }) : // Send masked card number when card number is not updated
+        Observable.of({ tsepToken: this.paymentMethod['last-four-digits'], maskedCardNumber: this.paymentMethod['last-four-digits'] }) : // Send masked card number when card number is not updated
         this.tsysService.getManifest()
           .mergeMap(data => {
-            cruPayments.creditCard.init(this.envService.get(), data.deviceId || '88812128320102', data.manifest); //TODO: remove hard coded deviceId when added to the manifest api endpoint
+            cruPayments.creditCard.init(this.envService.get(), data.deviceId, data.manifest);
             return cruPayments.creditCard.encrypt(this.creditCardPayment.cardNumber, this.creditCardPayment.securityCode, this.creditCardPayment.expiryMonth, this.creditCardPayment.expiryYear);
           });
       tokenObservable.subscribe(tokenObj => {
@@ -134,7 +140,7 @@ class CreditCardController {
               creditCard: {
                 address: this.useMailingAddress ? undefined : this.creditCardPayment.address,
                 'card-number': tokenObj.tsepToken,
-                'card-type': this.cardInfo.type(this.creditCardPayment.cardNumber) || this.paymentMethod['card-type'],
+                'card-type': this.cardInfo.type(this.creditCardPayment.cardNumber) || this.paymentMethod && this.paymentMethod['card-type'],
                 'cardholder-name': this.creditCardPayment.cardholderName,
                 'expiry-month': this.creditCardPayment.expiryMonth,
                 'expiry-year': this.creditCardPayment.expiryYear,
@@ -153,7 +159,7 @@ class CreditCardController {
             error: error
           }
         });
-        this.$scope.$apply();
+        scrollModalToTop();
       });
     }else{
       this.onPaymentFormStateChange({

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -167,7 +167,7 @@ describe('credit card form', () => {
     });
     it('should not send a credit card or security code if a paymentMethod is present and cardNumber is unchanged', () => {
       self.controller.paymentMethod = {
-        'card-number': '4567',
+        'last-four-digits': '4567',
         'card-type': 'MasterCard'
       };
       self.controller.creditCardPayment = {
@@ -396,7 +396,7 @@ describe('credit card form', () => {
       it('should populate the creditCardPayment fields if a paymentMethod is present', () => {
         self.controller.paymentMethod = {
           address: { streetAddress: 'Some Address' },
-          'card-number': '1234',
+          'last-four-digits': '1234',
           'cardholder-name': 'Some Person',
           'expiry-month': '10',
           'expiry-year': '2015'

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -78,7 +78,7 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-4" ng-if="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber"><!-- TODO: disable if not in checkout? -->
+      <div class="col-sm-4" ng-if="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber">
         <div class="form-group is-required" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.securityCode | showErrors)}">
           <label translate>CVV Code</label>
           <input type="text" name="securityCode" class="form-control form-control-subtle" ng-model="$ctrl.creditCardPayment.securityCode" required>

--- a/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.component.js
+++ b/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.component.js
@@ -81,7 +81,7 @@ class deletePaymentMethodModalController {
   }
 
   getPaymentMethodOptionLabel(paymentMethod){
-    return (paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ending in ****' + (paymentMethod['display-account-number'] || paymentMethod['card-number']);
+    return (paymentMethod['bank-name'] || paymentMethod['card-type']) + ' ending in ****' + (paymentMethod['display-account-number'] || paymentMethod['last-four-digits']);
   }
 
   getNewPaymentMethodId(){

--- a/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.component.spec.js
+++ b/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.component.spec.js
@@ -143,7 +143,7 @@ describe( 'delete payment method modal', function () {
     } );
     it( 'returns card display string', () => {
       self.controller.resolve.paymentMethod['card-type'] = 'Visa';
-      self.controller.resolve.paymentMethod['card-number'] = '4321';
+      self.controller.resolve.paymentMethod['last-four-digits'] = '4321';
       expect( self.controller.getPaymentMethodOptionLabel(self.controller.resolve.paymentMethod)).toBe('Visa ending in ****4321');
     } );
   } );

--- a/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
+++ b/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
@@ -83,7 +83,7 @@
                       <button id="addPaymentButton"
                               class="btn btn-primary"
                               ng-click="$ctrl.onPaymentFormStateChange({state: 'submitted'})"
-                              ng-disabled="$ctrl.paymentFormState === 'loading'"
+                              ng-disabled="$ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'"
                               translate>
                         Add Payment Method
                       </button>

--- a/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
@@ -9,7 +9,7 @@
       <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/diners-curved-128px.png" ng-switch-when="Diners Club"/>
     </span>
     <strong>{{$ctrl.paymentMethod['card-type']}}</strong>
-    <span translate>ends in ****{{$ctrl.paymentMethod['card-number']}}</span>
+    <span translate>ends in ****{{$ctrl.paymentMethod['last-four-digits']}}</span>
     <small class="number" ng-class="{'text-danger': $ctrl.expired}">
       <span class="hidden-xs" ng-if="!$ctrl.expired" translate>EXPIRES</span>
       <span class="hidden-xs" ng-if="$ctrl.expired" translate>EXPIRED</span>

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
@@ -34,7 +34,7 @@
                 id="saveChangesButton"
                 class="btn btn-primary pull-right"
                 ng-click="$ctrl.resolve.onPaymentFormStateChange({$event: {state: 'submitted'}})"
-                ng-disabled="$ctrl.resolve.paymentForm.state === 'loading' || $ctrl.resolve.paymentForm.state === 'success'">
+                ng-disabled="$ctrl.resolve.paymentForm.state === 'loading' || $ctrl.resolve.paymentForm.state === 'encrypting' || $ctrl.resolve.paymentForm.state === 'success'">
           <span ng-if="!$ctrl.resolve.paymentMethod" translate>Add Payment Method</span>
           <span ng-if="$ctrl.resolve.paymentMethod" translate>Update Payment Method</span>
         </button>

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
@@ -1,4 +1,4 @@
-<loading type="overlay" ng-if="$ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'success'"></loading>
+<loading type="overlay" ng-if="$ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting' || $ctrl.paymentFormState === 'success'"></loading>
 
 <div class="alert alert-danger" role="alert" ng-if="$ctrl.paymentFormState === 'error'">
   <p ng-switch="$ctrl.paymentFormError">


### PR DESCRIPTION
- Add encrypting state to paymentForm states to show loading indicators while tokenization or encryption is happening.
- Scroll to top on encryption failure and saving errors
- Remove unneeded $scope.$apply
- Remove hard coded deviceId
- Handle ‘card-type’ error when payment method is undefined
- Use ‘last-four-digits’ key which was added to api
- Have payment methods page use type to determine if it is a credit card

I feel like I threw the `encrypting` string around quite a few places... Maybe there's a cleaner way but setting the state to `loading` (I probably could have named that state better) starts the API request to save the payment method too soon. Encryption/tokenization needs to occur first.