### PR TITLE
Fix profile image height in designation editor

### DIFF
--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -146,6 +146,9 @@ hr.horizontal-divider {
   max-width: 40%;
   max-height: 345px;
   position: relative;
+  & > img {
+    max-height: 345px;
+  }
 }
 
 .loading {


### PR DESCRIPTION
This is only an issue in the editor where the `secondary-detail` class is not actually on the `img` tag. It causes the text to flow under the image because the container is smaller than the image. Uploading a new image may resize it properly, idk. But my old portrait aspect ratio image was overflowing.