### PR TITLE
Add "displayName" nav attribute

### DIFF
--- a/src/common/components/nav/desktopNav.tpl.html
+++ b/src/common/components/nav/desktopNav.tpl.html
@@ -87,7 +87,10 @@
         <div class="sign-in" ng-if="!$ctrl.isSignedIn" ng-click="$ctrl.signIn()" translate>Sign In</div>
         <div class="signed-in" ng-if="$ctrl.isSignedIn">
           <div uib-dropdown>
-            <a uib-dropdown-toggle>{{$ctrl.sessionService.session.first_name}} {{$ctrl.sessionService.session.last_name}}</a>
+            <a uib-dropdown-toggle>
+              {{$ctrl.displayName ? $ctrl.displayName :
+                $ctrl.sessionService.session.first_name + ' ' + $ctrl.sessionService.session.last_name}}
+            </a>
             <ul class="pull-right" uib-dropdown-menu>
               <span class="triangle"></span>
               <li class="nav-edit-profile">

--- a/src/common/components/nav/nav.component.js
+++ b/src/common/components/nav/nav.component.js
@@ -178,6 +178,7 @@ class NavController{
 
   sessionChanged() {
     this.isSignedIn = (this.customProfile && this.sessionService.session.email) ||
+      this.displayName ||
       includes(['IDENTIFIED', 'REGISTERED'], this.sessionService.getRole());
   }
 
@@ -277,7 +278,8 @@ export default angular
       searchResultsPath: '@',
       editProfilePath: '@',
       signOutPath: '@',
-      customProfile: '<',
+      customProfile: '<', //boolean: if true, will use 'cru-profile' cookie for auth state and user first/last name
+      displayName: '@', //string: override 'cru-profile' cookie and display this string as the user's first/last name
       pullRightOptions: '<',
       logoLink: '@',
       languagePickerCountry: '@',


### PR DESCRIPTION
For Staff Web

Goal is to remove "customProfile" completely.  Only use the profile cookie on give.cru.org.  Will be able to once new cru.org design is up.

cc @wrandall22 