### PR TITLE
Fix duplicate gift in cart redirect

### DIFF
--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.js
@@ -32,7 +32,8 @@ export const giveGiftParams = {
 class ProductConfigModalController {
 
   /* @ngInject */
-  constructor( $location, $scope, $log, designationsService, cartService, modalStateService, analyticsFactory ) {
+  constructor( $window, $location, $scope, $log, designationsService, cartService, modalStateService, analyticsFactory ) {
+    this.$window = $window;
     this.$location = $location;
     this.$scope = $scope;
     this.$log = $log;

--- a/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
@@ -241,7 +241,7 @@
               type="button"
               tabindex="-1"
               ng-if="$ctrl.errorAlreadyInCart"
-              ng-click="$ctrl.close(); $ctrl.$location.path('/cart')"
+              ng-click="$ctrl.close(); $ctrl.$window.location = '/cart'"
               translate>
         View Cart
       </button>


### PR DESCRIPTION
https://jira.cru.org/browse/EP-1897

According to the Jira task using `location.path()` seems to be working everywhere except the your-giving page... Not sure why but didn't really spend time looking into it. I just made the redirect match  what we are using elsewhere.