### PR TITLE
[#EP-1974] Show alternate sign-in/sign-up post checkout.

### DIFF
--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -79,6 +79,12 @@ hr.vertical-divider {
   width: 1px;
 }
 
+hr.horizontal-divider {
+  width: 100%;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
 .container,
 .container-fluid {
   &:focus {

--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -1,4 +1,10 @@
 <div class="col-md-12 col-xs-12">
+  <div class="form-group" ng-if="$ctrl.lastPurchaseId && !$ctrl.identified">
+    <h4 class="text-center" translate>If you don&apos;t have a Cru username, you can create one now</h4>
+    <a id="createAccountLink" href="" ng-click="$ctrl.onStateChange({state: 'sign-up'})" class="btn btn-block btn-primary" translate>Create a Username &amp; Password</a>
+    <hr class="horizontal-divider"/>
+    <h4 class="text-center" translate>If you already have a Cru username, use it to sign in so we can link it to your giving</h4>
+  </div>
   <p ng-if="$ctrl.identified" class="text-center">
     <strong translate>Welcome back, {{$ctrl.sessionService.session.first_name}} {{$ctrl.sessionService.session.last_name}}!</strong>
   </p>
@@ -11,7 +17,7 @@
     <span translate>Not {{$ctrl.sessionService.session.first_name}} {{$ctrl.sessionService.session.last_name}}?</span>
     <a id="signOutLink" href="" ng-click="$ctrl.signOut()" translate>Sign Out</a>
   </p>
-  <div class="form-group" ng-if="!$ctrl.identified">
+  <div class="form-group" ng-if="!$ctrl.identified && !$ctrl.lastPurchaseId">
     <p class="text-center strike">
       <span translate>Don't have an account?</span>
     </p>


### PR DESCRIPTION
This adds an alternate sign-in/sign-up modal for use during user match post checkout.
It ties into the fact that the lastPurchaseId will be present during this workflow, and not others.