### PR TITLE
double nav cart fixes

### DIFF
--- a/src/common/components/nav/desktopNav.tpl.html
+++ b/src/common/components/nav/desktopNav.tpl.html
@@ -71,12 +71,12 @@
         </div>
       </div>
 
-      <div class="cart">
+      <div class="cart" ng-if="!$ctrl.subNavLocked">
         <div uib-dropdown on-toggle="$ctrl.cartOpened()" is-open="$ctrl.cartOpen" auto-close="outsideClick">
           <a uib-dropdown-toggle></a>
           <div class="pull-right" uib-dropdown-menu>
             <span class="triangle"></span>
-            <nav-cart></nav-cart>
+            <nav-cart cart-data="$ctrl.cartData"></nav-cart>
           </div>
         </div>
       </div>

--- a/src/common/components/nav/mobileNav.tpl.html
+++ b/src/common/components/nav/mobileNav.tpl.html
@@ -86,7 +86,7 @@
         </div>
       </div>
       <div role="tabpanel" class="tab-pane active" ng-show="$ctrl.mobileTab === 'cart'">
-        <nav-cart mobile="true"></nav-cart>
+        <nav-cart mobile="true" cart-data="$ctrl.cartData"></nav-cart>
       </div>
       <div role="tabpanel" class="tab-pane active" ng-if="$ctrl.mobileTab === 'more'">
         <ul id="mob-more">

--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -23,17 +23,21 @@ import mobileTemplate from './mobileNav.tpl.html';
 import desktopTemplate from './desktopNav.tpl.html';
 import signOutTemplate from './signOut.modal.tpl.html';
 
+export let subNavLockEvent = 'subNavLock';
+export let subNavUnlockEvent = 'subNavUnlock';
+
 let componentName = 'cruNav';
 
 class NavController{
 
   /* @ngInject */
-  constructor($log, $rootScope, $http, $document, $window, $uibModal, $timeout, envService, sessionService, sessionModalService){
+  constructor($log, $rootScope, $scope, $http, $document, $window, $uibModal, $timeout, envService, sessionService, sessionModalService){
     this.$log = $log;
     this.$http = $http;
     this.$document = $document;
     this.$uibModal = $uibModal;
     this.$window = $window;
+    this.$scope = $scope;
     this.$rootScope = $rootScope;
     this.$timeout = $timeout;
 
@@ -85,6 +89,8 @@ class NavController{
     this.subscription = this.sessionService.sessionSubject.subscribe( () => this.sessionChanged() );
 
     this.$rootScope.$on(giftAddedEvent, () => this.giftAddedToCart() );
+    this.$rootScope.$on(subNavLockEvent, () => this.$scope.$apply(() => this.subNavLocked = true ));
+    this.$rootScope.$on(subNavUnlockEvent, () => this.$scope.$apply(() => this.subNavLocked = false ));
     // Register signedOut event on child scope
     // this basically sets the listener at a lower priority, allowing $rootScope listeners first chance to respond
     this.$rootScope.$new(true, this.$rootScope).$on(SignOutEvent, (event) => this.signedOut(event) );
@@ -122,12 +128,7 @@ class NavController{
       this.mobileNavOpen = true;
       this.mobileTab = 'cart';
     }else{
-      //only open visible cart
-      if(angular.element(this.$document[0].getElementById('sub-navigation')).hasClass('out')){
-        this.cartOpenSubNav = true;
-      }else{
-        this.cartOpen = true;
-      }
+      this.cartOpen = true;
     }
   }
 

--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -63,7 +63,7 @@ class NavController{
     this.getNav().subscribe((structure) => {
         this.menuStructure = structure;
 
-        if(this.$window.location.hostname && includes(this.$window.location.hostname, 'give')){
+        if(this.$window.location.hostname && includes(this.$window.location.hostname, 'cru.org')){
           this.subMenuStructure = [{
             title: 'Give',
             path: '/',
@@ -122,8 +122,12 @@ class NavController{
       this.mobileNavOpen = true;
       this.mobileTab = 'cart';
     }else{
-      this.$window.scrollTo(0, 0);
-      this.cartOpen = true;
+      //only open visible cart
+      if(angular.element(this.$document[0].getElementById('sub-navigation')).hasClass('out')){
+        this.cartOpenSubNav = true;
+      }else{
+        this.cartOpen = true;
+      }
     }
   }
 

--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -63,7 +63,7 @@ class NavController{
     this.getNav().subscribe((structure) => {
         this.menuStructure = structure;
 
-        if(this.$window.location.hostname && includes(this.$window.location.hostname, 'cru.org')){
+        if(this.$window.location.hostname && includes(this.$window.location.hostname, 'give')){
           this.subMenuStructure = [{
             title: 'Give',
             path: '/',

--- a/src/common/components/nav/nav.component.spec.js
+++ b/src/common/components/nav/nav.component.spec.js
@@ -3,7 +3,7 @@ import 'angular-mocks';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
-import module from './nav.component';
+import module, {subNavLockEvent, subNavUnlockEvent} from './nav.component';
 
 import navStructure from 'common/components/nav/fixtures/nav.fixture';
 
@@ -153,6 +153,17 @@ describe( 'nav', function () {
       $ctrl.$onInit();
       expect($ctrl.$log.warn.logs[0]).toEqual(['Aborted or timed out request while loading the nav.', { status: -1 }]);
     });
+
+    it( 'should send event to set subNavLack var', () => {
+      $ctrl.$onInit();
+      expect( $ctrl.$rootScope.$on ).toHaveBeenCalledWith( subNavLockEvent, jasmine.any( Function ) );
+      $ctrl.$rootScope.$on.calls.argsFor( 1 )[1]();
+      expect( $ctrl.subNavLocked ).toEqual( true );
+
+      expect( $ctrl.$rootScope.$on ).toHaveBeenCalledWith( subNavUnlockEvent, jasmine.any( Function ) );
+      $ctrl.$rootScope.$on.calls.argsFor( 2 )[1]();
+      expect( $ctrl.subNavLocked ).toEqual( false );
+    } );
   } );
 
   describe( 'giftAddedToCart()', () => {

--- a/src/common/components/nav/nav.component.spec.js
+++ b/src/common/components/nav/nav.component.spec.js
@@ -162,9 +162,8 @@ describe( 'nav', function () {
       $ctrl.mobileNavOpen = false;
     } );
 
-    it( 'scrolls to top and opens nav cart when giftAdded', () => {
+    it( 'opens nav cart when giftAdded', () => {
       $ctrl.giftAddedToCart();
-      expect( $ctrl.$window.scrollTo ).toHaveBeenCalledWith( 0, 0 );
       expect( $ctrl.cartOpen ).toEqual( true );
 
       $ctrl.menuType = 'mobile';

--- a/src/common/components/nav/navCart/navCart.component.js
+++ b/src/common/components/nav/navCart/navCart.component.js
@@ -31,6 +31,10 @@ class NavCartController{
     this.$rootScope.$on(giftAddedEvent, () => this.loadCart(true));
     this.$rootScope.$on(cartUpdatedEvent, () => this.loadCart());
     this.sessionService.sessionSubject.subscribe( () => !this.firstLoad && this.loadCart() ); // Ignore session events until another event loads cart
+
+    if(this.cartData){
+      this.hasItems = !isEmpty(this.cartData.items);
+    }
   }
 
   loadCart(setAnalyticsEvent) {
@@ -70,6 +74,7 @@ export default angular
     controller: NavCartController,
     templateUrl: template,
     bindings: {
-      mobile: '@'
+      mobile: '@',
+      cartData: '='
     }
   });

--- a/src/common/components/nav/subNav.directive.js
+++ b/src/common/components/nav/subNav.directive.js
@@ -1,11 +1,12 @@
 import angular from 'angular';
 
+import {subNavLockEvent, subNavUnlockEvent} from 'common/components/nav/nav.component';
 import template from './subNav.tpl.html';
 
 let directiveName = 'cruSubNav';
 
 /* @ngInject */
-function cruSubNav($window) {
+function cruSubNav($rootScope, $window) {
   let offsetTop;
   return {
     restrict: 'E',
@@ -14,6 +15,7 @@ function cruSubNav($window) {
 
       let subNavigation = element.children()[0];
       let parent = element.parent();
+      let lastSubNavEvent;
 
       let desktopNavigation = parent.children()[0] || {style: {}};
       offsetTop = !offsetTop ? subNavigation.offsetTop : offsetTop;
@@ -22,8 +24,15 @@ function cruSubNav($window) {
         desktopNavigation.style['margin-bottom'] =
           ($window.scrollY > offsetTop ?
             subNavigation.clientHeight : 0) + 'px';
-      });
 
+        if($window.scrollY > offsetTop && lastSubNavEvent !== subNavLockEvent){
+          $rootScope.$emit(subNavLockEvent);
+          lastSubNavEvent = subNavLockEvent;
+        }else if($window.scrollY <= offsetTop && lastSubNavEvent !== subNavUnlockEvent){
+          $rootScope.$emit(subNavUnlockEvent);
+          lastSubNavEvent = subNavUnlockEvent;
+        }
+      });
     }
   };
 }

--- a/src/common/components/nav/subNav.directive.js
+++ b/src/common/components/nav/subNav.directive.js
@@ -19,7 +19,7 @@ function cruSubNav($rootScope, $window) {
 
       let desktopNavigation = parent.children()[0] || {style: {}};
       offsetTop = !offsetTop ? subNavigation.offsetTop : offsetTop;
-      angular.element($window).bind('scroll', () => {
+      $window.addEventListener('scroll', () => {
         subNavigation.className = $window.scrollY > offsetTop ? 'out' : '';
         desktopNavigation.style['margin-bottom'] =
           ($window.scrollY > offsetTop ?

--- a/src/common/components/nav/subNav.directive.spec.js
+++ b/src/common/components/nav/subNav.directive.spec.js
@@ -12,8 +12,6 @@ describe( 'cruSubNav', function () {
     scope = _$rootScope_.$new();
     subNav = _$compile_('<cru-sub-nav></cru-sub-nav>')(scope);
     scope.$digest();
-
-    spyOn( scope, '$emit' );
   } ) );
 
   it( 'is class set', () => {
@@ -25,9 +23,12 @@ describe( 'cruSubNav', function () {
   } );
 
   it( 'should emit event when sub navigation is locked', () => {
-    angular.element($window).triggerHandler('scroll');
-    scope.$digest();
+    spyOn( scope, '$emit' );
 
+    $window.scrollTo(0, 1);
     expect(scope.$emit).toHaveBeenCalledWith(subNavUnlockEvent);
+
+    $window.scrollTo(0, 1400);
+    expect(scope.$emit).toHaveBeenCalledWith(subNavLockEvent);
   } );
 } );

--- a/src/common/components/nav/subNav.directive.spec.js
+++ b/src/common/components/nav/subNav.directive.spec.js
@@ -5,30 +5,34 @@ import module from './subNav.directive';
 
 describe( 'cruSubNav', function () {
   beforeEach( angular.mock.module( module.name ) );
-  let $window, scope, subNav;
+  let $window, $rootScope, subNav;
 
   beforeEach( inject( function ( _$compile_, _$rootScope_, _$window_ ) {
     $window = _$window_;
-    scope = _$rootScope_.$new();
-    subNav = _$compile_('<cru-sub-nav></cru-sub-nav>')(scope);
-    scope.$digest();
+    $rootScope = _$rootScope_;
+    subNav = _$compile_('<cru-sub-nav></cru-sub-nav>')($rootScope.$new());
+    spyOn( $window, 'addEventListener' );
+    spyOn( $rootScope, '$emit' );
+    $rootScope.$digest();
   } ) );
 
   it( 'is class set', () => {
     angular.element($window).triggerHandler('scroll');
-    scope.$digest();
+    $rootScope.$digest();
 
     let subNavigation = subNav.children()[0];
     expect( subNavigation.className ).toEqual( '' );
   } );
 
   it( 'should emit event when sub navigation is locked', () => {
-    spyOn( scope, '$emit' );
+    expect($window.addEventListener).toHaveBeenCalledWith('scroll', jasmine.any(Function));
 
-    $window.scrollTo(0, 1);
-    expect(scope.$emit).toHaveBeenCalledWith(subNavUnlockEvent);
+    $window.scrollY = 0;
+    $window.addEventListener.calls.argsFor(0)[1]();
+    expect($rootScope.$emit).toHaveBeenCalledWith(subNavUnlockEvent);
 
-    $window.scrollTo(0, 1400);
-    expect(scope.$emit).toHaveBeenCalledWith(subNavLockEvent);
+    $window.scrollY = 1400;
+    $window.addEventListener.calls.argsFor(0)[1]();
+    expect($rootScope.$emit).toHaveBeenCalledWith(subNavLockEvent);
   } );
 } );

--- a/src/common/components/nav/subNav.directive.spec.js
+++ b/src/common/components/nav/subNav.directive.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import {subNavLockEvent, subNavUnlockEvent} from 'common/components/nav/nav.component';
 import module from './subNav.directive';
 
 describe( 'cruSubNav', function () {
@@ -11,13 +12,22 @@ describe( 'cruSubNav', function () {
     scope = _$rootScope_.$new();
     subNav = _$compile_('<cru-sub-nav></cru-sub-nav>')(scope);
     scope.$digest();
+
+    spyOn( scope, '$emit' );
   } ) );
 
   it( 'is class set', () => {
     angular.element($window).triggerHandler('scroll');
+    scope.$digest();
 
     let subNavigation = subNav.children()[0];
-    scope.$digest();
     expect( subNavigation.className ).toEqual( '' );
+  } );
+
+  it( 'should emit event when sub navigation is locked', () => {
+    angular.element($window).triggerHandler('scroll');
+    scope.$digest();
+
+    expect(scope.$emit).toHaveBeenCalledWith(subNavUnlockEvent);
   } );
 } );

--- a/src/common/components/nav/subNav.tpl.html
+++ b/src/common/components/nav/subNav.tpl.html
@@ -30,7 +30,7 @@
     </ul>
 
     <div class="cart">
-      <div uib-dropdown on-toggle="$ctrl.cartOpened()" is-open="$ctrl.cartOpen" auto-close="outsideClick">
+      <div uib-dropdown on-toggle="$ctrl.cartOpened()" is-open="$ctrl.cartOpenSubNav" auto-close="outsideClick">
         <a uib-dropdown-toggle></a>
         <div class="pull-right" uib-dropdown-menu>
           <span class="triangle"></span>

--- a/src/common/components/nav/subNav.tpl.html
+++ b/src/common/components/nav/subNav.tpl.html
@@ -29,12 +29,12 @@
       </li>
     </ul>
 
-    <div class="cart">
-      <div uib-dropdown on-toggle="$ctrl.cartOpened()" is-open="$ctrl.cartOpenSubNav" auto-close="outsideClick">
+    <div class="cart" ng-if="$ctrl.subNavLocked">
+      <div uib-dropdown on-toggle="$ctrl.cartOpened()" is-open="$ctrl.cartOpen" auto-close="outsideClick">
         <a uib-dropdown-toggle></a>
         <div class="pull-right" uib-dropdown-menu>
           <span class="triangle"></span>
-          <nav-cart></nav-cart>
+          <nav-cart cart-data="$ctrl.cartData"></nav-cart>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Looking for some input on this.  I discovered the auto close on "outsideClick" does not work if both of the nav cart dropdowns are using the same `is-open` variable.  Giving them each a different variable solved that issue.  But now only the correct (visible) dropdown should open when a new gift is added.

What I have works, but am looking for some input.

Another idea I had was to emit an event when the sub navigation is locked (via subNav.directive) and use that to remove the cart div from the DOM when it's not visible.  I believe in that case I could keep using the same variable for `is-open` on both.