### PR TITLE
Convert sessionModal controller to component

### DIFF
--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -11,18 +11,22 @@ import registerAccountModal from 'common/components/registerAccountModal/registe
 
 import {scrollModalToTop} from 'common/services/modalState.service';
 
-let controllerName = 'sessionModalController';
+import template from './sessionModal.tpl.html';
+
+let componentName = 'sessionModal';
 
 class SessionModalController {
 
   /* @ngInject */
-  constructor( $uibModalInstance, $scope, sessionService, state ) {
-    this.$uibModalInstance = $uibModalInstance;
+  constructor( sessionService ) {
     this.sessionService = sessionService;
     this.isLoading = false;
     this.scrollModalToTop = scrollModalToTop;
-    this.lastPurchaseId = $scope.$resolve.lastPurchaseId;
-    this.stateChanged( state );
+  }
+
+  $onInit(){
+    this.stateChanged( this.resolve.state );
+    this.lastPurchaseId = this.resolve.lastPurchaseId;
   }
 
   stateChanged( state ) {
@@ -31,19 +35,19 @@ class SessionModalController {
   }
 
   onSignInSuccess() {
-    this.$uibModalInstance.close();
+    this.close();
   }
 
   onSignUpSuccess() {
-    this.$uibModalInstance.close();
+    this.close();
   }
 
   onFailure() {
-    this.$uibModalInstance.dismiss( 'error' );
+    this.dismiss({ $value:  'error' });
   }
 
   onCancel() {
-    this.$uibModalInstance.dismiss( 'cancel' );
+    this.dismiss({ $value: 'cancel' });
   }
 
   setLoading( loading ) {
@@ -52,7 +56,7 @@ class SessionModalController {
 }
 
 export default angular
-  .module( controllerName, [
+  .module( componentName, [
     signInModal.name,
     signUpModal.name,
     resetPasswordModal.name,
@@ -62,4 +66,12 @@ export default angular
     accountBenefitsModal.name,
     registerAccountModal.name
   ] )
-  .controller( controllerName, SessionModalController );
+  .component( componentName, {
+    controller: SessionModalController,
+    templateUrl: template,
+    bindings: {
+      resolve: '<',
+      close: '&',
+      dismiss: '&'
+    }
+  } );

--- a/src/common/services/session/sessionModal.component.spec.js
+++ b/src/common/services/session/sessionModal.component.spec.js
@@ -1,35 +1,39 @@
 import angular from 'angular';
 import 'angular-mocks';
-import module from './sessionModal.controller';
+import module from './sessionModal.component';
 
 describe( 'sessionModalController', function () {
   beforeEach( angular.mock.module( module.name ) );
-  let $ctrl, uibModalInstance, state;
+  let $ctrl, state;
 
-  beforeEach( inject( function ( $controller, ) {
-    uibModalInstance = jasmine.createSpyObj( 'uibModalInstance', ['close', 'dismiss'] );
+  beforeEach( inject( function ( $componentController, ) {
     state = 'sign-in';
-    $ctrl = $controller( module.name, {
-      $uibModalInstance: uibModalInstance,
-      state:             state,
-      $scope:            { $resolve: {} }
-    } );
+    $ctrl = $componentController( module.name, {},
+      {
+        resolve: {
+          state: state,
+          lastPurchaseId: '<some id>'
+        },
+        close: jasmine.createSpy('dismiss'),
+        dismiss: jasmine.createSpy('dismiss')
+      });
   } ) );
 
-  describe( '$ctrl.stateChanged', () => {
-    beforeEach(() => {
-      spyOn($ctrl, 'scrollModalToTop');
+  describe( '$ctrl.$onInit', () => {
+    it('should initialize the component state', () => {
+      expect( $ctrl.isLoading ).toEqual( false );
+      $ctrl.$onInit();
+      expect( $ctrl.state ).toEqual( 'sign-in' );
+      expect( $ctrl.lastPurchaseId ).toEqual( '<some id>' );
     });
+  });
 
+  describe( '$ctrl.stateChanged', () => {
     it('should scroll to the top of the modal', () => {
+      spyOn($ctrl, 'scrollModalToTop');
       $ctrl.stateChanged();
       expect($ctrl.scrollModalToTop).toHaveBeenCalled();
     });
-
-    it( 'should be defined', () => {
-      expect( $ctrl.stateChanged ).toBeDefined();
-      expect( $ctrl.state ).toEqual( 'sign-in' );
-    } );
 
     it( 'should update state', () => {
       $ctrl.stateChanged( 'sign-up' );
@@ -40,28 +44,28 @@ describe( 'sessionModalController', function () {
   describe( '$ctrl.onSignInSuccess', () => {
     it( 'should close modal', () => {
       $ctrl.onSignInSuccess();
-      expect( uibModalInstance.close ).toHaveBeenCalled();
+      expect( $ctrl.close ).toHaveBeenCalled();
     } );
   } );
 
   describe( '$ctrl.onSignUpSuccess', () => {
     it( 'should close modal', () => {
       $ctrl.onSignUpSuccess();
-      expect( uibModalInstance.close ).toHaveBeenCalled();
+      expect( $ctrl.close ).toHaveBeenCalled();
     } );
   } );
 
   describe( '$ctrl.onFailure', () => {
     it( 'should dismiss modal with \'error\'', () => {
       $ctrl.onFailure();
-      expect( uibModalInstance.dismiss ).toHaveBeenCalledWith( 'error' );
+      expect( $ctrl.dismiss ).toHaveBeenCalledWith({ $value: 'error' });
     } );
   } );
 
   describe( '$ctrl.onCancel', () => {
     it( 'should dismiss modal with \'cancel\'', () => {
       $ctrl.onCancel();
-      expect( uibModalInstance.dismiss ).toHaveBeenCalledWith( 'cancel' );
+      expect( $ctrl.dismiss ).toHaveBeenCalledWith({ $value: 'cancel' });
     } );
   } );
 

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -1,8 +1,7 @@
 import angular from 'angular';
 import 'angular-ui-bootstrap';
 import modalStateService from 'common/services/modalState.service';
-import sessionModalController from './sessionModal.controller';
-import sessionModalTemplate from './sessionModal.tpl.html';
+import sessionModalComponent from './sessionModal.component';
 import sessionModalWindowTemplate from './sessionModalWindow.tpl.html';
 import analyticsFactory from 'app/analytics/analytics.factory';
 
@@ -27,9 +26,7 @@ function SessionModalService( $uibModal, $log, modalStateService, analyticsFacto
     type = angular.isDefined( type ) ? type : 'sign-in';
     options = angular.isObject( options ) ? options : {};
     let modalOptions = angular.merge( {}, {
-      templateUrl:       sessionModalTemplate,
-      controller:        sessionModalController.name,
-      controllerAs:      '$ctrl',
+      component:         sessionModalComponent.name,
       size:              'sm',
       windowTemplateUrl: sessionModalWindowTemplate,
       resolve:           {
@@ -89,7 +86,7 @@ export default angular
   .module( serviceName, [
     'ui.bootstrap',
     modalStateService.name,
-    sessionModalController.name,
+    sessionModalComponent.name,
     analyticsFactory.name
   ] )
   .factory( serviceName, SessionModalService )


### PR DESCRIPTION
This is low priority. I thought I needed access to the `dismiss` function and for some reason thought a component was the only way to pass it on which isn't really the case. Anyways, I'd done most of the work and I think this improves the code and is good cleanup.