### PR TITLE
Improve session handling with reset password modal

### DIFF
--- a/src/common/components/resetPasswordModal/resetPasswordModal.tpl.html
+++ b/src/common/components/resetPasswordModal/resetPasswordModal.tpl.html
@@ -52,11 +52,13 @@
       <loading type="overlay" ng-if="$ctrl.isLoading"></loading>
     </form>
     <p class="mt- text-center" translate>
-      <a id="backToSignInLink" href="" ng-click="$ctrl.onStateChange({state: 'sign-in'})">Back to Sign In</a>
+      <a id="backToSignInLink" href="" ng-click="$ctrl.backToSignIn()">Back to Sign In</a>
     </p>
   </div>
-  <div ng-if="$ctrl.passwordChanged" class="alert alert-success">
-    <p translate>Your password has successfully been updated.</p>
-    <p translate>Return to <a id="returnToSignInLink" ng-click="$ctrl.onStateChange({state: 'sign-in'})">Sign In</a>.</p>
+  <div ng-if="$ctrl.passwordChanged">
+    <div class="alert alert-success">
+      <p translate>Your password has successfully been updated.</p>
+    </div>
+    <button class="btn btn-primary pull-right" ng-click="$ctrl.onSuccess()" translate>Continue</button>
   </div>
 </div>

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -5,8 +5,8 @@ import {Observable} from 'rxjs/Observable';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/observable/throw';
-import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/finally';
 
 import {updateRollbarPerson} from 'common/rollbar.config.js';
@@ -135,7 +135,7 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
           resetKey: resetKey
         }
       } ) )
-      .map( ( response ) => response.data );
+      .mergeMap( () => signIn(email, password) );
   }
 
   function downgradeToGuest( skipEvent = false ) {

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -217,12 +217,16 @@ describe( 'session service', function () {
   } );
 
   describe( 'resetPassword', () => {
-    it( 'makes http request to cas/reset_password', () => {
+    it( 'makes http request to cas/reset_password and then sign in', () => {
       $httpBackend.expectPOST( 'https://give-stage2.cru.org/cas/reset_password', {
         email:    'professorx@xavier.edu',
         password: 'Cerebro123',
         resetKey: 'abc123def456'
       } ).respond( 200, {} );
+      $httpBackend.expectPOST( 'https://give-stage2.cru.org/cas/login', {
+        username: 'professorx@xavier.edu',
+        password: 'Cerebro123'
+      } ).respond( 200, 'success' );
       sessionService
         .resetPassword( 'professorx@xavier.edu', 'Cerebro123', 'abc123def456' )
         .subscribe( ( data ) => {

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -24,7 +24,8 @@
           </forgot-password-modal>
           <reset-password-modal ng-switch-when="reset-password"
                                 modal-title="$ctrl.modalTitle"
-                                on-state-change="$ctrl.stateChanged(state)">
+                                on-state-change="$ctrl.stateChanged(state)"
+                                on-success="$ctrl.onSignInSuccess()">
           </reset-password-modal>
           <sign-up-modal ng-switch-when="sign-up"
                          modal-title="$ctrl.modalTitle"


### PR DESCRIPTION
- Refresh page when modal dismissed without updating password
- Sign in immediately after changing password

Based off [this comment](https://github.com/CruGlobal/give-web/pull/607#issuecomment-299034401).

@Omicron7 can you review this functionality? I'll add/fix tests after. Does signing in immediately after a password reset sound like it will work? One issue still is if the user clicks the `Back to Sign In` link and then dismisses the sign in modal, they won't be redirected away from the page. I thought about just tossing that link...