### PR TITLE
Cleanup reset password modal rollbar logs

### DIFF
--- a/src/common/services/session/sessionEnforcer.service.js
+++ b/src/common/services/session/sessionEnforcer.service.js
@@ -102,7 +102,7 @@ function SessionEnforcerService( orderService, sessionService, sessionModalServi
           backdrop: 'static',
           keyboard: false
         } ).result;
-        modal.then( () => {
+        modal && modal.then( () => {
           angular.forEach( enforced, ( enforcer ) => {
             if ( angular.isFunction( enforcer[EnforcerCallbacks.signIn] ) ) enforcer[EnforcerCallbacks.signIn]();
           } );
@@ -111,7 +111,7 @@ function SessionEnforcerService( orderService, sessionService, sessionModalServi
             if ( angular.isFunction( enforcer[EnforcerCallbacks.cancel] ) ) enforcer[EnforcerCallbacks.cancel]();
           } );
         } );
-        modal.finally( () => {
+        modal && modal.finally( () => {
           modal = undefined;
         } );
       }

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -18,7 +18,9 @@ function SessionModalService( $uibModal, $log, modalStateService, analyticsFacto
         currentModal.dismiss( 'replaced' );
       }
       else {
-        $log.error( 'Attempted to open more than 1 modal' );
+        if(currentModal.type !== 'reset-password'){
+          $log.error( 'Attempted to open more than 1 modal' );
+        }
         return false;
       }
     }
@@ -35,6 +37,7 @@ function SessionModalService( $uibModal, $log, modalStateService, analyticsFacto
       }
     }, options );
     currentModal = $uibModal.open( modalOptions );
+    currentModal.type = type;
     currentModal.result
       .finally( () => {
         // Clear the modal name when modals close


### PR DESCRIPTION
- Suppress “Attempted to open more than 1 modal” log when reset-password modal is open
- Handle case in session enforcer where modal is not defined because another modal was already open