### PR TITLE
[#EP-1869] Update vague contact support to email egift@cru.org

### DIFF
--- a/src/app/designationEditor/designationEditor.tpl.html
+++ b/src/app/designationEditor/designationEditor.tpl.html
@@ -1,10 +1,10 @@
 <div class="container loading-overlay-parent">
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingContentError">
-    <p translate>There was an error loading your profile. You can use the retry button to try loading it again. If you continue to see this message, please contact support</p>
+    <p translate>There was an error loading your profile. You can use the retry button to try loading it again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p><button id="retryButton1" type="button" class="btn btn-primary" ng-click="$ctrl.getDesignationContent()" translate>Retry</button></p>
   </div>
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.saveDesignationError">
-    <p translate>There was an error saving your profile. You can use the retry button to try saving it again. If you continue to see this message, please contact support</p>
+    <p translate>There was an error saving your profile. You can use the retry button to try saving it again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p><button id="retryButton2" type="button" class="btn btn-primary" ng-click="$ctrl.save()" translate>Retry</button></p>
   </div>
   <div class="panel panel-margin-bottom">

--- a/src/app/productConfig/productConfig.tpl.html
+++ b/src/app/productConfig/productConfig.tpl.html
@@ -1,6 +1,6 @@
 <i class="fa fa-exclamation-triangle text-danger"
    ng-if="$ctrl.error"
-   uib-tooltip="{{'Error setting up gift. You may be able to try again. If you continue to experience issues, contact support.' | translate}}">
+   uib-tooltip="{{'Error setting up gift. You may be able to try again. If you continue to experience issues, contact <a href=\'mailto:eGift@cru.org\'>eGift@cru.org</a> for assistance.' | translate}}">
 </i>
 <button class="btn btn-primary btn-{{$ctrl.buttonSize}}" ng-click="$ctrl.configModal()" ng-disabled="$ctrl.loadingModal">
   <span ng-if="!$ctrl.loadingModal">{{$ctrl.buttonLabel}}</span>

--- a/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
@@ -25,11 +25,11 @@
         <div class="panel panel-default give-modal-panel">
 
           <div ng-if="$ctrl.errorChangingFrequency" class="alert alert-danger" role="alert">
-            <p translate>There was an error configuring the frequency of your gift. You may try changing the frequency again but if you continue to experience issues, contact support.</p>
+            <p translate>There was an error configuring the frequency of your gift. You may try changing the frequency again but if you continue to experience issues, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
           </div>
 
           <div ng-if="$ctrl.errorSavingGeneric" role="alert" class="alert alert-danger">
-            <p translate>There was an unknown error adding your gift to the cart. Please verify all your info and try again. If you are still seeing this message, contact support.</p>
+            <p translate>There was an unknown error adding your gift to the cart. Please verify all your info and try again. If you are still seeing this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
           </div>
 
           <div ng-if="$ctrl.errorAlreadyInCart" class="alert alert-warning" role="alert">

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
@@ -21,7 +21,7 @@
           <translate>Loading recurring gifts...</translate>
         </loading>
         <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingError">
-          <p translate>There was an error loading your recurring gifts. You can use the retry button to try loading them again. If you continue to see this message, please contact support</p>
+          <p translate>There was an error loading your recurring gifts. You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
         </div>
         <div class="alert alert-warning" role="alert" ng-if="!$ctrl.loading && !$ctrl.loadingError && (!$ctrl.recurringGifts || $ctrl.recurringGifts.length === 0)">
           <p translate>

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.tpl.html
@@ -18,8 +18,8 @@
     <div class="row">
       <div class="col-md-12 col-xs-12">
         <div class="alert alert-danger" role="alert" ng-if="$ctrl.savingError" ng-switch="$ctrl.savingError">
-          <p ng-switch-when="Only Active recurring donations can be modified." translate>One of the gifts you are modifying is no longer an active gift. We may have accidentally shown you an inactive gift in a previous step. You may try only editing one gift at a time to determine which gift cannot be changed. If you continue to experience problems, please contact support.</p>
-          <p ng-switch-default translate>There was an error saving your gifts. Please check that all the entered information is valid and that you have a good internet connection. If you continue to see this message, please contact support.</p>
+          <p ng-switch-when="Only Active recurring donations can be modified." translate>One of the gifts you are modifying is no longer an active gift. We may have accidentally shown you an inactive gift in a previous step. You may try only editing one gift at a time to determine which gift cannot be changed. If you continue to experience problems, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
+          <p ng-switch-default translate>There was an error saving your gifts. Please check that all the entered information is valid and that you have a good internet connection. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
         </div>
         <div class="alert alert-warning" role="alert" ng-if="!$ctrl.hasChanges">
           <p translate>You haven't made any changes to your recurring gifts. Feel free to go back and make some changes.</p>

--- a/src/app/profile/yourGiving/historicalView/historicalView.tpl.html
+++ b/src/app/profile/yourGiving/historicalView/historicalView.tpl.html
@@ -1,8 +1,7 @@
 <div>
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingGiftsError">
     <p translate>There was an error loading your historical giving.</p>
-    <p translate>You can use the retry button to try loading them again. If you continue to see this message, please
-      contact support</p>
+    <p translate>You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p>
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.$onChanges()" translate>Retry

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.tpl.html
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.tpl.html
@@ -64,7 +64,7 @@
           Details&nbsp;
         </button>
         <div class="alert alert-danger text-sm-center" role="alert" ng-if="$ctrl.loadingDetailsError">
-          <p translate>Error loading detailed giving. You can try again. If you continue to see this message, please contact support</p>
+          <p translate>Error loading detailed giving. You can try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
         </div>
       </div>
     </div>

--- a/src/app/profile/yourGiving/recipientView/recipientView.tpl.html
+++ b/src/app/profile/yourGiving/recipientView/recipientView.tpl.html
@@ -1,8 +1,7 @@
 <div>
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingRecipientsError">
     <p translate>There was an error loading your giving by recipient.</p>
-    <p translate>You can use the retry button to try loading them again. If you continue to see this message, please
-      contact support</p>
+    <p translate>You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p>
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.loadRecipients($ctrl.filter == 'recent' ? undefined : $ctrl.filter)" translate>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/redirectGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/redirectGift.tpl.html
@@ -4,8 +4,7 @@
              cancel="$ctrl.cancel()"
              previous="$ctrl.previous()">
   <p translate>There was an error loading your recurring gifts.</p>
-  <p translate>You can use the retry button to try loading them again. If you continue to see this message, please
-    contact support.</p>
+  <p translate>You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
 </retry-modal>
 <div ng-switch="$ctrl.step">
   <div style="height: 100px;" ng-switch-default ng-if="!$ctrl.loadingRecurringGiftsError"></div>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.tpl.html
@@ -74,7 +74,7 @@
 
     <div class="modal-body">
       <div class="alert alert-danger" role="alert" ng-if="$ctrl.error">
-        <p translate>There was an error loading gift information. Please try again, or contact support.</p>
+        <p translate>There was an error loading gift information. Please try again, or contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
       </div>
     </div>
 

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/step3/confirmGifts/confirmGifts.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/step3/confirmGifts/confirmGifts.tpl.html
@@ -15,7 +15,7 @@
 
 <div class="modal-body">
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.error" ng-switch="$ctrl.error">
-    <p ng-switch-default translate>There was an error processing your restarts. Please try again, or contact support.</p>
+    <p ng-switch-default translate>There was an error processing your restarts. Please try again, or contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
   </div>
   <div ng-repeat="gift in $ctrl.saved" class="repeating-row">
     <div class="col-xs-12">

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.tpl.html
@@ -4,8 +4,8 @@
              cancel="$ctrl.cancel()"
              previous="$ctrl.previous()">
   <p translate>There was an error loading your recurring gifts.</p>
-  <p translate>You can use the retry button to try loading them again. If you continue to see this message, please
-    contact support.</p>
+  <p translate>You can use the retry button to try loading them again. If you continue to see this message,
+    contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
 </retry-modal>
 <div ng-switch="$ctrl.step">
   <div style="height: 100px;" ng-switch-default ng-if="!$ctrl.loadingRecurringGiftsError"></div>

--- a/src/app/profile/yourGiving/yourGiving.tpl.html
+++ b/src/app/profile/yourGiving/yourGiving.tpl.html
@@ -4,7 +4,7 @@
       <div class="col-md-12">
 
         <div class="alert alert-danger" role="alert" ng-if="$ctrl.profileLoadingError">
-          <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, please contact support</p>
+          <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
           <p><button type="button" class="btn btn-primary" ng-click="$ctrl.loadProfile()" translate>Retry</button></p>
         </div>
         <div class="alert alert-success" role="alert" ng-if="$ctrl.recurringGiftsUpdateSuccess" translate>Your recurring gifts were updated successfully.</div>

--- a/src/common/components/addressForm/addressForm.tpl.html
+++ b/src/common/components/addressForm/addressForm.tpl.html
@@ -11,7 +11,7 @@
                 ng-disabled="$ctrl.disabled">
         </select>
         <div role="alert" ng-if="$ctrl.loadingCountriesError">
-          <div class="help-block" translate>There was an error loading the list of countries. If you continue to see this message, please contact support.
+          <div class="help-block" translate>There was an error loading the list of countries. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
             <button id="retryButton1" type="button" class="btn btn-default btn-sm" ng-click="$ctrl.loadCountries()" translate>Retry</button></div>
         </div>
         <div role="alert" ng-messages="$ctrl.parentForm.addressCountry.$error" ng-if="($ctrl.parentForm.addressCountry | showErrors)">
@@ -116,7 +116,7 @@
                   ng-disabled="$ctrl.disabled">
           </select>
           <div role="alert" ng-if="$ctrl.loadingRegionsError">
-            <div class="help-block" translate>There was an error loading the list of regions/state. If you continue to see this message, please contact support.
+            <div class="help-block" translate>There was an error loading the list of regions/state. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
               <button id="retryButton2" type="button" class="btn btn-default btn-sm" ng-click="$ctrl.refreshRegions($ctrl.address.addressCountry, true)" translate>Retry</button></div>
           </div>
           <div role="alert" ng-messages="$ctrl.parentForm.addressRegion.$error" ng-if="($ctrl.parentForm.addressRegion | showErrors)">

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -18,7 +18,7 @@
     There was an error saving your contact info. Your session may have expired. If you continue to experience issues, try signing out and back in.
   </p>
   <p ng-switch-default translate>
-    There was an error saving your contact info. Please try again or contact support.
+    There was an error saving your contact info. Please try again or contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
   </p>
 </div>
 
@@ -28,7 +28,7 @@
   </loading>
 
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingDonorDetailsError">
-    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, please contact support.</p>
+    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p><button id="retryButton1" type="button" class="btn btn-primary" ng-click="$ctrl.loadDonorDetails()" translate>Retry</button></p>
   </div>
 

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
@@ -15,7 +15,7 @@
       You have already added this bank account. If you wish to make changes please edit your existing bank account.
     </span>
     <span ng-switch-default translate>
-      There was an error saving your payment method. Please verify all your info and try again. If you are still seeing this message, contact support.
+      There was an error saving your payment method. Please verify all your info and try again. If you are still seeing this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
     </span>
   </p>
 </div>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -1,11 +1,11 @@
 <div class="col-xs-12" ng-switch="$ctrl.matchState">
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingDonorDetailsError">
-    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, please contact support</p>
+    <p translate>There was an error loading your profile. You can use the retry button to try loading them again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     <p><button type="button" class="btn btn-primary" ng-click="$ctrl.$onInit()" translate>Retry</button></p>
   </div>
 
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.selectContactError || $ctrl.loadingQuestionsError">
-    <p translate>An error has occurred. Please try again. If you continue to see this message, please contact support</p>
+    <p translate>An error has occurred. Please try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
   </div>
   <user-match-identity ng-switch-when="identity"
                        contacts="$ctrl.contacts"


### PR DESCRIPTION
This updates all vague references to "contact support" to use the egift@cru.org email.