### PR TITLE
Allow updating credit cards during checkout

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -109,7 +109,7 @@ class ExistingPaymentMethodsController {
     }else{
       this.orderService.selectPaymentMethod(this.selectedPaymentMethod.selectAction)
         .subscribe(() => {
-            this.orderService.clearCardSecurityCode(); // Existing payment methods don't have a CVV
+            this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri); // Unset the CVV unless the user has provided a CVV for the selected payment method this order
             this.onPaymentFormStateChange({ $event: { state: 'loading' } });
           },
           (error) => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -182,11 +182,12 @@ describe('checkout', () => {
         });
 
         it('should save the selected payment', () => {
-          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account' }, selectAction: 'some uri' };
+          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account', uri: 'selected uri' }, selectAction: 'some uri' };
           self.controller.orderService.selectPaymentMethod.and.returnValue(Observable.of('success'));
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).toHaveBeenCalledWith('some uri' );
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
+          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(null, 'selected uri');
         });
         it('should handle a failed request to save the selected payment', () => {
           self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account' } };
@@ -201,14 +202,7 @@ describe('checkout', () => {
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
-        });
-        it('should not send a request if the payment is already selected and should not modify the cvv if it is already set', () => {
-          spyOn(self.controller.orderService, 'retrieveCardSecurityCode').and.returnValue('cvv already stored');
-          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account'}, chosen: true };
-          self.controller.selectPayment();
-          expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
           expect(self.controller.orderService.storeCardSecurityCode).not.toHaveBeenCalled();
-          expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
         });
       });
     });

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -5,7 +5,7 @@
       <label>
         <input type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" ng-disabled="expired" required>
         <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
-        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" ng-if="paymentMethod.self.type === 'cru.creditcards.named-credit-card'" translate>update</button>
+        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" ng-if="paymentMethod.self.type === 'cru.creditcards.named-credit-card'" translate>edit</button>
       </label>
     </div>
 

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -6,6 +6,7 @@
         <input ng-if="!expired" type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" required>
         <button ng-if="expired" class="btn btn-xs btn-default" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)">Update</button>
         <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
+        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)">edit</button>
       </label>
     </div>
 

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -3,10 +3,9 @@
   <div class="panel-body">
     <div class="radio radio-method" ng-repeat="paymentMethod in $ctrl.paymentMethods" ng-init="expired = !$ctrl.validPaymentMethod(paymentMethod)">
       <label>
-        <input ng-if="!expired" type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" required>
-        <button ng-if="expired" class="btn btn-xs btn-default" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)">Update</button>
+        <input type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" ng-disabled="expired" required>
         <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
-        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)">edit</button>
+        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" translate>update</button>
       </label>
     </div>
 

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -5,7 +5,7 @@
       <label>
         <input type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" ng-disabled="expired" required>
         <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
-        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" translate>update</button>
+        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" ng-if="paymentMethod.self.type === 'cru.creditcards.named-credit-card'" translate>update</button>
       </label>
     </div>
 

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -107,7 +107,7 @@ class Step3Controller{
     submitRequest.subscribe(() => {
         this.analyticsFactory.purchase(this.donorDetails, this.cartData);
         this.onSubmittingOrder({value: false});
-        this.orderService.clearCardSecurityCode();
+        this.orderService.clearCardSecurityCodes();
         this.onSubmitted();
         this.$scope.$emit( cartUpdatedEvent );
         this.$window.location = '/thank-you.html';

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -32,7 +32,7 @@ describe('checkout', () => {
             checkErrors: () => Observable.of(['email-info']),
             submit: () => Observable.of('called submit'),
             retrieveCardSecurityCode: () => self.storedCvv,
-            clearCardSecurityCode: () => {}
+            clearCardSecurityCodes: jasmine.createSpy('clearCardSecurityCodes')
           },
           $window: {
             location: '/checkout.html'
@@ -241,7 +241,6 @@ describe('checkout', () => {
     describe('submitOrder', () => {
       beforeEach(() => {
         spyOn(self.controller.orderService, 'submit').and.callThrough();
-        spyOn(self.controller.orderService, 'clearCardSecurityCode');
       });
 
       describe('another order submission in progress', () => {
@@ -268,7 +267,7 @@ describe('checkout', () => {
           self.controller.bankAccountPaymentDetails = {};
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).toHaveBeenCalled();
-          expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled();
           expect(self.controller.$window.location).toEqual('/thank-you.html');
           expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent);
         });
@@ -277,7 +276,7 @@ describe('checkout', () => {
           self.controller.bankAccountPaymentDetails = {};
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).toHaveBeenCalled();
-          expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled();
           expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'error saving bank account' }]);
           expect(self.controller.$window.location).toEqual('/checkout.html');
           expect(self.controller.submissionError).toEqual('error saving bank account');
@@ -287,7 +286,7 @@ describe('checkout', () => {
           self.storedCvv = '1234';
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234');
-          expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled();
           expect(self.controller.$window.location).toEqual('/thank-you.html');
           expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent);
         });
@@ -296,7 +295,7 @@ describe('checkout', () => {
           self.storedCvv = undefined;
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).toHaveBeenCalledWith(undefined);
-          expect(self.controller.orderService.clearCardSecurityCode).toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled();
           expect(self.controller.$window.location).toEqual('/thank-you.html');
           expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent);
         });
@@ -306,7 +305,7 @@ describe('checkout', () => {
           self.storedCvv = '1234';
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234');
-          expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled();
           expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'CardErrorException: Invalid Card Number: some details' }]);
           expect(self.controller.$window.location).toEqual('/checkout.html');
           expect(self.controller.submissionError).toEqual('CardErrorException');
@@ -314,7 +313,7 @@ describe('checkout', () => {
         it('should throw an error if neither bank account or credit card details are loaded', () => {
           self.controller.submitOrder();
           expect(self.controller.orderService.submit).not.toHaveBeenCalled();
-          expect(self.controller.orderService.clearCardSecurityCode).not.toHaveBeenCalled();
+          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled();
           expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'Current payment type is unknown' }]);
           expect(self.controller.$window.location).toEqual('/checkout.html');
           expect(self.controller.submissionError).toEqual('Current payment type is unknown');

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -106,10 +106,7 @@ class CreditCardController {
       this.creditCardPaymentForm.expiryMonth.$validate(); // Revalidate expiryMonth after expiryYear changes
     });
 
-    if(!this.paymentMethod) {
-      this.waitForSecurityCodeInitialization();
-    }
-
+    this.waitForSecurityCodeInitialization();
   }
 
   initializeExpirationDateOptions(){
@@ -146,7 +143,7 @@ class CreditCardController {
                 'expiry-year': this.creditCardPayment.expiryYear,
                 'last-four-digits': tokenObj.maskedCardNumber,
                 transactionId: tokenObj.transactionID,
-                cvv: tokenObj.cvv2
+                cvv: this.creditCardPayment.securityCode
               }
             }
           }

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -165,7 +165,7 @@ describe('credit card form', () => {
       expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: expectedData } });
       expect(self.outerScope.onPaymentFormStateChange).toHaveBeenCalledWith({ state: 'loading', payload: expectedData });
     });
-    it('should not send a credit card or security code if a paymentMethod is present and cardNumber is unchanged', () => {
+    it('should not send a credit card if a paymentMethod is present and cardNumber is unchanged', () => {
       self.controller.paymentMethod = {
         'last-four-digits': '4567',
         'card-type': 'MasterCard'
@@ -194,7 +194,7 @@ describe('credit card form', () => {
           'expiry-year': 2019,
           'last-four-digits': '4567',
           transactionId: undefined,
-          cvv: undefined
+          cvv: '123'
         }
       };
       expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: expectedData } });

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -78,10 +78,15 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-4" ng-if="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber">
-        <div class="form-group is-required" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.securityCode | showErrors)}">
+      <div class="col-sm-4" ng-if="!$ctrl.paymentMethod || $ctrl.disableCardNumber">
+        <div class="form-group" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.securityCode | showErrors), 'is-required': !$ctrl.paymentMethod}">
           <label translate>Security Code</label>
-          <input type="text" name="securityCode" class="form-control form-control-subtle" ng-model="$ctrl.creditCardPayment.securityCode" required>
+          <input type="text"
+                 name="securityCode"
+                 class="form-control form-control-subtle"
+                 ng-model="$ctrl.creditCardPayment.securityCode"
+                 ng-required="!$ctrl.paymentMethod"
+                 ng-attr-placeholder="{{$ctrl.paymentMethod && !$ctrl.creditCardPayment.cardNumber ? '***' : ''}}">
           <div role="alert" ng-messages="$ctrl.creditCardPaymentForm.securityCode.$error" ng-if="($ctrl.creditCardPaymentForm.securityCode | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter the security code</div>
             <div class="help-block" ng-message="minLength" translate>The security code must be at least 3 digits</div>


### PR DESCRIPTION
- Store all CVVs entered during current order in session storage and use them when credit cards are selected and edited
- Hide CVV field when editing cards where card number changes are allowed (self service) since CVV isn’t used there

https://jira.cru.org/browse/EP-1925