### PR TITLE
Cleanup contactInfo fields

### DIFF
--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -34,7 +34,6 @@ class Step1Controller{
   $onInit(){
     this.loadDonorDetails();
     this.waitForFormInitialization();
-    this.showTitle = this.sessionService.getRole() === Roles.public;
   }
 
   $onChanges(changes) {
@@ -69,6 +68,7 @@ class Step1Controller{
         this.loadingDonorDetails = false;
         this.donorDetails = data;
         this.nameFieldsDisabled = this.donorDetails['registration-state'] === 'COMPLETED';
+        this.spouseFieldsDisabled = !!this.donorDetails['spouse-name']['given-name'] || !!this.donorDetails['spouse-name']['family-name'];
         if(!this.nameFieldsDisabled && includes([Roles.registered, Roles.identified], this.sessionService.getRole())) {
           // Pre-populate first, last and email from session if missing from donorDetails
           if(!this.donorDetails['name']['given-name'] && angular.isDefined(this.sessionService.session.first_name)) {

--- a/src/common/components/contactInfo/contactInfo.component.spec.js
+++ b/src/common/components/contactInfo/contactInfo.component.spec.js
@@ -29,18 +29,6 @@ describe('contactInfo', function() {
       expect(self.controller.loadDonorDetails).toHaveBeenCalled();
       expect(self.controller.waitForFormInitialization).toHaveBeenCalled();
     });
-    it('if not a public user, it should hide the title', () => {
-      spyOn(self.controller, 'loadDonorDetails');
-      spyOn(self.controller.sessionService, 'getRole').and.returnValue('REGISTERED');
-      self.controller.$onInit();
-      expect(self.controller.showTitle).toEqual(false);
-    });
-    it('if a public user, it should show the title', () => {
-      spyOn(self.controller, 'loadDonorDetails');
-      spyOn(self.controller.sessionService, 'getRole').and.returnValue('PUBLIC');
-      self.controller.$onInit();
-      expect(self.controller.showTitle).toEqual(true);
-    });
   });
 
   describe('$onChanges', () => {
@@ -85,13 +73,14 @@ describe('contactInfo', function() {
 
   describe('loadDonorDetails', () => {
     it('should get the donor\'s details', () => {
-      spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': 'Organization' }));
+      spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': 'Organization', 'spouse-name': {} }));
       self.controller.loadDonorDetails();
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
       expect(self.controller.loadingDonorDetailsError).toEqual(false);
       expect(self.controller.loadingDonorDetails).toEqual(false);
-      expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Organization' });
+      expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Organization', 'spouse-name': {} });
       expect(self.controller.nameFieldsDisabled).toEqual(false);
+      expect(self.controller.spouseFieldsDisabled).toEqual(false);
     });
     it('should disable name fields if the user\'s registration state is completed', () => {
       let donorDetails = {
@@ -114,12 +103,13 @@ describe('contactInfo', function() {
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
       expect(self.controller.donorDetails).toEqual(donorDetails);
       expect(self.controller.nameFieldsDisabled).toEqual(true);
+      expect(self.controller.spouseFieldsDisabled).toEqual(true);
     });
     it('should set the donor type if it is an empty string', () => {
-      spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': '' }));
+      spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': '', 'spouse-name': {} }));
       self.controller.loadDonorDetails();
       expect(self.controller.orderService.getDonorDetails).toHaveBeenCalled();
-      expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Household' });
+      expect(self.controller.donorDetails).toEqual({ 'donor-type': 'Household', 'spouse-name': {} });
     });
 
     describe('pre-populate from session', () => {
@@ -141,6 +131,7 @@ describe('contactInfo', function() {
             'given-name': '',
             'family-name': ''
           },
+          'spouse-name': {},
           'email': undefined,
           'registration-state': 'NEW'
         }));
@@ -152,6 +143,7 @@ describe('contactInfo', function() {
             'given-name': 'Charles',
             'family-name': 'Xavier'
           },
+          'spouse-name': {},
           'email': 'professorx@xavier.edu',
           'registration-state': 'NEW'
         });

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -5,6 +5,12 @@
   <p ng-switch-when="Invalid email address" translate>
     There was an error saving your email address. Make sure it was entered correctly.
   </p>
+  <p ng-switch-when="Invalid phone number" translate>
+    There was an error saving your phone number. Make sure it was entered correctly.
+  </p>
+  <p ng-switch-when="Organization Name cannot be longer than 100." translate>
+    There was an error saving your organization name. Make sure it is not longer than 100 characters.
+  </p>
   <p ng-switch-when="In order to add the spouse , [family-name] and [given-name] are required" translate>
     There was an error saving your contact info. Make sure your spouse's first and last name are correct.
   </p>
@@ -40,23 +46,6 @@
   <form novalidate ng-keyup="$event.key === 'Enter' && $ctrl.submitDetails()" name="$ctrl.detailsForm">
     <div class="mb">
       <h4 class="panel-title  border-bottom-small  visible" translate>Your Information</h4>
-
-      <div class="row" ng-if="$ctrl.showTitle">
-        <div class="col-sm-6">
-          <div class="form-group  form-group-default">
-            <label translate>Title</label>
-            <select name="nameTitle" class="form-control form-control-subtle" ng-model="$ctrl.donorDetails['name']['title']">
-              <option></option>
-              <option value="Mr" translate>Mr</option>
-              <option value="Mrs" translate>Mrs</option>
-              <option value="Miss" translate>Miss</option>
-              <option value="Ms" translate>Ms</option>
-              <option value="Dr" translate>Dr</option>
-            </select>
-          </div>
-        </div>
-      </div>
-
       <div class="row">
         <div class="col-sm-4">
           <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.nameGivenName | showErrors)}">
@@ -122,6 +111,92 @@
 
       </div>
 
+      <div class="row" ng-if="$ctrl.donorDetails['donor-type'] === 'Household'">
+        <div class="col-sm-4">
+          <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseGivenName | showErrors)}">
+            <label translate>Spouse First Name</label>
+            <input type="text"
+                   class="form-control  form-control-subtle"
+                   name="spouseGivenName"
+                   ng-model="$ctrl.donorDetails['spouse-name']['given-name']"
+                   ng-maxlength="50"
+                   placeholder="{{ $ctrl.donorDetails['spouse-name']['family-name'] ? '' : 'Optional' | translate}}"
+                   ng-disabled="$ctrl.spouseFieldsDisabled">
+            <div role="alert" ng-messages="$ctrl.detailsForm.spouseGivenName.$error" ng-if="($ctrl.detailsForm.spouseGivenName | showErrors)">
+              <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-2">
+          <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseMiddleInitial | showErrors)}">
+            <label translate>MI</label>
+            <input type="text"
+                   class="form-control  form-control-subtle"
+                   name="spouseMiddleInitial"
+                   ng-model="$ctrl.donorDetails['spouse-name']['middle-initial']"
+                   ng-maxlength="50"
+                   ng-disabled="$ctrl.spouseFieldsDisabled">
+            <div role="alert" ng-messages="$ctrl.detailsForm.spouseMiddleInitial.$error" ng-if="($ctrl.detailsForm.spouseMiddleInitial | showErrors)">
+              <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-4">
+          <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseFamilyName | showErrors)}">
+            <label translate>Spouse Last Name</label>
+            <input type="text"
+                   class="form-control  form-control-subtle"
+                   name="spouseFamilyName"
+                   ng-model="$ctrl.donorDetails['spouse-name']['family-name']"
+                   ng-maxlength="50"
+                   placeholder="{{ $ctrl.donorDetails['spouse-name']['given-name'] ? '' : 'Optional' | translate}}"
+                   ng-disabled="$ctrl.spouseFieldsDisabled">
+            <div role="alert" ng-messages="$ctrl.detailsForm.spouseFamilyName.$error" ng-if="($ctrl.detailsForm.spouseFamilyName | showErrors)">
+              <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-2">
+          <div class="form-group">
+            <label translate>Suffix</label>
+            <div class="form-group">
+              <select name="spouseSuffix"
+                      class="form-control  form-control-subtle"
+                      ng-model="$ctrl.donorDetails['spouse-name']['suffix']"
+                      ng-disabled="$ctrl.spouseFieldsDisabled">
+                <option value=""></option>
+                <option value="Jr." translate>Jr</option>
+                <option value="Sr." translate>Sr</option>
+                <option value="II" translate>II</option>
+                <option value="III" translate>III</option>
+                <option value="IV" translate>IV</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row" ng-if="$ctrl.donorDetails['donor-type'] === 'Organization'">
+        <div class="col-sm-12">
+          <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.orgName | showErrors)}">
+            <label translate>Organization Name</label>
+            <input type="text" class="form-control form-control-subtle" name="orgName" ng-model="$ctrl.donorDetails['organization-name']" ng-maxlength="100" ng-disabled="$ctrl.nameFieldsDisabled" required>
+            <div role="alert" ng-messages="$ctrl.detailsForm.orgName.$error" ng-if="($ctrl.detailsForm.orgName | showErrors)">
+              <div class="help-block" ng-message="required" translate>You must enter an organization name</div>
+              <div class="help-block" ng-message="maxlength" translate>Organization name cannot be longer that 100 characters</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb">
+      <h4 class="panel-title  border-bottom-small  visible" translate>Mailing Address</h4>
+
+      <address-form address="$ctrl.donorDetails.mailingAddress" parent-form="$ctrl.detailsForm"></address-form>
+    </div>
+
+    <div class="mb">
+      <h4 class="panel-title  border-bottom-small  visible" translate>Contact Information</h4>
       <div class="row">
         <div class="col-sm-6">
           <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.phoneNumber | showErrors)}">
@@ -144,110 +219,6 @@
           </div>
         </div>
       </div>
-    </div>
-
-    <div class="mb_x">
-      <div class="panel panel-default" ng-if="$ctrl.donorDetails['donor-type'] === 'Household'">
-        <div class="panel-title  panel-heading visible" ng-click="showSpouseDetails = !showSpouseDetails" translate>
-          Spouse Name (Optional)
-        </div>
-        <div class="panel-collapse collapse in" ng-if="showSpouseDetails">
-          <div class="panel-body">
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="form-group">
-                  <label translate>Title</label>
-                  <div class="form-group">
-                    <select name="spouseTitle" class="form-control form-control-subtle" ng-model="$ctrl.donorDetails['spouse-name']['title']">
-                      <option></option>
-                      <option value="Mr" translate>Mr</option>
-                      <option value="Mrs" translate>Mrs</option>
-                      <option value="Miss" translate>Miss</option>
-                      <option value="Ms" translate>Ms</option>
-                      <option value="Dr" translate>Dr</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="row">
-              <div class="col-sm-4">
-                <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseGivenName | showErrors)}">
-                  <label translate>First Name</label>
-                  <input type="text"
-                         class="form-control  form-control-subtle"
-                         name="spouseGivenName"
-                         ng-model="$ctrl.donorDetails['spouse-name']['given-name']"
-                         ng-maxlength="50"
-                         ng-disabled="$ctrl.nameFieldsDisabled">
-                  <div role="alert" ng-messages="$ctrl.detailsForm.spouseGivenName.$error" ng-if="($ctrl.detailsForm.spouseGivenName | showErrors)">
-                    <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-sm-2">
-                <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseMiddleInitial | showErrors)}">
-                  <label translate>MI</label>
-                  <input type="text" class="form-control  form-control-subtle" name="spouseMiddleInitial" ng-model="$ctrl.donorDetails['spouse-name']['middle-initial']" ng-maxlength="50" ng-disabled="$ctrl.nameFieldsDisabled">
-                  <div role="alert" ng-messages="$ctrl.detailsForm.spouseMiddleInitial.$error" ng-if="($ctrl.detailsForm.spouseMiddleInitial | showErrors)">
-                    <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseFamilyName | showErrors)}">
-                  <label translate>Last Name</label>
-                  <input type="text"
-                         class="form-control  form-control-subtle"
-                         name="spouseFamilyName"
-                         ng-model="$ctrl.donorDetails['spouse-name']['family-name']"
-                         ng-maxlength="50"
-                         ng-disabled="$ctrl.nameFieldsDisabled">
-                  <div role="alert" ng-messages="$ctrl.detailsForm.spouseFamilyName.$error" ng-if="($ctrl.detailsForm.spouseFamilyName | showErrors)">
-                    <div class="help-block" ng-message="maxlength" translate>This field cannot be longer than 50 characters</div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-sm-2">
-                <div class="form-group">
-                  <label translate>Suffix</label>
-                  <div class="form-group">
-                    <select name="spouseSuffix" class="form-control  form-control-subtle" ng-model="$ctrl.donorDetails['spouse-name']['suffix']" ng-disabled="$ctrl.nameFieldsDisabled">
-                      <option value=""></option>
-                      <option value="Jr." translate>Jr</option>
-                      <option value="Sr." translate>Sr</option>
-                      <option value="II" translate>II</option>
-                      <option value="III" translate>III</option>
-                      <option value="IV" translate>IV</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-
-
-            </div>
-          </div><!-- // panel-body -->
-        </div>
-      </div>
-    </div>
-
-    <div class="mb">
-      <h4 class="panel-title  border-bottom-small  visible" translate>Mailing Address</h4>
-      <div class="row" ng-if="$ctrl.donorDetails['donor-type'] === 'Organization'">
-        <div class="col-sm-12">
-          <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.orgName | showErrors)}">
-            <label translate>Organization Name</label>
-            <input type="text" class="form-control form-control-subtle" name="orgName" ng-model="$ctrl.donorDetails['organization-name']" ng-maxlength="100" ng-disabled="$ctrl.nameFieldsDisabled" required>
-            <div role="alert" ng-messages="$ctrl.detailsForm.orgName.$error" ng-if="($ctrl.detailsForm.orgName | showErrors)">
-              <div class="help-block" ng-message="required" translate>You must enter an organization name</div>
-              <div class="help-block" ng-message="maxlength" translate>Organization name cannot be longer that 100 characters</div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <address-form address="$ctrl.donorDetails.mailingAddress" parent-form="$ctrl.detailsForm"></address-form>
     </div>
   </form>
 </div>


### PR DESCRIPTION
- Remove titles
- Allow adding of spouse if the donor doesn’t already have one
- Disable editing of all donor fields if registration is completed
- Move spouse fields out of collapsible panel
- Add Optional placeholders to spouse fields that disappear once first name or last name are typed
- Move org name field up to name section
- Move phone and email fields to the bottom
- Add more error message strings

https://jira.cru.org/browse/EP-1682