### PR TITLE
only override donor details on first load of form

### DIFF
--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import 'angular-messages';
 import assign from 'lodash/assign';
+import find from 'lodash/find';
 import includes from 'lodash/includes';
 import startsWith from 'lodash/startsWith';
 import {Observable} from 'rxjs/Observable';
@@ -90,7 +91,8 @@ class Step1Controller{
           }
         }
 
-        if(overrideDonorDetails){
+        const firstTimeLoading = !find(this.donorDetails.links, ['rel', 'donormatchesform']);
+        if(overrideDonorDetails && firstTimeLoading){
           this.donorDetails = assign(this.donorDetails, overrideDonorDetails);
         }
       },

--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import 'angular-messages';
 import assign from 'lodash/assign';
+import pick from 'lodash/pick';
 import find from 'lodash/find';
 import includes from 'lodash/includes';
 import startsWith from 'lodash/startsWith';
@@ -93,7 +94,9 @@ class Step1Controller{
 
         const firstTimeLoading = !find(this.donorDetails.links, ['rel', 'donormatchesform']);
         if(overrideDonorDetails && firstTimeLoading){
-          this.donorDetails = assign(this.donorDetails, overrideDonorDetails);
+          this.donorDetails = assign(this.donorDetails, pick(overrideDonorDetails, [
+            'donor-type', 'organization-name', 'phone-number', 'spouse-name', 'mailingAddress', 'email'
+          ]));
         }
       },
       error => {


### PR DESCRIPTION
This fixes an issue where a user would go back to edit their details from the review screen and they would be overridden by the defaults from the window object.

Let me know if you have a better way to detect this, I just noticed that that link doesn't exist on the first load, but does on the second.