### PR TITLE
Only restore old version of Angular if exists

### DIFF
--- a/src/common/components/nav/nav.bundle.js
+++ b/src/common/components/nav/nav.bundle.js
@@ -12,7 +12,9 @@
   //Manually bootstrap cruNav
   angular.element(document).ready(function () {
     angular.bootstrap(document.getElementsByTagName("cru-nav")[0], [nav.name]);
-    // restore the old angular version
-    window.angular = existingWindowDotAngular;
+    // restore the old angular version if exists
+    if(existingWindowDotAngular){
+      window.angular = existingWindowDotAngular;
+    }
   });
 }


### PR DESCRIPTION
angular is still needed on the page after the app loads for functions like angular.isDefined etc.