### PR TITLE
Fix duplicate user match answer bug

### DIFF
--- a/src/common/components/userMatchModal/userMatchQuestion/userMatchQuestion.component.js
+++ b/src/common/components/userMatchModal/userMatchQuestion/userMatchQuestion.component.js
@@ -20,6 +20,7 @@ class UserMatchQuestionController {
         key:    this.question.key,
         answer: this.answer.answer
       } );
+      delete this.answer;
     }
   }
 }

--- a/src/common/components/userMatchModal/userMatchQuestion/userMatchQuestion.component.spec.js
+++ b/src/common/components/userMatchModal/userMatchQuestion/userMatchQuestion.component.spec.js
@@ -26,14 +26,18 @@ describe( 'userMatchQuestion', function () {
       it( 'sets hasError', () => {
         $ctrl.selectAnswer();
         expect( $ctrl.hasError ).toEqual( true );
+        expect( $ctrl.onQuestionAnswer ).not.toHaveBeenCalled();
+        expect( $ctrl.answer ).toEqual({answer: 'answer'});
       } );
     } );
 
     describe( 'valid form', () => {
       it( 'submits the answer', () => {
         $ctrl.questionForm.$valid = true;
+        expect( $ctrl.answer ).toEqual({answer: 'answer'});
         $ctrl.selectAnswer();
         expect( $ctrl.onQuestionAnswer ).toHaveBeenCalledWith( {key: 'key', answer: 'answer'} );
+        expect( $ctrl.answer ).toBeUndefined();
       } );
     } );
   } );


### PR DESCRIPTION
- Clear userMatchQuestion's answer model after notifying the parent component of the answer so the answer input will be $invalid the next time

https://secure.helpscout.net/conversation/491382144/185452/?folderId=320673