### PR TITLE
Upgrade webpack-dev-server and fix public path which is now validated…

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "style-loader": "^0.16.0",
     "webpack": "^2.3.3",
     "webpack-bundle-analyzer": "^2.3.1",
-    "webpack-dev-server": "^2.4.2"
+    "webpack-dev-server": "^2.4.5"
   },
   "scripts": {
     "start": "webpack-dev-server",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,7 +137,8 @@ module.exports = env => {
         '/etc': aemDomain,
         '/designations': aemDomain
       },
-      port: 9000
+      port: 9000,
+      public: "localhost.cru.org:9000"
     }
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,11 +152,7 @@ angular-upload@^1.0.13:
   dependencies:
     angular ">=1.2.0"
 
-angular@*, angular@>=1.2.0, angular@^1.0.8:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.4.tgz#03b7b15c01a0802d7e2cf593240e604054dc77fb"
-
-angular@1.6.3:
+angular@*, angular@1.6.3, angular@>=1.2.0, angular@^1.0.8:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.6.3.tgz#5d34b799234e8fa17c6a3a14e0258733935f43e7"
 
@@ -5634,7 +5630,7 @@ webpack-bundle-analyzer@^2.3.1:
     mkdirp "^0.5.1"
     opener "^1.4.2"
 
-webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.9.0:
+webpack-dev-middleware@^1.0.11:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz#c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893"
   dependencies:
@@ -5643,9 +5639,18 @@ webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.9.0:
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.4.2.tgz#cf595d6b40878452b6d2ad7229056b686f8a16be"
+webpack-dev-middleware@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz#2e252ce1dfb020dbda1ccb37df26f30ab014dbd1"
+  dependencies:
+    memory-fs "~0.4.1"
+    mime "^1.3.4"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+
+webpack-dev-server@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz#31384ce81136be1080b4b4cde0eb9b90e54ee6cf"
   dependencies:
     ansi-html "0.0.7"
     chokidar "^1.6.0"
@@ -5662,7 +5667,7 @@ webpack-dev-server@^2.4.2:
     spdy "^3.4.1"
     strip-ansi "^3.0.0"
     supports-color "^3.1.1"
-    webpack-dev-middleware "^1.9.0"
+    webpack-dev-middleware "^1.10.2"
     yargs "^6.0.0"
 
 webpack-sources@^0.1.0:


### PR DESCRIPTION
… in 2.4.3

Bill ran into this I'm assuming because he used npm and npm ignores the yarn lock file and grabbed the newest version of `webpack-dev-server` for him. `localhost.cru.org` was giving a `Invalid Host header` error.

https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3

https://github.com/webpack/webpack-dev-server/issues/882