### PR TITLE
turn off autocomplete for bank and credit card fields

### DIFF
--- a/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
+++ b/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
@@ -37,7 +37,7 @@
       <div class="col-sm-4">
         <div class="form-group is-required" ng-class="{'has-error': ($ctrl.bankPaymentForm.routingNumber | showErrors)}">
           <label>Routing #</label>
-          <input type="text" class="form-control  form-control-subtle" name="routingNumber" ng-model="$ctrl.bankPayment.routingNumber" required>
+          <input type="text" class="form-control  form-control-subtle" name="routingNumber" autocomplete="off" ng-model="$ctrl.bankPayment.routingNumber" required>
           <div role="alert" ng-messages="$ctrl.bankPaymentForm.routingNumber.$error" ng-if="($ctrl.bankPaymentForm.routingNumber | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter a routing number</div>
             <div class="help-block" ng-message="length" translate>This routing number must contain 9 digits</div>
@@ -48,7 +48,7 @@
       <div class="col-sm-4">
         <div class="form-group is-required" ng-class="{'has-error': ($ctrl.bankPaymentForm.accountNumber | showErrors)}">
           <label>Account #</label>
-          <input type="text" class="form-control  form-control-subtle" name="accountNumber" ng-model="$ctrl.bankPayment.accountNumber" ng-attr-placeholder="************{{$ctrl.bankPayment.accountNumberPlaceholder}}" ng-required="!$ctrl.paymentMethod || $ctrl.bankPayment.accountNumber">
+          <input type="text" class="form-control  form-control-subtle" name="accountNumber" autocomplete="off" ng-model="$ctrl.bankPayment.accountNumber" ng-attr-placeholder="************{{$ctrl.bankPayment.accountNumberPlaceholder}}" ng-required="!$ctrl.paymentMethod || $ctrl.bankPayment.accountNumber">
           <div role="alert" ng-messages="$ctrl.bankPaymentForm.accountNumber.$error" ng-if="($ctrl.bankPaymentForm.accountNumber | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter an account number</div>
             <div class="help-block" ng-message="minlength" translate>This account number must contain 2 or more digits</div>
@@ -59,7 +59,7 @@
       <div class="col-sm-4">
         <div class="form-group is-required no-wrap" ng-class="{'has-error': ($ctrl.bankPaymentForm.verifyAccountNumber | showErrors)}">
           <label>Retype Account #</label>
-          <input type="text" class="form-control  form-control-subtle" name="verifyAccountNumber" ng-model="$ctrl.bankPayment.verifyAccountNumber" ng-attr-placeholder="************{{$ctrl.bankPayment.accountNumberPlaceholder}}" ng-required="$ctrl.bankPayment.accountNumber">
+          <input type="text" class="form-control  form-control-subtle" name="verifyAccountNumber" autocomplete="off" ng-model="$ctrl.bankPayment.verifyAccountNumber" ng-attr-placeholder="************{{$ctrl.bankPayment.accountNumberPlaceholder}}" ng-required="$ctrl.bankPayment.accountNumber">
           <div role="alert" ng-messages="$ctrl.bankPaymentForm.verifyAccountNumber.$error" ng-if="($ctrl.bankPaymentForm.verifyAccountNumber | showErrors)">
             <div class="help-block" ng-message="required" translate>You must retype your account number</div>
             <div class="help-block" ng-message="verifyAccountNumber" translate>Your account numbers do not match</div>

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -10,6 +10,7 @@
           <label translate>Card #</label>
           <input type="text"
                  name="cardNumber"
+                 autocomplete="off"
                  class="form-control  form-control-subtle"
                  ng-model="$ctrl.creditCardPayment.cardNumber"
                  ng-attr-placeholder="************{{$ctrl.creditCardPayment.cardNumberPlaceholder}}"
@@ -83,6 +84,7 @@
           <label translate>Security Code</label>
           <input type="text"
                  name="securityCode"
+                 autocomplete="off"
                  class="form-control form-control-subtle"
                  ng-model="$ctrl.creditCardPayment.securityCode"
                  ng-required="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber"

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -10,7 +10,7 @@
           <label translate>Card #</label>
           <input type="text"
                  name="cardNumber"
-                 autocomplete="off"
+                 autocomplete="cc-number"
                  class="form-control  form-control-subtle"
                  ng-model="$ctrl.creditCardPayment.cardNumber"
                  ng-attr-placeholder="************{{$ctrl.creditCardPayment.cardNumberPlaceholder}}"
@@ -29,7 +29,12 @@
       <div class="col-sm-6">
         <div class="form-group is-required" ng-class="{'has-error': ($ctrl.creditCardPaymentForm.cardholderName | showErrors)}">
           <label translate>Name On Card</label>
-          <input type="text" name="cardholderName" class="form-control  form-control-subtle" ng-model="$ctrl.creditCardPayment.cardholderName" ng-maxlength="50" required>
+          <input type="text"
+                 name="cardholderName"
+                 class="form-control  form-control-subtle"
+                 autocomplete="cc-name"
+                 ng-model="$ctrl.creditCardPayment.cardholderName"
+                 ng-maxlength="50" required>
           <div role="alert" ng-messages="$ctrl.creditCardPaymentForm.cardholderName.$error" ng-if="($ctrl.creditCardPaymentForm.cardholderName | showErrors)">
             <div class="help-block" ng-message="required" translate>You must enter the name on the card</div>
             <div class="help-block" ng-message="maxlength" translate>This name cannot be longer than 50 characters</div>
@@ -43,6 +48,7 @@
           <label translate>Exp. Month</label>
           <select class="form-control  form-control-subtle"
                   name="expiryMonth"
+                  autocomplete="cc-exp-month"
                   required
                   ng-model="$ctrl.creditCardPayment.expiryMonth">
             <option value="01" translate>01 - January</option>
@@ -69,6 +75,7 @@
           <label translate>Exp. Year</label>
           <select class="form-control  form-control-subtle"
                   name="expiryYear"
+                  autocomplete="cc-exp-year"
                   required
                   ng-model="$ctrl.creditCardPayment.expiryYear"
                   ng-options="year for year in $ctrl.expirationDateYears">
@@ -84,7 +91,7 @@
           <label translate>Security Code</label>
           <input type="text"
                  name="securityCode"
-                 autocomplete="off"
+                 autocomplete="cc-csc"
                  class="form-control form-control-subtle"
                  ng-model="$ctrl.creditCardPayment.securityCode"
                  ng-required="!$ctrl.paymentMethod || $ctrl.creditCardPayment.cardNumber"


### PR DESCRIPTION
Although this is helpful when testing, probably not great to have that remembered in the user's browser.