### PR TITLE
Update cvv in sessionStorage when selecting a payment method already …

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -105,6 +105,7 @@ class ExistingPaymentMethodsController {
 
   selectPayment(){
     if(this.selectedPaymentMethod.chosen){
+      this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri); // Unset the CVV unless the user has provided a CVV for the selected payment method this order
       this.onPaymentFormStateChange({ $event: { state: 'loading' } });
     }else{
       this.orderService.selectPaymentMethod(this.selectedPaymentMethod.selectAction)

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -198,11 +198,11 @@ describe('checkout', () => {
           expect(self.controller.$log.error.logs[0]).toEqual(['Error selecting payment method', 'some error']);
         });
         it('should not send a request if the payment is already selected', () => {
-          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account'}, chosen: true };
+          self.controller.selectedPaymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account', uri: 'chosen uri' }, chosen: true };
           self.controller.selectPayment();
           expect(self.controller.orderService.selectPaymentMethod).not.toHaveBeenCalled();
           expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading' } });
-          expect(self.controller.orderService.storeCardSecurityCode).not.toHaveBeenCalled();
+          expect(self.controller.orderService.storeCardSecurityCode).toHaveBeenCalledWith(null, 'chosen uri');
         });
       });
     });


### PR DESCRIPTION
…chosen in EP

I think this is kind of an edge case but if a user somehow had a CVV in session storage (maybe another user added a cvv, did not complete the order, signed out, and kept the tab open) and the new user just used the default payment method provided by EP, the old CVV would be used.