### PR TITLE
Scrub rollbar telemetry

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -4,6 +4,8 @@ import stacktrace from 'stacktrace-js';
 import map from 'lodash/map';
 import defaults from 'lodash/defaults';
 import get from 'lodash/get';
+import find from 'lodash/find';
+import includes from 'lodash/includes';
 
 let Rollbar;
 
@@ -18,6 +20,7 @@ function rollbarConfig(envServiceProvider, $provide) {
     transform: transformRollbarPayload,
     hostWhiteList: ['give.cru.org', 'give-prod.cru.org', 'give-stage2.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org'],
     scrubFields: ['password', 'cvv', 'cvv2', 'security-code', 'k'],
+    telemetryScrubber: scrubDomNodes(['cardNumber', 'cardholderName', 'expiryMonth', 'expiryYear', 'securityCode', 'bankName', 'accountType', 'routingNumber', 'accountNumber', 'verifyAccountNumber']),
     payload: {
       client: {
         javascript: {
@@ -129,11 +132,19 @@ function updateRollbarPerson(session){
   });
 }
 
+function scrubDomNodes(scrubNames){
+  return node => {
+    const nameAttr = find(node.attributes, attr => attr.key === 'name');
+    return !!nameAttr && includes(scrubNames, nameAttr.value);
+  };
+}
+
 export {
   rollbarConfig as default,
   updateRollbarPerson,
   rollbar, // For mocking during testing
   stacktrace, // For mocking during testing,
   formatStacktraceForRollbar, // To test this function separately
-  transformRollbarPayload // To test this function separately
+  transformRollbarPayload, // To test this function separately
+  scrubDomNodes // To test this function separately
 };

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -234,4 +234,37 @@ describe('rollbarConfig', () => {
       expect(module.transformRollbarPayload(payload)).toEqual(payload);
     });
   });
+
+  describe('scrubDomNodes', () => {
+    it('should return true for dom modes where the name matches', () => {
+      expect(module.scrubDomNodes(['creditCardField'])({
+        attributes: [
+          {
+            key: 'name',
+            value: 'creditCardField'
+          }
+        ]
+      })).toEqual(true);
+    });
+    it('should return false for dom modes where the name does not match', () => {
+      expect(module.scrubDomNodes(['creditCardField'])({
+        attributes: [
+          {
+            key: 'name',
+            value: 'notCreditCardField'
+          }
+        ]
+      })).toEqual(false);
+    });
+    it('should return false for dom modes that don\'t have a name', () => {
+      expect(module.scrubDomNodes(['creditCardField'])({
+        attributes: [
+          {
+            key: 'id',
+            value: 'creditCardField'
+          }
+        ]
+      })).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
I messed up. I should have know rollbar would start logging input fields, including credit card and bank account fields. I sort of knew it had that capability but wasn't thinking about it when upgrading. I guess I've mostly looked at telemetry for network requests. This scrubs the values from those fields.

https://github.com/CruGlobal/give-web/pull/712 added telemetry.