### PR TITLE
Use fakeLocalStorage to keep localStorage and sessionStorage in memor…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ comment: off
 coverage:
   ignore:
     - "src/app/analytics/*"
+    - "src/common/lib/*"

--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -18,6 +18,7 @@ import sessionEnforcerService, {EnforcerCallbacks} from 'common/services/session
 import {Roles, SignOutEvent} from 'common/services/session/session.service';
 
 import analyticsFactory from 'app/analytics/analytics.factory';
+import 'common/lib/fakeLocalStorage';
 
 import template from './checkout.tpl.html';
 

--- a/src/common/lib/fakeLocalStorage.js
+++ b/src/common/lib/fakeLocalStorage.js
@@ -1,0 +1,73 @@
+/* eslint-disable */
+// From https://gist.github.com/engelfrost/fd707819658f72b42f55
+
+// Fake localStorage implementation.
+// Mimics localStorage, including events.
+// It will work just like localStorage, except for the persistent storage part.
+
+var fakeLocalStorage = function() {
+  var fakeLocalStorage = {};
+  var storage;
+
+  // If Storage exists we modify it to write to our fakeLocalStorage object instead.
+  // If Storage does not exist we create an empty object.
+  if (window.Storage && window.localStorage) {
+    storage = window.Storage.prototype;
+  } else {
+    // We don't bother implementing a fake Storage object
+    window.localStorage = {};
+    storage = window.localStorage;
+  }
+
+  // For older IE
+  if (!window.location.origin) {
+    window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+  }
+
+  var dispatchStorageEvent = function(key, newValue) {
+    var oldValue = (key == null) ? null : storage.getItem(key); // `==` to match both null and undefined
+    var url = location.href.substr(location.origin.length);
+    var storageEvent = document.createEvent('StorageEvent'); // For IE, http://stackoverflow.com/a/25514935/1214183
+
+    storageEvent.initStorageEvent('storage', false, false, key, oldValue, newValue, url, null);
+    window.dispatchEvent(storageEvent);
+  };
+
+  storage.key = function(i) {
+    var key = Object.keys(fakeLocalStorage)[i];
+    return typeof key === 'string' ? key : null;
+  };
+
+  storage.getItem = function(key) {
+    return typeof fakeLocalStorage[key] === 'string' ? fakeLocalStorage[key] : null;
+  };
+
+  storage.setItem = function(key, value) {
+    dispatchStorageEvent(key, value);
+    fakeLocalStorage[key] = String(value);
+  };
+
+  storage.removeItem = function(key) {
+    dispatchStorageEvent(key, null);
+    delete fakeLocalStorage[key];
+  };
+
+  storage.clear = function() {
+    dispatchStorageEvent(null, null);
+    fakeLocalStorage = {};
+  };
+};
+
+// Example of how to use it
+if (typeof window.localStorage === 'object') {
+  // Safari will throw a fit if we try to use localStorage.setItem in private browsing mode.
+  try {
+    localStorage.setItem('localStorageTest', 1);
+    localStorage.removeItem('localStorageTest');
+  } catch (e) {
+    fakeLocalStorage();
+  }
+} else {
+  // Use fake localStorage for any browser that does not support it.
+  fakeLocalStorage();
+}


### PR DESCRIPTION
…y when the browser doesn’t support them.

https://jira.cru.org/browse/EP-1989

Since this overwrites the implementation of `window.Storage`, this seems to work for sessionStorage also.

I don't think we have any components other than checkout that are using Storage to communicate between different states of the same component so I just included it in that bundle.