### PR TITLE
Correct card number disabling and cvv hiding

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -87,7 +87,7 @@ class ExistingPaymentMethodsController {
       resolve: {
         paymentForm: this.paymentFormResolve,
         paymentMethod: existingPaymentMethod,
-        disableCardNumber: !!existingPaymentMethod,
+        disableCardNumber: !!existingPaymentMethod && !existingPaymentMethod['from-current-order'],
         mailingAddress: this.mailingAddress,
         onPaymentFormStateChange: () => param => {
           param.$event.stayOnStep = true;

--- a/src/app/profile/payment-methods/payment-method/payment-method.component.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.component.js
@@ -44,6 +44,7 @@ class PaymentMethodController{
       resolve: {
         paymentForm: this.paymentFormResolve,
         paymentMethod: this.model,
+        hideCvv: true,
         mailingAddress: this.mailingAddress,
         onPaymentFormStateChange: () => params => this.onPaymentFormStateChange(params.$event)
       }

--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -91,6 +91,7 @@ class PaymentMethodsController {
       windowTemplateUrl: giveModalWindowTemplate,
       resolve: {
         paymentForm: this.paymentFormResolve,
+        hideCvv: true,
         mailingAddress: this.mailingAddress,
         onPaymentFormStateChange: () => param => this.onPaymentFormStateChange(param.$event)
       }

--- a/src/app/profile/yourGiving/editRecurringGifts/step0/addUpdatePaymentMethod.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step0/addUpdatePaymentMethod.tpl.html
@@ -24,7 +24,7 @@
   <div class="container-fluid" tabindex="-1" role="dialog">
     <div class="row">
       <div class="col-md-12 col-xs-12">
-        <payment-method-form payment-form-state="$ctrl.paymentFormState" payment-form-error="$ctrl.paymentFormError" on-payment-form-state-change="$ctrl.onPaymentFormStateChange($event)" payment-method="$ctrl.paymentMethod" mailing-address="$ctrl.mailingAddress"></payment-method-form>
+        <payment-method-form payment-form-state="$ctrl.paymentFormState" payment-form-error="$ctrl.paymentFormError" on-payment-form-state-change="$ctrl.onPaymentFormStateChange($event)" payment-method="$ctrl.paymentMethod" hide-cvv="true" mailing-address="$ctrl.mailingAddress"></payment-method-form>
       </div>
     </div>
   </div>

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -76,9 +76,10 @@ class CreditCardController {
   waitForSecurityCodeInitialization() {
     let unregister = this.$scope.$watch('$ctrl.creditCardPaymentForm.securityCode', () => {
       unregister();
-      if(!this.paymentMethod) { // If editing existing payment method, don't require a CVV
-        this.creditCardPaymentForm.securityCode.$validators.minLength = cruPayments.creditCard.cvv.validate.minLength;
-      }
+      this.creditCardPaymentForm.securityCode.$validators.minLength = number => {
+        // If editing existing payment method, don't require a CVV
+        return !this.creditCardPaymentForm.securityCode.$viewValue && this.paymentMethod && !this.creditCardPayment.cardNumber || cruPayments.creditCard.cvv.validate.minLength(number);
+      };
       this.creditCardPaymentForm.securityCode.$validators.maxLength = cruPayments.creditCard.cvv.validate.maxLength;
       this.creditCardPaymentForm.securityCode.$validators.cardTypeLength = number => cruPayments.creditCard.cvv.validate.cardTypeLength(number, cruPayments.creditCard.card.info.type(this.creditCardPayment.cardNumber));
       this.creditCardPaymentForm.cardNumber.$viewChangeListeners.push(() => {
@@ -108,7 +109,9 @@ class CreditCardController {
       this.creditCardPaymentForm.expiryMonth.$validate(); // Revalidate expiryMonth after expiryYear changes
     });
 
-    this.waitForSecurityCodeInitialization();
+    if(!this.hideCvv){
+      this.waitForSecurityCodeInitialization();
+    }
   }
 
   initializeExpirationDateOptions(){
@@ -185,6 +188,7 @@ export default angular
       paymentFormState: '<',
       paymentMethod: '<',
       disableCardNumber: '<',
+      hideCvv: '<',
       mailingAddress: '<',
       onPaymentFormStateChange: '&'
     }

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -349,11 +349,6 @@ describe('credit card form', () => {
       it('should not be valid if the field is empty',  () => {
         expect(self.formController.securityCode.$valid).toEqual(false);
       });
-      it('should not exist if existing payment method is present',  () => {
-        self.controller.paymentMethod = {};
-        self.formController.securityCode.$setViewValue('foo');
-        expect(self.formController.securityCode).toBeUndefined();
-      });
       it('should not be valid if it is less than 3 digits',  () => {
         self.formController.securityCode.$setViewValue('12');
         expect(self.formController.securityCode.$valid).toEqual(false);
@@ -388,6 +383,21 @@ describe('credit card form', () => {
         self.formController.securityCode.$setViewValue('123');
         expect(self.formController.securityCode.$valid).toEqual(true);
         self.formController.cardNumber.$setViewValue('371449635398431');
+        expect(self.formController.securityCode.$valid).toEqual(false);
+      });
+      it('should be valid if it is empty and is an existing payment method',  () => {
+        self.controller.paymentMethod = {
+          'last-four-digits': '1234'
+        };
+        self.formController.securityCode.$setViewValue('');
+        expect(self.formController.securityCode.$valid).toEqual(true);
+      });
+      it('should not be valid if it is empty, is an existing payment method, but has a modified card number',  () => {
+        self.controller.paymentMethod = {
+          'last-four-digits': '1234'
+        };
+        self.formController.cardNumber.$setViewValue('4111111111111111');
+        self.formController.securityCode.$setViewValue('');
         expect(self.formController.securityCode.$valid).toEqual(false);
       });
     });

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -78,14 +78,14 @@
           </div>
         </div>
       </div>
-      <div class="col-sm-4" ng-if="!$ctrl.paymentMethod || $ctrl.disableCardNumber">
+      <div class="col-sm-4" ng-if="!$ctrl.hideCvv">
         <div class="form-group" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.securityCode | showErrors), 'is-required': !$ctrl.paymentMethod}">
           <label translate>Security Code</label>
           <input type="text"
                  name="securityCode"
                  class="form-control form-control-subtle"
                  ng-model="$ctrl.creditCardPayment.securityCode"
-                 ng-required="!$ctrl.paymentMethod"
+                 ng-required="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber"
                  ng-attr-placeholder="{{$ctrl.paymentMethod && !$ctrl.creditCardPayment.cardNumber ? '***' : ''}}">
           <div role="alert" ng-messages="$ctrl.creditCardPaymentForm.securityCode.$error" ng-if="($ctrl.creditCardPaymentForm.securityCode | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter the security code</div>

--- a/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
+++ b/src/common/components/paymentMethods/deletePaymentMethod/deletePaymentMethod.modal.tpl.html
@@ -71,7 +71,7 @@
               </div>
 
               <div class="mb--" ng-switch-when="addPaymentMethod">
-                <payment-method-form payment-form-state="$ctrl.paymentFormState" payment-form-error="$ctrl.paymentFormError" on-payment-form-state-change="$ctrl.onPaymentFormStateChange($event)" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
+                <payment-method-form payment-form-state="$ctrl.paymentFormState" payment-form-error="$ctrl.paymentFormError" on-payment-form-state-change="$ctrl.onPaymentFormStateChange($event)" hide-cvv="true" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
                 <div class="mb0">
                   <div class="row">
                     <div class="col-xs-6">

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -48,6 +48,7 @@ export default angular
       paymentFormError: '<',
       paymentMethod: '<',
       disableCardNumber: '<',
+      hideCvv: '<',
       mailingAddress: '<',
       onPaymentFormStateChange: '&'
     }

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.modal.tpl.html
@@ -20,7 +20,7 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
-        <payment-method-form payment-form-state="$ctrl.resolve.paymentForm.state" payment-form-error="$ctrl.resolve.paymentForm.error" on-payment-form-state-change="$ctrl.resolve.onPaymentFormStateChange({$event: $event})" payment-method="$ctrl.resolve.paymentMethod" disable-card-number="$ctrl.resolve.disableCardNumber" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
+        <payment-method-form payment-form-state="$ctrl.resolve.paymentForm.state" payment-form-error="$ctrl.resolve.paymentForm.error" on-payment-form-state-change="$ctrl.resolve.onPaymentFormStateChange({$event: $event})" payment-method="$ctrl.resolve.paymentMethod" disable-card-number="$ctrl.resolve.disableCardNumber" hide-cvv="$ctrl.resolve.hideCvv" mailing-address="$ctrl.resolve.mailingAddress"></payment-method-form>
       </div>
     </div>
 

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
@@ -50,6 +50,6 @@
 </div>
 <div class="tab-org cart-tab show" ng-if="$ctrl.paymentType === 'creditCard'">
 
-  <credit-card-form payment-form-state="$ctrl.paymentFormState" on-payment-form-state-change="$ctrl.onPaymentFormStateChange({ $event: $event })" payment-method="$ctrl.paymentMethod" disable-card-number="$ctrl.disableCardNumber" mailing-address="$ctrl.mailingAddress"></credit-card-form>
+  <credit-card-form payment-form-state="$ctrl.paymentFormState" on-payment-form-state-change="$ctrl.onPaymentFormStateChange({ $event: $event })" payment-method="$ctrl.paymentMethod" disable-card-number="$ctrl.disableCardNumber" hide-cvv="$ctrl.hideCvv" mailing-address="$ctrl.mailingAddress"></credit-card-form>
 
 </div>


### PR DESCRIPTION
- Disable card number when editing a card that is not from current order
- Add hideCvv binding to hide CVV field in profile
- Allow no CVV when editing an existing payment method and the card number has not changed

Front end changes for https://jira.cru.org/browse/EP-1962