### PR TITLE
Allow multiple formats for suggested amounts

### DIFF
--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -183,10 +183,10 @@ class DesignationsService {
           // Map suggested amounts
           if( data.data['jcr:content'].suggestedAmounts) {
             angular.forEach( data.data['jcr:content'].suggestedAmounts, ( v, k ) => {
-              if ( toFinite( k ) > 0 ) suggestedAmounts.push( {
+              if ( toFinite( k ) > 0 || k.includes('item') ) suggestedAmounts.push( {
                 amount: toFinite( v.amount ),
                 label: v.description,
-                order: toFinite( k )
+                order: toFinite( k ) > 0 ? toFinite( k ) : k.substring(4)
               } );
             } );
           }


### PR DESCRIPTION
The out of the box Touch UI composite multifield editor creates nodes in the form of `item0`, `item1`, etc. We want to switch to using that instead of the broken Classic UI editor that was created for this purpose. In order to support the transition, this PR is here.