### PR TITLE
Scrub rollbar fields

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -17,6 +17,7 @@ function rollbarConfig(envServiceProvider, $provide) {
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
     transform: transformRollbarPayload,
     hostWhiteList: ['give.cru.org', 'give-stage2.cru.org', 'stage.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org'],
+    scrubFields: ['password', 'cvv', 'cvv2', 'security-code'],
     payload: {
       client: {
         javascript: {


### PR DESCRIPTION
I'm hoping this is all it takes to prevent logs like this https://rollbar.com/Cru/give-web/items/40/occurrences/22840322111/

Can you guys think of any other keys that would be good to add?

The defaults are here https://rollbar.com/docs/notifier/rollbar.js/#context-1 but I didn't think we needed them all.