### PR TITLE
Send card number when editing a credit card during checkout

### DIFF
--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -7,7 +7,6 @@ import 'rxjs/add/operator/pluck';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 import map from 'lodash/map';
-import pick from 'lodash/pick';
 import omit from 'lodash/omit';
 import sortPaymentMethods from 'common/services/paymentHelpers/paymentMethodSort';
 
@@ -153,7 +152,7 @@ class Order{
       .mergeMap(data => {
         return this.cortexApiService.post({
           path: this.hateoasHelperService.getLink(data.updateForm, 'updatecreditcardfororderaction'),
-          data: pick(paymentInfo, ['address', 'cardholder-name', 'expiry-month', 'expiry-year'])
+          data: omit(paymentInfo, 'cvv')
         })
           .do(() => {
             this.storeCardSecurityCode(paymentInfo.cvv, paymentMethod.self.uri);

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -381,20 +381,16 @@ describe('order service', () => {
       };
     });
     it('should update the given payment method', () => {
-      this.runTestWith({ 'cardholder-name': 'New name', cvv: '963' },
-        { 'cardholder-name': 'New name' }, '963');
+      this.runTestWith({ 'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa', cvv: '963' },
+        { 'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa' }, '963');
     });
     it('should update the given payment method with an address', () => {
       this.runTestWith({ 'cardholder-name': 'New name', cvv: '789', address: { country: 'US' } },
         { 'cardholder-name': 'New name', address: { 'country-name': 'US' } }, '789');
     });
-    it('should omit the credit card field since it can\'t be updated', () => {
-      this.runTestWith({ 'cardholder-name': 'New name', cvv: '741', 'card-number': '0000' },
-        { 'cardholder-name': 'New name' }, '741');
-    });
     it('should call storeCardSecurityCode with undefined when the cvv wasn\'t changed', () => {
       this.runTestWith({ 'cardholder-name': 'New name', 'card-number': '0000' },
-        { 'cardholder-name': 'New name' }, undefined);
+        { 'cardholder-name': 'New name', 'card-number': '0000' }, undefined);
     });
   });
 


### PR DESCRIPTION
I missed this when making changes for https://jira.cru.org/browse/EP-1962. Previously the card number couldn't be modified.