### PR TITLE
Improve Rollbar stacktraces

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,8 @@ module.exports = {
   entry: isBuild ? entryPoints : { main: 'app/main/main.component.js' },
   output: {
     filename: '[name].js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    devtoolModuleFilenameTemplate: info => info.resourcePath.replace(/^\.\//, '')
   },
   plugins: concat(
     [
@@ -44,7 +45,10 @@ module.exports = {
           from: '**/*.+(json|svg|woff|ttf|png|ico|jpg|gif|eot)',
           to: '[path][name].[ext]'
         }
-      ])
+      ]),
+      new webpack.EnvironmentPlugin({
+        'TRAVIS_COMMIT': 'development'
+      })
     ],
     isBuild ?
       [


### PR DESCRIPTION
- Enable sourcemaps on Rollbar
- Remove webpack:/// prefix from sourcemapped file names
- Parse exception handler error to generate stacktrace instead of relying on the call stack of the custom logging function

I apologize for all the rollbar emails you may have gotten. Most of them should have been from the development environment.