### PR TITLE
Fix profile/receipts Load More button.

### DIFF
--- a/src/app/profile/receipts/receipts.tpl.html
+++ b/src/app/profile/receipts/receipts.tpl.html
@@ -65,7 +65,7 @@
         <div class="row mt">
           <div class="col-xs-12">
             <button
-              ng-if="$ctrl.maxShow < filtered.length"
+              ng-if="$ctrl.maxShow < $ctrl.receipts.length"
               ng-click="$ctrl.maxShow = $ctrl.maxShow + $ctrl.step"
               class="btn btn-default center-block ps_x">Load More</button>
           </div>


### PR DESCRIPTION
Look at total number of receipts instead of filtered length (which is always 25 or less).