### PR TITLE
Scrub password reset k query param from rollbar

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -17,7 +17,7 @@ function rollbarConfig(envServiceProvider, $provide) {
     enabled: !envServiceProvider.is('development'), // Disable rollbar in development environment
     transform: transformRollbarPayload,
     hostWhiteList: ['give.cru.org', 'give-prod.cru.org', 'give-stage2.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org'],
-    scrubFields: ['password', 'cvv', 'cvv2', 'security-code'],
+    scrubFields: ['password', 'cvv', 'cvv2', 'security-code', 'k'],
     payload: {
       client: {
         javascript: {


### PR DESCRIPTION
I don't think we want this key in Rollbar. https://github.com/CruGlobal/give-web/blob/master/src/common/components/resetPasswordModal/resetPasswordModal.component.js#L29-L29 It would allow anyone with access to rollbar to potentially reset a user's password. There are a few request urls in Rollbar that contain this.