### PR TITLE
In product config, handle attempted opening of second modal more grac…

### DIFF
--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -78,9 +78,9 @@ class CartController {
   }
 
   editItem( item ) {
-    this.productModalService
-      .configureProduct( item.code, item.config, true, item.uri )
-      .result
+    const modal = this.productModalService
+      .configureProduct( item.code, item.config, true, item.uri );
+    modal && modal.result
       .then( () => {
         pull(this.cartData.items, item);
         this.loadCart(true);

--- a/src/app/productConfig/productConfig.component.js
+++ b/src/app/productConfig/productConfig.component.js
@@ -34,6 +34,11 @@ class ProductConfigController {
         'campaign-code': this.campaignCode,
         'campaign-page': this.campaignPage
       }, false );
+    if(!modalInstance){
+      // Another modal already opened
+      this.loadingModal = false;
+      return;
+    }
     modalInstance.rendered.then( () => {
       this.loadingModal = false;
       this.analyticsFactory.giveGiftModal(this.productCode);

--- a/src/app/productConfig/productConfig.component.spec.js
+++ b/src/app/productConfig/productConfig.component.spec.js
@@ -102,6 +102,11 @@ describe( 'productConfig', function () {
       expect( $ctrl.loadingModal ).toEqual( false );
       expect( $ctrl.$log.error.logs[0] ).toBeUndefined();
     } );
+    it( 'should gracefully handle an attempt to open a second modal', () => {
+      productModalService.configureProduct.and.returnValue(false);
+      $ctrl.configModal();
+      expect( $ctrl.loadingModal ).toEqual( false );
+    } );
   } );
 } );
 


### PR DESCRIPTION
…efully

This sort of fixes some of the subsequent errors sent to rollbar related to https://jira.cru.org/browse/EP-2021 ([can't call rendered of undefined](https://rollbar.com/Cru/give-web/items/999/)) but doesn't address the main issues. My assumption with that issue was that some users were unable to open the product config modal but that could be wrong. If multiple buttons are clicked before the first one finishes loading, this code will get run and prevent JS errors.