### PR TITLE
Move loading css into component

### DIFF
--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -151,52 +151,6 @@ hr.horizontal-divider {
   }
 }
 
-.loading {
-  display: inline-block;
-  height: 26px;
-  width: 7px;
-  border-radius: 10%;
-  animation: fade1 1s infinite;
-  transition: background .2s;
-  vertical-align: middle;
-  &.loading2 {
-    animation: fade2 1s infinite;
-    height: 32px;
-  }
-  &.loading3 {
-    animation: fade3 1s infinite;
-    height: 32px;
-  }
-  &.loading4 {
-    animation: fade4 1s infinite;
-    height: 26px;
-  }
-}
-
-@keyframes fade1 {
-  0% {
-    background: #43B3C9;
-  }
-}
-
-@keyframes fade2 {
-  33% {
-    background: #F9B625;
-  }
-}
-
-@keyframes fade3 {
-  66% {
-    background: #DE8123;
-  }
-}
-
-@keyframes fade4 {
-  90% {
-    background: #007398;
-  }
-}
-
 .self-service {
   margin-top: 29px;
   font-size: 125%;

--- a/src/common/components/loading/loading.scss
+++ b/src/common/components/loading/loading.scss
@@ -1,22 +1,72 @@
 loading{
   display: block;
   text-align: center;
+  .loading-bar {
+    display: inline-block;
+    width: 7px;
+    border-radius: 10%;
+    transition: background .2s;
+    vertical-align: middle;
+  }
+  .loading1 {
+    animation: fade1 1s infinite;
+    height: 26px;
+  }
+  .loading2 {
+    animation: fade2 1s infinite;
+    height: 32px;
+  }
+  .loading3 {
+    animation: fade3 1s infinite;
+    height: 32px;
+  }
+  .loading4 {
+    animation: fade4 1s infinite;
+    height: 26px;
+  }
+
+  @keyframes fade1 {
+    0% {
+      background: #43B3C9;
+    }
+  }
+
+  @keyframes fade2 {
+    33% {
+      background: #F9B625;
+    }
+  }
+
+  @keyframes fade3 {
+    66% {
+      background: #DE8123;
+    }
+  }
+
+  @keyframes fade4 {
+    90% {
+      background: #007398;
+    }
+  }
+
   .loading-centered {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    &.loading-overlay {
-      display: flex;
-      align-items: center;
-      justify-content: space-around;
-      width: 100%;
-      height: 100%;
-      background-color: rgba(255, 255, 255, 0.7);
-      z-index: 2;
-    }
   }
-  .loading-wrap{
+
+  .loading-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.7);
+    z-index: 2;
+  }
+
+  .loadingWrap{
     display: inline-block
   }
 }

--- a/src/common/components/loading/loading.tpl.html
+++ b/src/common/components/loading/loading.tpl.html
@@ -1,16 +1,16 @@
 <div ng-class="{
-        'loading-centered loading-overlay' : $ctrl.type === 'overlay',
-        'loading-centered' : $ctrl.type === 'centered'
+        'loading-centered': $ctrl.type === 'centered' || $ctrl.type === 'overlay',
+        'loading-overlay': $ctrl.type === 'overlay'
       }">
   <div>
     <span ng-class="{ 'mr-' : $ctrl.inline === 'true', 'center-block' : $ctrl.inline !== 'true'  }">
       <ng-transclude></ng-transclude>
     </span>
     <span class="loading-wrap">
-      <span class="loading loading1"></span>
-      <span class="loading loading2"></span>
-      <span class="loading loading3"></span>
-      <span class="loading loading4"></span>
+      <span class="loading-bar loading1"></span>
+      <span class="loading-bar loading2"></span>
+      <span class="loading-bar loading3"></span>
+      <span class="loading-bar loading4"></span>
     </span>
   </div>
 </div>


### PR DESCRIPTION
I did this cleanup as I was playing with CSS Modules in Angular 1.X and figured it would be good to pull it out and get it merged regardless of how we do CSS encapsulation.