### PR TITLE
Allow order submission without CVV

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -5,7 +5,7 @@ import 'angular-ui-bootstrap';
 import paymentMethodDisplay from 'common/components/paymentMethods/paymentMethodDisplay.component';
 import paymentMethodFormModal from 'common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.component';
 
-import orderService, {existingPaymentMethodFlag} from 'common/services/api/order.service';
+import orderService from 'common/services/api/order.service';
 import {validPaymentMethod} from 'common/services/paymentHelpers/validPaymentMethods';
 import giveModalWindowTemplate from 'common/templates/giveModalWindow.tpl';
 
@@ -106,13 +106,10 @@ class ExistingPaymentMethodsController {
   selectPayment(){
     if(this.selectedPaymentMethod.chosen){
       this.onPaymentFormStateChange({ $event: { state: 'loading' } });
-      if(!this.orderService.retrieveCardSecurityCode()){
-        this.orderService.storeCardSecurityCode(existingPaymentMethodFlag);
-      }
     }else{
       this.orderService.selectPaymentMethod(this.selectedPaymentMethod.selectAction)
         .subscribe(() => {
-            this.orderService.storeCardSecurityCode(existingPaymentMethodFlag);
+            this.orderService.clearCardSecurityCode(); // Existing payment methods don't have a CVV
             this.onPaymentFormStateChange({ $event: { state: 'loading' } });
           },
           (error) => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -5,8 +5,6 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/toPromise';
 
-import {existingPaymentMethodFlag} from 'common/services/api/order.service';
-
 import module from './existingPaymentMethods.component';
 
 describe('checkout', () => {
@@ -189,7 +187,6 @@ describe('checkout', () => {
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).toHaveBeenCalledWith('some uri' );
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
-          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(existingPaymentMethodFlag);
         });
         it('should handle a failed request to save the selected payment', () => {
           self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account' } };
@@ -203,7 +200,6 @@ describe('checkout', () => {
           self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account'}, chosen: true };
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
-          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(existingPaymentMethodFlag);
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
         });
         it('should not send a request if the payment is already selected and should not modify the cvv if it is already set', () => {

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -5,7 +5,7 @@ import 'rxjs/add/observable/throw';
 import displayAddressComponent from 'common/components/display-address/display-address.component';
 import displayRateTotals from 'common/components/displayRateTotals/displayRateTotals.component';
 
-import orderService, {existingPaymentMethodFlag} from 'common/services/api/order.service';
+import orderService from 'common/services/api/order.service';
 import capitalizeFilter from 'common/filters/capitalize.filter';
 import desigSrcDirective from 'common/directives/desigSrc.directive';
 import {cartUpdatedEvent} from 'common/components/nav/navCart/navCart.component';
@@ -42,39 +42,39 @@ class Step3Controller{
   loadDonorDetails(){
     this.orderService.getDonorDetails()
       .subscribe((data) => {
-        this.donorDetails = data;
-      },
-      error => {
-        this.$log.error('Error loading donorDetails', error);
-      });
+          this.donorDetails = data;
+        },
+        error => {
+          this.$log.error('Error loading donorDetails', error);
+        });
   }
 
   loadCurrentPayment(){
     this.orderService.getCurrentPayment()
       .subscribe((data) => {
-        if(!data){
-          this.$log.error('Error loading current payment info: current payment doesn\'t seem to exist');
-        }else if(data.self.type === 'elasticpath.bankaccounts.bank-account') {
-          this.bankAccountPaymentDetails = data;
-        }else if(data.self.type === 'cru.creditcards.named-credit-card'){
-          this.creditCardPaymentDetails = data;
-        }else{
-          this.$log.error('Error loading current payment info: current payment type is unknown');
-        }
-      },
-      error => {
-        this.$log.error('Error loading current payment info', error);
-      });
+          if(!data){
+            this.$log.error('Error loading current payment info: current payment doesn\'t seem to exist');
+          }else if(data.self.type === 'elasticpath.bankaccounts.bank-account') {
+            this.bankAccountPaymentDetails = data;
+          }else if(data.self.type === 'cru.creditcards.named-credit-card'){
+            this.creditCardPaymentDetails = data;
+          }else{
+            this.$log.error('Error loading current payment info: current payment type is unknown');
+          }
+        },
+        error => {
+          this.$log.error('Error loading current payment info', error);
+        });
   }
 
   checkErrors(){
     this.orderService.checkErrors()
       .subscribe((data) => {
-        this.needinfoErrors = data;
-      },
-      error => {
-        this.$log.error('Error loading checkErrors', error);
-      });
+          this.needinfoErrors = data;
+        },
+        error => {
+          this.$log.error('Error loading checkErrors', error);
+        });
   }
 
   canSubmitOrder(){
@@ -99,11 +99,7 @@ class Step3Controller{
       submitRequest = this.orderService.submit();
     }else if(this.creditCardPaymentDetails){
       const cvv = this.orderService.retrieveCardSecurityCode();
-      if(cvv === existingPaymentMethodFlag){
-        submitRequest = this.orderService.submit();
-      }else{
-        submitRequest = cvv ? this.orderService.submit(cvv) : Observable.throw('Submitting a credit card purchase requires a CVV and the CVV was not retrieved correctly');
-      }
+      submitRequest = this.orderService.submit(cvv);
     }else{
       submitRequest = Observable.throw('Current payment type is unknown');
     }

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -4,7 +4,6 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 
-import {existingPaymentMethodFlag} from 'common/services/api/order.service';
 import {cartUpdatedEvent} from 'common/components/nav/navCart/navCart.component';
 
 import module from './step-3.component';
@@ -292,11 +291,11 @@ describe('checkout', () => {
           expect(self.controller.$window.location).toEqual('/thank-you.html');
           expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent);
         });
-        it('should submit the order without a CVV if paying with an existing credit card', () => {
+        it('should submit the order without a CVV if paying with an existing credit card or the cvv in session storage is missing', () => {
           self.controller.creditCardPaymentDetails = {};
-          self.storedCvv = existingPaymentMethodFlag;
+          self.storedCvv = undefined;
           self.controller.submitOrder();
-          expect(self.controller.orderService.submit).toHaveBeenCalledWith();
+          expect(self.controller.orderService.submit).toHaveBeenCalledWith(undefined);
           expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
           expect(self.controller.$window.location).toEqual('/thank-you.html');
           expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent);
@@ -311,15 +310,6 @@ describe('checkout', () => {
           expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', 'error saving credit card']);
           expect(self.controller.$window.location).toEqual('/checkout.html');
           expect(self.controller.submissionError).toEqual('error saving credit card');
-        });
-        it('should throw an error if paying with a credit card and the CVV is missing', () => {
-          self.controller.creditCardPaymentDetails = {};
-          self.controller.submitOrder();
-          expect(self.controller.orderService.submit).not.toHaveBeenCalled();
-          expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', 'Submitting a credit card purchase requires a CVV and the CVV was not retrieved correctly']);
-          expect(self.controller.$window.location).toEqual('/checkout.html');
-          expect(self.controller.submissionError).toEqual('Submitting a credit card purchase requires a CVV and the CVV was not retrieved correctly');
         });
         it('should throw an error if neither bank account or credit card details are loaded', () => {
           self.controller.submitOrder();

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -7,9 +7,6 @@
       <span ng-switch-default translate>There was an unknown error indicating that the order is still missing data. Please verify all your info, try refreshing the page, and, if you are still seeing this message, contact support.</span>
     </p>
     <p ng-if="$ctrl.submissionError" ng-switch="$ctrl.submissionError">
-      <span ng-switch-when="Submitting a credit card purchase requires a CVV and the CVV was not retrieved correctly" translate>
-        There was an error submitting your credit card's security code. Your session may have expired before it was sent. Try changing your payment method and saving your credit card again.
-      </span>
       <span ng-switch-when="Current payment type is unknown" translate>
         There was an error submitting your payment. Verify that your payment info is correct or try adding it again. If you are still seeing this message, contact support.
       </span>

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -17,8 +17,6 @@ import hateoasHelperService from 'common/services/hateoasHelper.service';
 import formatAddressForCortex from '../addressHelpers/formatAddressForCortex';
 import formatAddressForTemplate from '../addressHelpers/formatAddressForTemplate';
 
-export const existingPaymentMethodFlag = 'existing_payment_method';
-
 let serviceName = 'orderService';
 
 class Order{
@@ -248,8 +246,8 @@ class Order{
       });
   }
 
-  storeCardSecurityCode(encryptedCvv){
-    this.sessionStorage.setItem('cvv', encryptedCvv);
+  storeCardSecurityCode(cvv){
+    this.sessionStorage.setItem('cvv', cvv);
   }
 
   retrieveCardSecurityCode(){

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -5,7 +5,7 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import formatAddressForTemplate from '../addressHelpers/formatAddressForTemplate';
 
-import module, {existingPaymentMethodFlag} from './order.service';
+import module from './order.service';
 
 import cartResponse from 'common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js';
 import paymentMethodBankAccountResponse from 'common/services/api/fixtures/cortex-order-paymentmethod-bankaccount.fixture.js';
@@ -641,10 +641,6 @@ describe('order service', () => {
     it('should store the encrypted cvv', () => {
       self.orderService.storeCardSecurityCode('123');
       expect(self.$window.sessionStorage.getItem('cvv')).toEqual('123');
-    });
-    it('should allow \'existing payment method\' to be stored', () => {
-      self.orderService.storeCardSecurityCode(existingPaymentMethodFlag);
-      expect(self.$window.sessionStorage.getItem('cvv')).toEqual(existingPaymentMethodFlag);
     });
   });
 


### PR DESCRIPTION
- Prevents the user from getting stuck if the CVV in session storage is cleared
- Removes existingPaymentMethodFlag since that functionality is the same as no CVV

https://jira.cru.org/browse/EP-1891