### PR TITLE
Force Angular 1.6.3 for now due to showErrors ng-class issue with 1.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "give-web",
   "version": "1.0.0",
   "dependencies": {
-    "angular": "^1.6.3",
+    "angular": "1.6.3",
     "angular-animate": "^1.6.3",
     "angular-cookies": "^1.6.3",
     "angular-environment": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,9 +152,13 @@ angular-upload@^1.0.13:
   dependencies:
     angular ">=1.2.0"
 
-angular@*, angular@>=1.2.0, angular@^1.0.8, angular@^1.6.3:
+angular@*, angular@>=1.2.0, angular@^1.0.8:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.4.tgz#03b7b15c01a0802d7e2cf593240e604054dc77fb"
+
+angular@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.3.tgz#5d34b799234e8fa17c6a3a14e0258733935f43e7"
 
 ansi-escapes@^1.1.0:
   version "1.4.0"
@@ -1703,14 +1707,6 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-duplicate-package-checker-webpack-plugin@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-1.2.4.tgz#ad0ec3d41c759880ec2329f6a1fcb4de3b948350"
-  dependencies:
-    chalk "^1.1.3"
-    find-root "^1.0.0"
-    lodash "^4.17.4"
-
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -2230,10 +2226,6 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
-
-find-root@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
 
 find-up@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Looks like this might be a bug. I'm going to see if we get any more feedback on this thread before making bigger changes: https://github.com/angular/angular.js/issues/15905.