### PR TITLE
Branded checkout callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,38 @@ Add the following code to your page where appropriate:
 ```html
 <link rel="stylesheet" href="https://give-static.cru.org/branded-checkout.min.css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
-<branded-checkout ng-app="brandedCheckout" code="<designation number>" campaign-code="<campaign code>" amount="<amount>" frequency="<frequency>" day="<day>"></branded-checkout>
+
+<branded-checkout
+    ng-app="brandedCheckout"
+    code="<designation number>"
+    campaign-code="<campaign code>"
+    amount="<amount>"
+    frequency="<frequency>"
+    day="<day>"
+    on-order-completed="$event.$window.onOrderCompleted($event.purchase)">
+</branded-checkout>
+
 <script src="https://give-static.cru.org/app.js"></script>
+<script>
+  window.onOrderCompleted = function (purchaseData) {
+    console.log('Order completed successfully', purchaseData);
+  };
+</script>
 ```
-The `<branded-checkout>` element is where the branded checkout angular app will be loaded. It accepts the following attributes:
+The `<branded-checkout>` element is where the branded checkout Angular app will be loaded. It accepts the following attributes:
+- `ng-app="brandedCheckout"` - tells Angular which module to load - **Required** - you could bootstrap Angular manually or include this `brandedCheckout` module in your own custom Angular module instead if desired
 - `code` - the designation number you would like donors to give to - **Required**
 - `campaign-code` - the campaign code you would like to use - *Optional*
 - `amount` - defaults the gift's amount - *Optional*
 - `frequency` - defaults the gift's frequency - *Optional* - can be one of the following values:
-  - `NA` - single gift - this is the defualt so it doesn't need to be specified
-  - `MON` - monthly recurring gift
-  - `QUARTERLY` - quarterly recurring gift
-  - `ANNUAL` - annually recurring gift
+  - `single` - single gift - this is the default so it doesn't need to be specified
+  - `monthly` - monthly recurring gift
+  - `quarterly` - quarterly recurring gift
+  - `annually` - annually recurring gift
 - `day` - for recuring gifts this defaults the gift's day of the month - *Optional* - can be `1` to `28`
+- `on-order-completed` - an Angular expression that is executed when the order was submitted successfully - *Optional* -  provides 2 variables:
+  - `$event.$window` - Provides access to the browser's global `window` object. This allows you to call a custom callback function like `onOrderCompleted` in the example.
+  - `$event.purchase` - contains the order's details that are loaded for the thank you page
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "angular-upload": "^1.0.13",
     "babel-runtime": "^6.23.0",
     "bootstrap-sass": "3.3.1",
+    "change-case-object": "^2.0.0",
     "cru-payments": "^1.2.2",
     "crypto-js": "^3.1.9-1",
     "jwt-decode": "^2.2.0",

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -1,4 +1,6 @@
 import angular from 'angular';
+import pick from 'lodash/pick';
+import changeCaseObject from 'change-case-object';
 
 import commonModule from 'common/common.module';
 import step1 from './step-1/branded-checkout-step-1.component';
@@ -11,10 +13,10 @@ import template from './branded-checkout.tpl.html';
 
 let componentName = 'brandedCheckout';
 
-class BrandedCheckoutController{
+class BrandedCheckoutController {
 
   /* @ngInject */
-  constructor($window){
+  constructor($window) {
     this.$window = $window;
   }
 
@@ -22,8 +24,8 @@ class BrandedCheckoutController{
     this.checkoutStep = 'giftContactPayment';
   }
 
-  next(){
-    switch(this.checkoutStep){
+  next() {
+    switch (this.checkoutStep) {
       case 'giftContactPayment':
         this.checkoutStep = 'review';
         break;
@@ -34,13 +36,17 @@ class BrandedCheckoutController{
     this.$window.scrollTo(0, 0);
   }
 
-  previous(){
-    switch(this.checkoutStep){
+  previous() {
+    switch (this.checkoutStep) {
       case 'review':
         this.checkoutStep = 'giftContactPayment';
         break;
     }
     this.$window.scrollTo(0, 0);
+  }
+
+  onThankYouPurchaseLoaded(purchase) {
+    this.onOrderCompleted({$event: {$window: this.$window, purchase: changeCaseObject.camelCase(pick(purchase, ['donorDetails', 'lineItems']))}});
   }
 }
 
@@ -59,6 +65,7 @@ export default angular
       campaignCode: '@',
       amount: '@',
       frequency: '@',
-      day: '@'
+      day: '@',
+      onOrderCompleted: '&'
     }
   });

--- a/src/app/branded/branded-checkout.spec.js
+++ b/src/app/branded/branded-checkout.spec.js
@@ -10,6 +10,8 @@ describe('branded checkout', () => {
   beforeEach(inject($componentController => {
     $ctrl = $componentController(module.name, {
       $window: { scrollTo: jasmine.createSpy('scrollTo') }
+    }, {
+      onOrderCompleted: jasmine.createSpy('onOrderCompleted')
     });
   }));
 
@@ -46,6 +48,25 @@ describe('branded checkout', () => {
       $ctrl.checkoutStep = 'review';
       $ctrl.previous();
       expect($ctrl.checkoutStep).toEqual('giftContactPayment');
+    });
+  });
+
+  describe('onThankYouPurchaseLoaded', () => {
+    it('should pass the purchase info to the onOrderCompleted binding', () => {
+      $ctrl.onThankYouPurchaseLoaded({
+        donorDetails: {
+          'donor-type': 'Household'
+        },
+        paymentMeans: {},
+        lineItems: {},
+        rawData: {}
+      });
+      expect($ctrl.onOrderCompleted).toHaveBeenCalledWith({$event: {$window: $ctrl.$window, purchase: {
+        donorDetails: {
+          donorType: 'Household'
+        },
+        lineItems: {}
+      }}});
     });
   });
 });

--- a/src/app/branded/branded-checkout.tpl.html
+++ b/src/app/branded/branded-checkout.tpl.html
@@ -17,7 +17,8 @@
           previous="$ctrl.previous()">
         </branded-checkout-step-2>
         <thank-you-summary
-          ng-if="$ctrl.checkoutStep === 'thankYou'">
+          ng-if="$ctrl.checkoutStep === 'thankYou'"
+          on-purchase-loaded="$ctrl.onThankYouPurchaseLoaded($event.purchase)">
         </thank-you-summary>
       </div>
     </div>

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -35,7 +35,17 @@ class BrandedCheckoutStep1Controller{
     this.itemConfig = {};
     this.itemConfig['campaign-code'] = this.campaignCode;
     this.itemConfig.amount = this.amount;
-    this.defaultFrequency = this.frequency;
+    switch(this.frequency){
+      case 'monthly':
+        this.defaultFrequency = 'MON';
+        break;
+      case 'quarterly':
+        this.defaultFrequency = 'QUARTERLY';
+        break;
+      case 'annually':
+        this.defaultFrequency = 'ANNUAL';
+        break;
+    }
     this.itemConfig['recurring-day-of-month'] = this.day;
   }
 

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -32,7 +32,6 @@ describe('branded checkout step 1', () => {
     it('should initialize item config', () => {
       $ctrl.campaignCode = '1234';
       $ctrl.amount = '75';
-      $ctrl.frequency = 'MON';
       $ctrl.day = '9';
       $ctrl.initItemConfig();
       expect($ctrl.itemConfig).toEqual({
@@ -40,7 +39,22 @@ describe('branded checkout step 1', () => {
         amount: '75',
         'recurring-day-of-month': '9'
       });
+      expect($ctrl.defaultFrequency).toBeUndefined();
+    });
+    it('should initialize monthly gifts', () => {
+      $ctrl.frequency = 'monthly';
+      $ctrl.initItemConfig();
       expect($ctrl.defaultFrequency).toEqual('MON');
+    });
+    it('should initialize quarterly gifts', () => {
+      $ctrl.frequency = 'quarterly';
+      $ctrl.initItemConfig();
+      expect($ctrl.defaultFrequency).toEqual('QUARTERLY');
+    });
+    it('should initialize annual gifts', () => {
+      $ctrl.frequency = 'annually';
+      $ctrl.initItemConfig();
+      expect($ctrl.defaultFrequency).toEqual('ANNUAL');
     });
   });
 

--- a/src/app/thankYou/summary/thankYouSummary.component.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.js
@@ -74,8 +74,8 @@ class ThankYouSummaryController{
           );
           delete this.loadingError;
           this.loading = false;
-          this.onDonorDetailsLoaded({
-            $event: { donorDetails: this.purchase.donorDetails }
+          this.onPurchaseLoaded({
+            $event: { purchase: this.purchase }
           });
 
           this.analyticsFactory.pageLoaded();
@@ -112,6 +112,6 @@ export default angular
     controller: ThankYouSummaryController,
     templateUrl: template,
     bindings: {
-      onDonorDetailsLoaded: '&'
+      onPurchaseLoaded: '&'
     }
   });

--- a/src/app/thankYou/summary/thankYouSummary.component.spec.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.spec.js
@@ -60,7 +60,7 @@ describe('thank you summary', () => {
         $window: {location: '/thank-you.html'}
       },
       {
-        onDonorDetailsLoaded: jasmine.createSpy('onDonorDetailsLoaded')
+        onPurchaseLoaded: jasmine.createSpy('onPurchaseLoaded')
       });
   }));
 
@@ -117,8 +117,8 @@ describe('thank you summary', () => {
       ]);
       expect(self.controller.loading).toEqual(false);
       expect(self.controller.loadingError).toBeUndefined();
-      expect(self.controller.onDonorDetailsLoaded).toHaveBeenCalledWith({
-        $event: { donorDetails: self.mockPurchase.donorDetails }
+      expect(self.controller.onPurchaseLoaded).toHaveBeenCalledWith({
+        $event: { purchase: self.mockPurchase }
       });
     });
     it('should not request purchase data if lastPurchaseLink is not defined', () => {

--- a/src/app/thankYou/thankYou.tpl.html
+++ b/src/app/thankYou/thankYou.tpl.html
@@ -2,7 +2,7 @@
   <div class="container container-edge-small container-edge-extrasmall">
     <div class="row">
       <div class="col-md-8">
-        <thank-you-summary on-donor-details-loaded="$ctrl.donorDetails = $event.donorDetails"></thank-you-summary>
+        <thank-you-summary on-purchase-loaded="$ctrl.donorDetails = $event.purchase.donorDetails"></thank-you-summary>
       </div>
 
       <div class="col-md-4">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,13 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camel-case@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-1.2.2.tgz#1aca7c4d195359a2ce9955793433c6e5542511f2"
+  dependencies:
+    sentence-case "^1.1.1"
+    upper-case "^1.1.1"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1106,6 +1113,14 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+change-case-object@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/change-case-object/-/change-case-object-2.0.0.tgz#a87d6e4540798a0049deabc5da8a71ffdbf065da"
+  dependencies:
+    camel-case "^1.2.0"
+    param-case "^1.1.1"
+    snake-case "^1.1.1"
 
 chokidar@^1.4.1, chokidar@^1.4.3, chokidar@^1.6.0:
   version "1.6.1"
@@ -4005,6 +4020,12 @@ param-case@2.1.x:
   dependencies:
     no-case "^2.2.0"
 
+param-case@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-1.1.2.tgz#dcb091a43c259b9228f1c341e7b6a44ea0bf9743"
+  dependencies:
+    sentence-case "^1.1.2"
+
 parse-asn1@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
@@ -4898,6 +4919,12 @@ send@0.15.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+sentence-case@^1.1.1, sentence-case@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-1.1.3.tgz#8034aafc2145772d3abe1509aa42c9e1042dc139"
+  dependencies:
+    lower-case "^1.1.1"
+
 serve-index@^1.7.2:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.8.0.tgz#7c5d96c13fb131101f93c1c5774f8516a1e78d3b"
@@ -4987,6 +5014,12 @@ slick-carousel@1.5.9:
   resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.5.9.tgz#2bdcae38e7a58e72430e97055bfacc167f3364d3"
   dependencies:
     jquery ">=1.7.2"
+
+snake-case@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-1.1.2.tgz#0c2f25e305158d9a18d3d977066187fef8a5a66a"
+  dependencies:
+    sentence-case "^1.1.2"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
If you can think of any cleaner ways to call a user defined function from an angular output binding, let me know. The best I got was `on-order-completed="$event.$window.onOrderCompleted($event.purchase)"`.

The legacy branded checkout supported this and Josh said it was probably still desired.