### PR TITLE
Don’t require CVV when not showing CVV input

### DIFF
--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -132,7 +132,7 @@ class CreditCardController {
         this.tsysService.getManifest()
           .mergeMap(data => {
             cruPayments.creditCard.init(this.envService.get(), data.deviceId, data.manifest);
-            return cruPayments.creditCard.encrypt(this.creditCardPayment.cardNumber, this.creditCardPayment.securityCode, this.creditCardPayment.expiryMonth, this.creditCardPayment.expiryYear);
+            return cruPayments.creditCard.encrypt(this.creditCardPayment.cardNumber, this.hideCvv ? null : this.creditCardPayment.securityCode, this.creditCardPayment.expiryMonth, this.creditCardPayment.expiryYear);
           });
       tokenObservable.subscribe(tokenObj => {
         this.onPaymentFormStateChange({

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -165,6 +165,22 @@ describe('credit card form', () => {
       expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: expectedData } });
       expect(self.outerScope.onPaymentFormStateChange).toHaveBeenCalledWith({ state: 'loading', payload: expectedData });
     });
+    it('should call encrypt with a null cvv if the cvv input is hidden', () => {
+      self.controller.hideCvv = true;
+      self.controller.creditCardPayment = {
+        cardNumber: '4111111111111111',
+        cardholderName: 'Person Name',
+        expiryMonth: 12,
+        expiryYear: 2019
+      };
+      self.controller.useMailingAddress = true;
+      self.formController.$valid = true;
+      self.controller.savePayment();
+      expect(self.controller.tsysService.getManifest).toHaveBeenCalled();
+      expect(cruPayments.creditCard.init).toHaveBeenCalledWith('development', '<device id>', '<manifest>');
+      expect(cruPayments.creditCard.encrypt).toHaveBeenCalledWith('4111111111111111', null, 12, 2019);
+      expect(self.formController.$setSubmitted).toHaveBeenCalled();
+    });
     it('should not send a credit card if a paymentMethod is present and cardNumber is unchanged', () => {
       self.controller.paymentMethod = {
         'last-four-digits': '4567',


### PR DESCRIPTION
- Pass null CVV to cru-payments to skip CVV validation in this case

Currently saving payment methods in the profile is broken because it is requiring the CVV. Checkout has no issues.