### PR TITLE
Add TSYS env attribute to branded checkout to change the manifest url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,14 @@ This currently includes all cru.org styling from cru.scss.
 
 #### Branded checkout basic example
 
-Add the following code to your page where appropriate. You must change the value of the `code` and `tsys-env` attributes:
-- `code` must be changed to the designation number you want users to give to.
-- `tsys-env` must be changed to match your environment. It is provided by DPS when adding your domain to the TSYS whitelist.
+Add the following code to your page where appropriate. You must change the value of `designation-number` to the designation number you want users to give to.
 ```html
 <link rel="stylesheet" href="https://give-static.cru.org/branded-checkout.min.css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
 
 <branded-checkout
     ng-app="brandedCheckout"
-    code="0763355"
-    tsys-env="cru">
+    designation-number="0763355">
 </branded-checkout>
 
 <script src="https://give-static.cru.org/branded-checkout.js"></script>
@@ -55,13 +52,13 @@ Add the following code to your page where appropriate:
 
 <branded-checkout
     ng-app="brandedCheckout"
-    code="<designation number>"
-    tsys-env="<tsys-env>"
+    designation-number="<designation number>"
     campaign-code="<campaign code>"
     amount="<amount>"
     frequency="<frequency>"
     day="<day>"
     donor-details="<donor details object>"
+    tsys-device="<tsys-device>"
     on-order-completed="$event.$window.onOrderCompleted($event.purchase)">
 </branded-checkout>
 
@@ -77,8 +74,7 @@ Add the following code to your page where appropriate:
 
 The `<branded-checkout>` element is where the branded checkout Angular app will be loaded. It is configured by providing HTML attributes that will be loaded by Angular. Attributes with values containing angle brackets (such as `<designation number>`) are placeholders and should be replaced with real values or, if not needed, the whole attribute should be omitted. The `<branded-checkout>` element accepts the following attributes:
 - `ng-app="brandedCheckout"` - tells Angular which module to load - **Required** - you could bootstrap Angular manually or include this `brandedCheckout` module in your own custom Angular module instead if desired
-- `code` - the designation number you would like donors to give to - **Required**
-- `tsys-env` - the environment name for processing credit cards with TSYS - **Required** - Provided by DPS when adding your domain to the TSYS whitelist
+- `designation-number` - the designation number you would like donors to give to - **Required**
 - `campaign-code` - the campaign code you would like to use - *Optional*
 - `amount` - defaults the gift's amount - *Optional*
 - `frequency` - defaults the gift's frequency - *Optional* - can be one of the following values:
@@ -124,6 +120,7 @@ The `<branded-checkout>` element is where the branded checkout Angular app will 
         email: 'email@example.com'
     }
     ```
+- `tsys-device` - the device name for processing credit cards with TSYS - *Optional* - May be provided by DPS when adding your domain to the TSYS whitelist if you are using a different TSYS Merchant ID than Cru's main Merchant ID
 - `on-order-completed` - an Angular expression that is executed when the order was submitted successfully - *Optional* -  provides 2 variables:
   - `$event.$window` - Provides access to the browser's global `window` object. This allows you to call a custom callback function like `onOrderCompleted` in the example.
   - `$event.purchase` - contains the order's details that are loaded for the thank you page

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Add the following code to your page where appropriate:
 
 <branded-checkout
     ng-app="brandedCheckout"
-    code="0763355">
+    code="0763355"
+    tsys-env="default">
 </branded-checkout>
 
 <script src="https://give-static.cru.org/branded-checkout.js"></script>
@@ -53,6 +54,7 @@ Add the following code to your page where appropriate:
 <branded-checkout
     ng-app="brandedCheckout"
     code="<designation number>"
+    tsys-env="<tsys-env>"
     campaign-code="<campaign code>"
     amount="<amount>"
     frequency="<frequency>"
@@ -74,6 +76,7 @@ Add the following code to your page where appropriate:
 The `<branded-checkout>` element is where the branded checkout Angular app will be loaded. It is configured by providing HTML attributes that will be loaded by Angular. Attributes with values containing angle brackets (such as `<designation number>`) are placeholders and should be replaced with real values or, if not needed, the whole attribute should be omitted. The `<branded-checkout>` element accepts the following attributes:
 - `ng-app="brandedCheckout"` - tells Angular which module to load - **Required** - you could bootstrap Angular manually or include this `brandedCheckout` module in your own custom Angular module instead if desired
 - `code` - the designation number you would like donors to give to - **Required**
+- `tsys-env` - the environment name for processing credit cards with TSYS - **Required** - Provided by DPS when adding your domain to the TSYS whitelist
 - `campaign-code` - the campaign code you would like to use - *Optional*
 - `amount` - defaults the gift's amount - *Optional*
 - `frequency` - defaults the gift's frequency - *Optional* - can be one of the following values:
@@ -81,7 +84,7 @@ The `<branded-checkout>` element is where the branded checkout Angular app will 
   - `monthly` - monthly recurring gift
   - `quarterly` - quarterly recurring gift
   - `annually` - annually recurring gift
-- `day` - for recuring gifts this defaults the gift's day of the month - *Optional* - can be `1` to `28`
+- `day` - for recurring gifts this defaults the gift's day of the month - *Optional* - can be `1` to `28`
 - `donor-details` - set default values for donor's name and contact info - *Optional* - can be provided as an inline string JSON string or as an Angular expression referencing a variable from an outside Angular module - should be in this format:
     ```javascript
     {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ This currently includes all cru.org styling from cru.scss.
 
 #### Branded checkout basic example
 
-Add the following code to your page where appropriate:
+Add the following code to your page where appropriate. You must change the value of the `code` and `tsys-env` attributes:
+- `code` must be changed to the designation number you want users to give to.
+- `tsys-env` must be changed to match your environment. It is provided by DPS when adding your domain to the TSYS whitelist.
 ```html
 <link rel="stylesheet" href="https://give-static.cru.org/branded-checkout.min.css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
@@ -38,7 +40,7 @@ Add the following code to your page where appropriate:
 <branded-checkout
     ng-app="brandedCheckout"
     code="0763355"
-    tsys-env="default">
+    tsys-env="cru">
 </branded-checkout>
 
 <script src="https://give-static.cru.org/branded-checkout.js"></script>

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -17,12 +17,14 @@ let componentName = 'brandedCheckout';
 class BrandedCheckoutController {
 
   /* @ngInject */
-  constructor($window, analyticsFactory) {
+  constructor($window, analyticsFactory, tsysService) {
     this.$window = $window;
     this.analyticsFactory = analyticsFactory;
+    this.tsysService = tsysService;
   }
 
   $onInit() {
+    this.tsysService.setEnvironment(this.tsysEnv);
     this.checkoutStep = 'giftContactPayment';
     this.formatDonorDetails();
     this.analyticsFactory.pageLoaded(true);
@@ -85,6 +87,7 @@ export default angular
     templateUrl: template,
     bindings: {
       code: '@',
+      tsysEnv: '@',
       campaignCode: '@',
       amount: '@',
       frequency: '@',

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -24,7 +24,8 @@ class BrandedCheckoutController {
   }
 
   $onInit() {
-    this.tsysService.setEnvironment(this.tsysEnv);
+    this.code = this.designationNumber;
+    this.tsysService.setDevice(this.tsysDevice);
     this.checkoutStep = 'giftContactPayment';
     this.formatDonorDetails();
     this.analyticsFactory.pageLoaded(true);
@@ -86,8 +87,8 @@ export default angular
     controller: BrandedCheckoutController,
     templateUrl: template,
     bindings: {
-      code: '@',
-      tsysEnv: '@',
+      designationNumber: '@',
+      tsysDevice: '@',
       campaignCode: '@',
       amount: '@',
       frequency: '@',

--- a/src/app/branded/branded-checkout.spec.js
+++ b/src/app/branded/branded-checkout.spec.js
@@ -9,9 +9,11 @@ describe('branded checkout', () => {
 
   beforeEach(inject($componentController => {
     $ctrl = $componentController(module.name, {
-      $window: { scrollTo: jasmine.createSpy('scrollTo') }
+      $window: jasmine.createSpyObj('$window', ['scrollTo']),
+      tsysService: jasmine.createSpyObj('tsysService', ['setEnvironment'])
     }, {
-      onOrderCompleted: jasmine.createSpy('onOrderCompleted')
+      onOrderCompleted: jasmine.createSpy('onOrderCompleted'),
+      tsysEnv: 'test-env'
     });
   }));
 
@@ -21,6 +23,7 @@ describe('branded checkout', () => {
       $ctrl.$onInit();
       expect($ctrl.checkoutStep).toEqual('giftContactPayment');
       expect($ctrl.formatDonorDetails).toHaveBeenCalled();
+      expect($ctrl.tsysService.setEnvironment).toHaveBeenCalledWith('test-env');
     });
   });
 

--- a/src/app/branded/branded-checkout.spec.js
+++ b/src/app/branded/branded-checkout.spec.js
@@ -10,10 +10,11 @@ describe('branded checkout', () => {
   beforeEach(inject($componentController => {
     $ctrl = $componentController(module.name, {
       $window: jasmine.createSpyObj('$window', ['scrollTo']),
-      tsysService: jasmine.createSpyObj('tsysService', ['setEnvironment'])
+      tsysService: jasmine.createSpyObj('tsysService', ['setDevice'])
     }, {
-      onOrderCompleted: jasmine.createSpy('onOrderCompleted'),
-      tsysEnv: 'test-env'
+      designationNumber: '1234567',
+      tsysDevice: 'test-env',
+      onOrderCompleted: jasmine.createSpy('onOrderCompleted')
     });
   }));
 
@@ -21,9 +22,10 @@ describe('branded checkout', () => {
     it('should set initial checkout step and call formatDonorDetails', () => {
       spyOn($ctrl, 'formatDonorDetails');
       $ctrl.$onInit();
+      expect($ctrl.code).toEqual('1234567');
+      expect($ctrl.tsysService.setDevice).toHaveBeenCalledWith('test-env');
       expect($ctrl.checkoutStep).toEqual('giftContactPayment');
       expect($ctrl.formatDonorDetails).toHaveBeenCalled();
-      expect($ctrl.tsysService.setEnvironment).toHaveBeenCalledWith('test-env');
     });
   });
 

--- a/src/common/services/api/tsys.service.js
+++ b/src/common/services/api/tsys.service.js
@@ -10,11 +10,16 @@ class Tsys{
   /*@ngInject*/
   constructor(cortexApiService){
     this.cortexApiService = cortexApiService;
+    this.environment = '';
+  }
+
+  setEnvironment(environment){
+    this.environment = environment === 'default' ? '' : environment;
   }
 
   getManifest(){
     return this.cortexApiService.get({
-      path: ['tsys', 'manifest']
+      path: this.environment ? ['tsys', 'manifest', this.environment] : ['tsys', 'manifest']
     });
   }
 

--- a/src/common/services/api/tsys.service.js
+++ b/src/common/services/api/tsys.service.js
@@ -10,16 +10,16 @@ class Tsys{
   /*@ngInject*/
   constructor(cortexApiService){
     this.cortexApiService = cortexApiService;
-    this.environment = '';
+    this.device = '';
   }
 
-  setEnvironment(environment){
-    this.environment = environment;
+  setDevice(device){
+    this.device = device;
   }
 
   getManifest(){
     return this.cortexApiService.get({
-      path: this.environment ? ['tsys', 'manifest', this.environment] : ['tsys', 'manifest']
+      path: this.device ? ['tsys', 'manifest', this.device] : ['tsys', 'manifest']
     });
   }
 

--- a/src/common/services/api/tsys.service.js
+++ b/src/common/services/api/tsys.service.js
@@ -14,7 +14,7 @@ class Tsys{
   }
 
   setEnvironment(environment){
-    this.environment = environment === 'default' ? '' : environment;
+    this.environment = environment;
   }
 
   getManifest(){

--- a/src/common/services/api/tsys.service.spec.js
+++ b/src/common/services/api/tsys.service.spec.js
@@ -23,12 +23,6 @@ describe('order service', () => {
       self.tsysService.setEnvironment('test-env');
       expect(self.tsysService.environment).toEqual('test-env');
     });
-    
-    it('should handle default', () => {
-      expect(self.tsysService.environment).toEqual('');
-      self.tsysService.setEnvironment('default');
-      expect(self.tsysService.environment).toEqual('');
-    });
   });
 
   describe('getManifest', () => {

--- a/src/common/services/api/tsys.service.spec.js
+++ b/src/common/services/api/tsys.service.spec.js
@@ -17,9 +17,34 @@ describe('order service', () => {
     self.$httpBackend.verifyNoOutstandingRequest();
   });
 
+  describe('setEnvironment', () => {
+    it('should set the branded checkout TSYS environment', () => {
+      expect(self.tsysService.environment).toEqual('');
+      self.tsysService.setEnvironment('test-env');
+      expect(self.tsysService.environment).toEqual('test-env');
+    });
+    
+    it('should handle default', () => {
+      expect(self.tsysService.environment).toEqual('');
+      self.tsysService.setEnvironment('default');
+      expect(self.tsysService.environment).toEqual('');
+    });
+  });
+
   describe('getManifest', () => {
     it('should load the device id and manifest for TSYS tokenization', () => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/tsys/manifest')
+        .respond(200, { deviceId: '<device id>', manifest: '<manifest>' });
+      self.tsysService.getManifest()
+        .subscribe(data => {
+          expect(data).toEqual({ deviceId: '<device id>', manifest: '<manifest>' });
+        });
+      self.$httpBackend.flush();
+    });
+
+    it('should use the branded checkout TSYS environment if specified', () => {
+      self.tsysService.environment = 'test-env';
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/tsys/manifest/test-env')
         .respond(200, { deviceId: '<device id>', manifest: '<manifest>' });
       self.tsysService.getManifest()
         .subscribe(data => {

--- a/src/common/services/api/tsys.service.spec.js
+++ b/src/common/services/api/tsys.service.spec.js
@@ -17,11 +17,11 @@ describe('order service', () => {
     self.$httpBackend.verifyNoOutstandingRequest();
   });
 
-  describe('setEnvironment', () => {
-    it('should set the branded checkout TSYS environment', () => {
-      expect(self.tsysService.environment).toEqual('');
-      self.tsysService.setEnvironment('test-env');
-      expect(self.tsysService.environment).toEqual('test-env');
+  describe('setDevice', () => {
+    it('should set the branded checkout TSYS device', () => {
+      expect(self.tsysService.device).toEqual('');
+      self.tsysService.setDevice('test-env');
+      expect(self.tsysService.device).toEqual('test-env');
     });
   });
 
@@ -37,7 +37,7 @@ describe('order service', () => {
     });
 
     it('should use the branded checkout TSYS environment if specified', () => {
-      self.tsysService.environment = 'test-env';
+      self.tsysService.device = 'test-env';
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/tsys/manifest/test-env')
         .respond(200, { deviceId: '<device id>', manifest: '<manifest>' });
       self.tsysService.getManifest()


### PR DESCRIPTION
From our discussions about StoryRunners on hipchat and a seeing the [helpscout ticket](https://secure.helpscout.net/conversation/454114224/172768/?folderId=320673) that is 10 days old, I figured I would just get this done. We needed a way of letting EP know which device id to use for the manifest generation so we can whitelist other domains with TSYS.

Let me know if you have any naming suggestions or ways to improve the docs. I made a `default` string to try and make it clearer in the basic example that this needs to be changed.

@mattdrees is https://give-stage2.cru.org/cortex/tsys/manifest/test-env the right url to hit? I was getting a 404 presumably because that `accountIdentifier` (from your `/tsys/manifest/{accountIdentifier}` endpoint in hipchat) doesn't exist or this hasn't been fully implemented on the EP side.