### PR TITLE
fixed editor height

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -168,6 +168,7 @@ class DesignationEditorController {
       templateUrl:       textEditorModalTemplate,
       controller:        textEditorModalController.name,
       controllerAs:      '$ctrl',
+      size:              'lg designation-editor-modal',
       resolve : {
         initialText: () => {
           return this.designationContent[field];

--- a/src/app/designationEditor/textEditorModal/textEditor.scss
+++ b/src/app/designationEditor/textEditorModal/textEditor.scss
@@ -1,7 +1,14 @@
 @charset "UTF-8";
 
 text-angular{
+  .ta-editor{
+    max-height: 400px;
+  }
   .btn-group{
     margin-bottom: .5em;
   }
+}
+
+.designation-editor-modal {
+  height: auto !important;
 }


### PR DESCRIPTION
Removed need to scroll back up to the editor toolbar if editor content is very long.

The height auto was added to remove the window scroll bar when the editor is open.

Should solve this issue: https://secure.helpscout.net/conversation/361946896/132276