### PR TITLE
Add an entry point for the common module so it’s run when the common.…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const isBuild = process.env.npm_lifecycle_event === 'build';
 const ci = process.env.CI === 'true';
 
 const entryPoints = {
+  common: 'common/common.module.js',
   cart: 'app/cart/cart.component.js',
   checkout: 'app/checkout/checkout.component.js',
   thankYou: 'app/thankYou/thankYou.component.js',


### PR DESCRIPTION
…js bundle is included

This should fix the error we encountered. You diagnosed the problem correctly. I guess the bundle of common chunks is lazy and doesn't actually import any ES6 modules unless another file (which has an entry point) is loaded or there is an entry point with the same name that gets bundled into the common bundle. Took me a little while to figure out but it's a really simple config change.

Sorry for the production issues. I should have tested just the common bundle earlier. I guess this is my fault, you just had the excitement of deploying it :)

http://cru-givedev.s3-website-us-east-1.amazonaws.com/index.html should be a good test. It wasn't working (had the same error as cru.org) until I pushed this branch to dev.