### PR TITLE
Cart count cookie

### DIFF
--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -14,10 +14,9 @@ describe('cart service', () => {
   beforeEach(angular.mock.module(module.name));
   let self = {};
 
-  beforeEach(inject((cartService, $httpBackend, $rootScope) => {
+  beforeEach(inject((cartService, $httpBackend) => {
     self.cartService = cartService;
     self.$httpBackend = $httpBackend;
-    self.$rootScope = $rootScope;
   }));
 
   afterEach(() => {
@@ -27,6 +26,8 @@ describe('cart service', () => {
 
   describe('get', () => {
     beforeEach(() => {
+      spyOn(self.cartService.$cookies, 'put');
+      spyOn(self.cartService.$cookies, 'remove');
       spyOn(self.cartService.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2016-10-01'));
       jasmine.clock().mockDate(moment('2016-09-01').toDate()); // Make sure current date is before next draw date
     });
@@ -53,7 +54,7 @@ describe('cart service', () => {
       self.cartService.get()
         .subscribe((data) => {
           expect(data).toEqual({});
-          expect(self.cartService.$cookies.get('giveCartItemCount')).toEqual(undefined);
+          expect(self.cartService.$cookies.remove).toHaveBeenCalledWith('giveCartItemCount', jasmine.any(Object));
         });
       self.$httpBackend.flush();
     });
@@ -81,8 +82,7 @@ describe('cart service', () => {
             { frequency: 'Quarterly', amount: 50, total: '$50.00' }
           ]);
 
-          self.$rootScope.$digest();
-          expect(self.cartService.$cookies.get('giveCartItemCount')).toEqual(3);
+          expect(self.cartService.$cookies.put).toHaveBeenCalledWith('giveCartItemCount', 3, jasmine.any(Object));
         });
       self.$httpBackend.flush();
     });

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -14,9 +14,10 @@ describe('cart service', () => {
   beforeEach(angular.mock.module(module.name));
   let self = {};
 
-  beforeEach(inject((cartService, $httpBackend) => {
+  beforeEach(inject((cartService, $httpBackend, $rootScope) => {
     self.cartService = cartService;
     self.$httpBackend = $httpBackend;
+    self.$rootScope = $rootScope;
   }));
 
   afterEach(() => {
@@ -52,6 +53,7 @@ describe('cart service', () => {
       self.cartService.get()
         .subscribe((data) => {
           expect(data).toEqual({});
+          expect(self.cartService.$cookies.get('giveCartItemCount')).toEqual(undefined);
         });
       self.$httpBackend.flush();
     });
@@ -78,6 +80,9 @@ describe('cart service', () => {
             { frequency: 'Annually', amount: 50, total: '$50.00' },
             { frequency: 'Quarterly', amount: 50, total: '$50.00' }
           ]);
+
+          self.$rootScope.$digest();
+          expect(self.cartService.$cookies.get('giveCartItemCount')).toEqual(3);
         });
       self.$httpBackend.flush();
     });


### PR DESCRIPTION

![screen shot 2018-04-26 at 2 05 26 pm](https://user-images.githubusercontent.com/4603906/39323583-fda5d1b6-495a-11e8-8e4f-7d0e3366e817.png)

Give and Cru.org will have a new design that shows the item count in the header.  Setting a cookie will avoid doing a cart get request on every page load.