### PR TITLE
Convert suggestedAmounts ordering to a number.

### DIFF
--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -186,7 +186,7 @@ class DesignationsService {
               if ( toFinite( k ) > 0 ) suggestedAmounts.push( {
                 amount: toFinite( v.amount ),
                 label: v.description,
-                order: k
+                order: toFinite( k )
               } );
             } );
           }

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -134,8 +134,8 @@ describe('designation service', () => {
       self.designationsService.suggestedAmounts('0123456', itemConfig)
         .subscribe(suggestedAmounts => {
           expect( suggestedAmounts ).toEqual( [
-            {amount: 25, label: "for 10 Bibles", order: "1"},
-            {amount: 100, label: "for 40 Bibles", order: "2"}
+            {amount: 25, label: "for 10 Bibles", order: 1},
+            {amount: 100, label: "for 40 Bibles", order: 2}
           ] );
           expect( itemConfig['default-campaign-code'] ).toEqual( '867EM1' );
           expect( itemConfig['jcr-title'] ).toEqual( 'PowerPacksTM for Inner City Children' );


### PR DESCRIPTION
This fixes helpscout issue where suggestedAmounts with more than 10 amounts were getting sorted by string instead of numerically.
( ex: integer - 1, 2, 3, 7, 10, 11, 12, 20 ... vs string - 1, 10, 11, 12, 2, 20, 3, 7 ...)