### PR TITLE
remove unnecessary cycle css from home page

### DIFF
--- a/src/assets/scss/_slider.scss
+++ b/src/assets/scss/_slider.scss
@@ -120,42 +120,13 @@
         width: auto;
         position: static;
         padding: $gutter;
-        opacity: 1;
       }
       h3 {
         font-size: 24px;
         line-height: 1.35em;
-        opacity: 0;
         margin-left: 0px;
         transition: .35s all;
       }
-      .btn {
-        opacity: 0;
-        margin-left: 0px;
-        transition: .5s all;
-      }
-    }  
-
-    &.cycle-slide-active {
-      .slide-image {
-      }
-      .slide-caption {
-        left: auto;
-        right: 0;
-        bottom: 0;
-        top: auto;
-        opacity: 1;
-        h3 {
-          margin-left: 0;
-          opacity: 1;
-        }
-        .btn {
-          margin-left: 0;
-          opacity: 1;
-        }
-      }
     }
-
   }
-
 }


### PR DESCRIPTION
https://jira.cru.org/browse/EP-1911

This css was causing the cycle slider on home page to not update the Give Now buttons correctly.  There wasn't a need to manually control the opacity, the jquery plugin does that.