### PR TITLE
Remove cents if not present in suggested amounts.

### DIFF
--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -33,9 +33,10 @@ const componentName = 'productConfigForm';
 class ProductConfigFormController {
 
   /* @ngInject */
-  constructor( $scope, $log, designationsService, cartService, commonService, analyticsFactory ) {
+  constructor( $scope, $log, $filter, designationsService, cartService, commonService, analyticsFactory ) {
     this.$scope = $scope;
     this.$log = $log;
+    this.$filter = $filter;
     this.designationsService = designationsService;
     this.cartService = cartService;
     this.commonService = commonService;
@@ -270,6 +271,10 @@ class ProductConfigFormController {
       value += ` - ${this.productData.displayName}`;
     }
     return value;
+  }
+
+  suggestedAmount(amount) {
+    return this.$filter('currency')(amount, '$', `${amount}`.indexOf('.') > -1 ? 2 : 0);
   }
 }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -439,4 +439,14 @@ describe( 'product config form component', function () {
       expect($ctrl.displayId()).toEqual('#0123456 - Title');
     });
   });
+
+  describe('suggestedAmount( amount )', () => {
+    it('should format suggestedAmounts correctly.', () => {
+      expect($ctrl.suggestedAmount(123.45)).toEqual('$123.45');
+      expect($ctrl.suggestedAmount(12345.67)).toEqual('$12,345.67');
+      expect($ctrl.suggestedAmount(123.4)).toEqual('$123.40');
+      expect($ctrl.suggestedAmount(123)).toEqual('$123');
+      expect($ctrl.suggestedAmount(1234)).toEqual('$1,234');
+    });
+  });
 } );

--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -49,7 +49,7 @@
                      type="radio"
                      ng-click="$ctrl.changeAmount(suggested.amount)"
                      ng-checked="!$ctrl.customInputActive && $ctrl.itemConfig.amount === suggested.amount">
-              {{suggested.amount | currency:'$'}} {{suggested.label}}
+              {{$ctrl.suggestedAmount(suggested.amount)}} {{suggested.label}}
             </label>
           </div>
           <div class="radio radio-custom-amount form-inline" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">


### PR DESCRIPTION
Previous commit (#669) didn't fix the issue. Angular's currency filter defaults to the locale decimal places when not provided one.

This uses a controller method to see if a decimal is present in the amount and switches the decimal places sent to the currency filter.