### PR TITLE
Allow edits to spouse name during the order the spouse was added

### DIFF
--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -68,7 +68,7 @@ class Step1Controller{
         this.loadingDonorDetails = false;
         this.donorDetails = data;
         this.nameFieldsDisabled = this.donorDetails['registration-state'] === 'COMPLETED';
-        this.spouseFieldsDisabled = !!this.donorDetails['spouse-name']['given-name'] || !!this.donorDetails['spouse-name']['family-name'] || this.donorDetails.staff;
+        this.spouseFieldsDisabled = !this.orderService.spouseEditableForOrder(this.donorDetails);
         if(!this.nameFieldsDisabled && includes([Roles.registered, Roles.identified], this.sessionService.getRole())) {
           // Pre-populate first, last and email from session if missing from donorDetails
           if(!this.donorDetails['name']['given-name'] && angular.isDefined(this.sessionService.session.first_name)) {

--- a/src/common/components/contactInfo/contactInfo.component.spec.js
+++ b/src/common/components/contactInfo/contactInfo.component.spec.js
@@ -84,6 +84,7 @@ describe('contactInfo', function() {
       expect(self.controller.spouseFieldsDisabled).toEqual(false);
     });
     it('should disable name fields if the user\'s registration state is completed', () => {
+      spyOn(self.controller.orderService, 'spouseEditableForOrder').and.returnValue(false);
       let donorDetails = {
         'donor-type': 'Organization',
         'name': {
@@ -105,6 +106,7 @@ describe('contactInfo', function() {
       expect(self.controller.donorDetails).toEqual(donorDetails);
       expect(self.controller.nameFieldsDisabled).toEqual(true);
       expect(self.controller.spouseFieldsDisabled).toEqual(true);
+      expect(self.controller.orderService.spouseEditableForOrder).toHaveBeenCalledWith(donorDetails);
     });
     it('should set the donor type if it is an empty string', () => {
       spyOn(self.controller.orderService, 'getDonorDetails').and.callFake(() => Observable.of({ 'donor-type': '', 'spouse-name': {} }));

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -26,6 +26,7 @@ class Order{
     this.cortexApiService = cortexApiService;
     this.hateoasHelperService = hateoasHelperService;
     this.sessionStorage = $window.sessionStorage;
+    this.localStorage = $window.localStorage;
     this.$log = $log;
   }
 
@@ -289,6 +290,22 @@ class Order{
 
   retrieveLastPurchaseLink(){
     return this.sessionStorage.getItem('lastPurchaseLink');
+  }
+
+  spouseEditableForOrder(donorDetails){
+    if(donorDetails.staff) return false;
+    const currentOrder = this.hateoasHelperService.getLink(donorDetails, 'order');
+    const storedOrder = this.localStorage.getItem('currentOrder');
+    const hasSpouse = !!donorDetails['spouse-name']['given-name'] || !!donorDetails['spouse-name']['family-name'];
+    const startedOrderWithoutSpouse = angular.fromJson(this.localStorage.getItem('startedOrderWithoutSpouse'));
+
+    if(currentOrder !== storedOrder || startedOrderWithoutSpouse === null){
+      this.localStorage.setItem('currentOrder', currentOrder);
+      this.localStorage.setItem('startedOrderWithoutSpouse', angular.toJson(!hasSpouse));
+      return !hasSpouse;
+    }else{
+      return startedOrderWithoutSpouse;
+    }
   }
 
 }


### PR DESCRIPTION
https://jira.cru.org/browse/EP-1905

I discovered looking at the EP order id was a good way of telling when a new order has been started. This makes it easier to figure out when to clear the flag so I moved it to localStorage.

I was wondering if this would but useful for knowing when to clear the CVV or the lastPurchaseLink.

I think the CVV needs to stay in sessionStorage so it isn't persisted forever. It might still be good to clear the CVV when the order id changes but as the payment methods are keyed by payment method id anyways, that might not be an issue.

The lastPurchaseLink is used after the order is completed so the order id may have already been reset.