### PR TITLE
Add trust_device to signIn for MFA

### DIFF
--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -30,7 +30,7 @@ class SignInFormController {
     this.isSigningIn = true;
     delete this.errorMessage;
     this.sessionService
-      .signIn( this.username, this.password, this.mfa_token, this.lastPurchaseId )
+      .signIn( this.username, this.password, this.mfa_token, this.trust_device, this.lastPurchaseId )
       .subscribe( () => {
         this.onSuccess();
       }, error => {

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -69,7 +69,7 @@ describe( 'signInForm', function () {
 
       it( 'calls sessionService signIn', () => {
         expect( $ctrl.isSigningIn ).toEqual( true );
-        expect( $ctrl.sessionService.signIn ).toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', undefined, undefined );
+        expect( $ctrl.sessionService.signIn ).toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', undefined, undefined, undefined );
       } );
 
       it( 'signs in successfully', () => {
@@ -135,21 +135,31 @@ describe( 'signInForm', function () {
         $ctrl.username = 'professorx@xavier.edu';
         $ctrl.password = 'Cerebro123';
         $ctrl.mfa_token = '123456';
-        $ctrl.signIn();
+        $ctrl.trust_device = false;
       } ) );
 
       it( 'calls sessionService signIn', () => {
+        $ctrl.signIn();
         expect( $ctrl.isSigningIn ).toEqual( true );
-        expect( $ctrl.sessionService.signIn ).toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', '123456', undefined );
+        expect( $ctrl.sessionService.signIn ).toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', '123456', false, undefined );
+      } );
+
+      it( 'calls sessionService signIn with trust_device', () => {
+        $ctrl.trust_device = true;
+        $ctrl.signIn();
+        expect( $ctrl.isSigningIn ).toEqual( true );
+        expect( $ctrl.sessionService.signIn ).toHaveBeenCalledWith( 'professorx@xavier.edu', 'Cerebro123', '123456', true, undefined );
       } );
 
       it( 'signs in successfully', () => {
+        $ctrl.signIn();
         deferred.resolve( {} );
         $rootScope.$digest();
         expect( bindings.onSuccess ).toHaveBeenCalled();
       } );
 
       it( 'requires multi-factor', () => {
+        $ctrl.signIn();
         deferred.reject( {data: {error: 'invalid_grant', thekey_authn_error: 'mfa_required' } } );
         $rootScope.$digest();
         expect( bindings.onFailure ).not.toHaveBeenCalled();

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -52,6 +52,17 @@
              ng-disabled="$ctrl.isSigningIn"
              ng-model="$ctrl.mfa_token">
     </div>
+    <div class="form-group">
+      <label class="checkbox-inline">
+        <input id="trust_device"
+               name="trust_device"
+               type="checkbox"
+               ng-model="$ctrl.trust_device"
+               ng-disabled="$ctrl.isSigningIn"
+               translate> Don't ask for codes again on this device.
+      </label>
+    </div>
+
   </div>
   <button
     type="submit"

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -58,13 +58,15 @@ function session( $cookies, $rootScope, $http, $timeout, envService ) {
   };
 
   /* Public Methods */
-  function signIn( username, password, mfa_token, lastPurchaseId ) {
+  function signIn( username, password, mfa_token, trust_device, lastPurchaseId ) {
     let data = {
       username: username,
       password: password
     };
     if(angular.isDefined(mfa_token))
       data.mfa_token = mfa_token;
+    if(trust_device)
+      data.trust_device = '1';
     // Only send lastPurchaseId if present and currently public
     if(angular.isDefined(lastPurchaseId) && currentRole() === Roles.public)
       data.lastPurchaseId = lastPurchaseId;

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -169,6 +169,21 @@ describe( 'session service', function () {
       $httpBackend.flush();
     } );
 
+    it( 'makes http request to cas/login with mfa and trust_device', () => {
+      $httpBackend.expectPOST( 'https://give-stage2.cru.org/cas/login', {
+        username: 'user@example.com',
+        password: 'hello123',
+        mfa_token: '123456',
+        trust_device: '1'
+      } ).respond( 200, 'success' );
+      sessionService
+        .signIn( 'user@example.com', 'hello123', '123456', true )
+        .subscribe( ( data ) => {
+          expect( data ).toEqual( 'success' );
+        } );
+      $httpBackend.flush();
+    } );
+
     it( 'includes lastPurchaseId when present and PUBLIC', () => {
       spyOn( sessionService, 'getRole' ).and.returnValue(Roles.public);
       $httpBackend.expectPOST( 'https://give-stage2.cru.org/cas/login', {
@@ -177,7 +192,7 @@ describe( 'session service', function () {
         lastPurchaseId: 'gxbcdviu='
       } ).respond( 200, 'success' );
       sessionService
-        .signIn( 'user@example.com', 'hello123', undefined, 'gxbcdviu=' )
+        .signIn( 'user@example.com', 'hello123', undefined, undefined, 'gxbcdviu=' )
         .subscribe( ( data ) => {
           expect( data ).toEqual( 'success' );
         } );


### PR DESCRIPTION
Adds a "Don't ask for codes again on this device." checkbox on the MFA section on the signIn form.
Value is passed to cortex_gateway as trust_device=1 if checked.