### PR TITLE
Catch analytics error inside $timeout

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -318,8 +318,12 @@ function analyticsFactory($window, $timeout, $log, sessionService) {
 
         // Allow time for data layer changes to be consumed & fire image request
         $timeout(function () {
-          $window.s.t();
-          $window.s.clearVars();
+          try {
+            $window.s.t();
+            $window.s.clearVars();
+          }catch(e){
+            $log.warn('Error caught in analyticsFactory.pageLoaded while trying to fire analytics image request or clearVars', e);
+          }
         }, 1000);
       }catch(e){
         $log.warn('Error caught in analyticsFactory.pageLoaded', e);


### PR DESCRIPTION
I think this will catch these: https://rollbar.com/Cru/give-web/items/?query=t%27%20of%20undefined&sort=last_desc&status=active