### PR TITLE
Cleanup checkout routing and checkout analytics

### DIFF
--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -49,7 +49,8 @@ class CheckoutController{
       }
     });
     this.$rootScope.$on( SignOutEvent, ( event ) => this.signedOut( event ) );
-    this.initStepParam();
+    this.initStepParam(true);
+    this.listenForLocationChange();
     this.analyticsFactory.pageLoaded();
   }
 
@@ -58,11 +59,15 @@ class CheckoutController{
     this.$locationChangeSuccessListener && this.$locationChangeSuccessListener();
   }
 
-  initStepParam(){
-    this.changeStep(this.$location.search().step || 'contact');
-    this.$location.replace();
-    this.$locationChangeSuccessListener = this.$locationChangeSuccessListener || this.$rootScope.$on('$locationChangeSuccess', () => {
-      this.initStepParam();
+  initStepParam(replace){
+    this.changeStep(this.$location.search().step || 'contact', replace);
+  }
+
+  listenForLocationChange() {
+    this.$locationChangeSuccessListener = this.$rootScope.$on('$locationChangeSuccess', () => {
+      this.initStepParam(this.$location.search().step || 'contact');
+      this.analyticsFactory.setEvent('checkout step ' + this.checkoutStep);
+      this.analyticsFactory.track('aa-checkout-step-' + this.checkoutStep);
     });
   }
 
@@ -73,12 +78,11 @@ class CheckoutController{
     }
   }
 
-  changeStep(newStep){
+  changeStep(newStep, replace){
     this.$window.scrollTo(0, 0);
     this.checkoutStep = newStep;
     this.$location.search('step', this.checkoutStep);
-
-    this.analyticsFactory.track('aa-checkout-step-' + this.checkoutStep);
+    replace && this.$location.replace();
   }
 
   loadCart(){


### PR DESCRIPTION
- Prevent analytics events from being called too early or multiple times
- Add setEvent calls for more flexibility for analytics team [EP-2068](https://jira.cru.org/browse/EP-2068)