### PR TITLE
Multiple giving links

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -11,6 +11,7 @@ import designationEditorService from 'common/services/api/designationEditor.serv
 
 import titleModalController from './titleModal/title.modal';
 import pageOptionsModalController from './pageOptionsModal/pageOptions.modal';
+import personalOptionsModalController from './personalOptionsModal/personalOptions.modal';
 import photoModalController from './photoModal/photo.modal';
 import textEditorModalController from './textEditorModal/textEditor.modal';
 import websiteModalController from './websiteModal/website.modal';
@@ -18,6 +19,7 @@ import websiteModalController from './websiteModal/website.modal';
 import template from './designationEditor.tpl.html';
 import titleModalTemplate from './titleModal/titleModal.tpl.html';
 import pageOptionsModalTemplate from './pageOptionsModal/pageOptionsModal.tpl.html';
+import personalOptionsModalTemplate from './personalOptionsModal/personalOptionsModal.tpl.html';
 import photoModalTemplate from './photoModal/photoModal.tpl.html';
 import textEditorModalTemplate from './textEditorModal/textEditorModal.tpl.html';
 import websiteModalTemplate from './websiteModal/websiteModal.tpl.html';
@@ -37,6 +39,7 @@ class DesignationEditorController {
 
     this.imgDomain = envService.read('imgDomain');
     this.imgDomainDesignation = envService.read('imgDomainDesignation');
+    this.giveDomain = envService.read('publicGive');
 
     this.$location = $location;
     this.$q = $q;
@@ -139,6 +142,24 @@ class DesignationEditorController {
         this.designationContent.parentDesignationNumber = data.parentDesignationNumber;
         this.designationContent.suggestedAmounts = data.suggestedAmounts;
         this.designationContent.facebookPixelId = data.facebookPixelId;
+        this.save();
+      }, angular.noop );
+  }
+
+  editPersonalOptions() {
+    let modalOptions = {
+      templateUrl: personalOptionsModalTemplate,
+      controller: personalOptionsModalController.name,
+      controllerAs: '$ctrl',
+      resolve : {
+        giveDomain: () => { return this.giveDomain; },
+        designationNumber: () => { return this.designationNumber; },
+        givingLinks: () => { return this.designationContent.givingLinks; }
+      }
+    };
+    this.$uibModal.open( modalOptions ).result
+      .then( (data) => {
+        this.designationContent.givingLinks = data.givingLinks;
         this.save();
       }, angular.noop );
   }
@@ -248,6 +269,7 @@ export default angular
     designationEditorService.name,
     titleModalController.name,
     pageOptionsModalController.name,
+    personalOptionsModalController.name,
     photoModalController.name,
     textEditorModalController.name,
     websiteModalController.name

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -25,6 +25,9 @@ const designationSecurityResponse = {
   "status": "",
   "pointedToDesignationPath": "",
   "suggestedAmounts": [],
+  "givingLinks": {"jcr:primaryType":"nt:unstructured",
+    "item0": {"jcr:primaryType":"nt:unstructured","url":"https://example.com","name":"Name"}
+  },
   "primaryFirstName": "",
   "primaryMiddleName": "",
   "primaryLastName": "",
@@ -205,6 +208,34 @@ describe( 'Designation Editor', function () {
 
         expect($ctrl.designationContent.parentDesignationNumber).toEqual('000777');
         expect($ctrl.designationContent.facebookPixelId).toEqual('563541681');
+        expect($ctrl.designationContent.suggestedAmounts).toEqual([]);
+      } );
+    });
+
+    describe('personal options modal', () => {
+      let modalPromise;
+      beforeEach(inject((_$q_) => {
+        modalPromise = _$q_.defer();
+        spyOn( $ctrl.$uibModal, 'open' ).and.returnValue( {result: modalPromise.promise} );
+      }));
+
+      it( 'should open modal', () => {
+        $ctrl.designationNumber = '000555';
+        $ctrl.giveDomain = 'https://give.example.com';
+        $ctrl.designationContent = designationSecurityResponse;
+
+        $ctrl.editPersonalOptions();
+
+        expect($ctrl.$uibModal.open).toHaveBeenCalled();
+        expect($ctrl.$uibModal.open.calls.argsFor( 0 )[0].resolve.designationNumber()).toEqual(designationSecurityResponse.designationNumber);
+        expect($ctrl.$uibModal.open.calls.argsFor( 0 )[0].resolve.giveDomain()).toEqual($ctrl.giveDomain);
+        expect($ctrl.$uibModal.open.calls.argsFor( 0 )[0].resolve.givingLinks()).toEqual(designationSecurityResponse.givingLinks);
+
+        modalPromise.resolve({
+          givingLinks: []
+        });
+        $rootScope.$digest();
+
         expect($ctrl.designationContent.suggestedAmounts).toEqual([]);
       } );
     });

--- a/src/app/designationEditor/designationEditor.tpl.html
+++ b/src/app/designationEditor/designationEditor.tpl.html
@@ -35,6 +35,11 @@
             Done Editing
           </a>
 
+          <button id="personalOptionsButton" type="button" class="btn btn-default" ng-click="$ctrl.editPersonalOptions()"
+                  ng-if="$ctrl.contentLoaded && $ctrl.isPerson()" translate>
+            Page Options
+          </button>
+
           <button id="pageOptionsButton" type="button" class="btn btn-default" ng-click="$ctrl.editPageOptions()"
                   ng-if="$ctrl.contentLoaded && !$ctrl.isPerson()" translate>
             Page Options

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
@@ -1,0 +1,35 @@
+import angular from 'angular';
+import transform from 'lodash/transform';
+import sortBy from 'lodash/sortBy';
+
+let controllerName = 'personalOptionsCtrl';
+
+class ModalInstanceCtrl {
+
+  /* @ngInject */
+  constructor(designationNumber, giveDomain, givingLinks) {
+    this.designationNumber = designationNumber;
+    this.giveDomain = giveDomain;
+
+    this.givingLinks = transform(givingLinks, (result, value, key) => {
+      if(key === 'jcr:primaryType'){ return; }
+      result.push({
+        name: value.name,
+        url: value.url,
+        order: Number(key)
+      });
+    }, []);
+    this.givingLinks = sortBy(this.givingLinks, 'order');
+  }
+
+  transformGivingLinks(){
+    return transform(this.givingLinks, (result, value, i) => {
+      delete value.order;
+      result[i+1] = value;
+    }, {});
+  }
+}
+
+export default angular
+  .module(controllerName, [])
+  .controller(controllerName, ModalInstanceCtrl);

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
@@ -1,0 +1,36 @@
+import angular from 'angular';
+import 'angular-mocks';
+import module from './personalOptions.modal';
+
+describe('Designation Editor Personal Options', function() {
+  beforeEach(angular.mock.module(module.name));
+  var $ctrl;
+
+  beforeEach(inject(function($rootScope, $controller) {
+    var $scope = $rootScope.$new();
+
+    $ctrl = $controller( module.name, {
+      designationNumber: '000555',
+      giveDomain: 'https://give.cru.org',
+      givingLinks: {"jcr:primaryType":"nt:unstructured",
+        "1": {"jcr:primaryType":"nt:unstructured","url":"https://example.com","name":"Name"}
+      },
+      $scope: $scope
+    } );
+  }));
+
+  it('to be defined', function() {
+    expect($ctrl).toBeDefined();
+  });
+
+  it('to define modal resolves', function() {
+    expect($ctrl.designationNumber).toEqual('000555');
+    expect($ctrl.givingLinks).toEqual([{name: 'Name', url: 'https://example.com', order: 1}]);
+  });
+
+  it('transforms giving links', function() {
+    expect($ctrl.transformGivingLinks()).toEqual({
+      '1': {name: 'Name', url: 'https://example.com'}
+    });
+  });
+});

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -1,0 +1,80 @@
+<div class="modal-body">
+  <form name="personalForm">
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" ng-init="$ctrl.tab = 'givingLinks'">
+      <li ng-class="{'active': $ctrl.tab === 'givingLinks'}">
+        <a href="" ng-click="$ctrl.tab = 'givingLinks'">
+          Giving Links
+        </a>
+      </li>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <div class="tab-pane active" ng-if="$ctrl.tab === 'givingLinks'">
+        <table class="table table-hover table-condensed">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th>URL</th>
+            <th></th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td><input type="text" class="form-control" style="border: 0; box-shadow: none;" name="name"
+                       value="Give at Cru.org" readonly="readonly"/></td>
+            <td><input type="url" class="form-control" style="border: 0; box-shadow: none;" name="url"
+                       value="{{$ctrl.giveDomain}}/{{$ctrl.designationNumber}}" readonly="readonly"/></td>
+            <td></td>
+          </tr>
+          <tr ng-repeat="a in $ctrl.givingLinks track by $index" ng-form="givingLinkForm">
+            <td class="form-group" ng-class="{'has-error': !givingLinkForm.name.$valid}">
+              <input name="name"
+                     type="text"
+                     class="form-control"
+                     ng-model="a.name"
+                     placeholder="Give at example"
+                     required ng-change="console.log(givingLinkForm)">
+              <span class="help-block" ng-hide="givingLinkForm.name.$valid">Name is required.</span>
+            </td>
+            <td class="form-group" ng-class="{'has-error': !givingLinkForm.url.$valid}">
+              <input name="url"
+                     type="url"
+                     class="form-control"
+                     placeholder="https://www.example.com"
+                     ng-model="a.url"
+                     required>
+              <span class="help-block" ng-hide="givingLinkForm.url.$valid">Url is required.</span>
+            </td>
+            <td><a href="" class="btn-link btn" ng-click="$ctrl.givingLinks.splice($index, 1)">
+              <i class="fa fa-minus-circle"></i>
+            </a></td>
+          </tr>
+          </tbody>
+          <tfoot>
+          <tr>
+            <td colspan="3">
+              <a id="addSuggestedAmountButton" href="" ng-click="$ctrl.givingLinks.push({})"><i
+                class="fa fa-plus-circle"></i> Add another Giving Link</a>
+            </td>
+          </tr>
+          </tfoot>
+        </table>
+      </div>
+
+    </div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button id="saveChangesButton"
+          type="button"
+          class="btn btn-primary pull-right"
+          ng-click="$close({
+            givingLinks: $ctrl.transformGivingLinks()
+          })"
+          ng-disabled="!personalForm.$valid">
+    Save &amp; Close
+  </button>
+  <button id="cancelChangesButton" type="button" class="btn btn-default" ng-click="$dismiss()">Cancel</button>
+</div>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -12,18 +12,21 @@
     <!-- Tab panes -->
     <div class="tab-content">
       <div class="tab-pane active" ng-if="$ctrl.tab === 'givingLinks'">
+        <div class="form-group">
+          <span class="help-block">Setup additional country giving links.</span>
+        </div>
         <table class="table table-hover table-condensed">
           <thead>
           <tr>
-            <th>Name</th>
-            <th>URL</th>
+            <th>Country Name</th>
+            <th>Give Site URL</th>
             <th></th>
           </tr>
           </thead>
           <tbody>
           <tr>
             <td><input type="text" class="form-control" style="border: 0; box-shadow: none;" name="name"
-                       value="Give at Cru.org" readonly="readonly"/></td>
+                       value="US" readonly="readonly"/></td>
             <td><input type="url" class="form-control" style="border: 0; box-shadow: none;" name="url"
                        value="{{$ctrl.giveDomain}}/{{$ctrl.designationNumber}}" readonly="readonly"/></td>
             <td></td>
@@ -34,7 +37,7 @@
                      type="text"
                      class="form-control"
                      ng-model="a.name"
-                     placeholder="Give at example"
+                     placeholder="Country Name"
                      required ng-change="console.log(givingLinkForm)">
               <span class="help-block" ng-hide="givingLinkForm.name.$valid">Name is required.</span>
             </td>
@@ -42,7 +45,7 @@
               <input name="url"
                      type="url"
                      class="form-control"
-                     placeholder="https://www.example.com"
+                     placeholder="https://give.country.co/name"
                      ng-model="a.url"
                      required>
               <span class="help-block" ng-hide="givingLinkForm.url.$valid">Url is required.</span>
@@ -55,8 +58,8 @@
           <tfoot>
           <tr>
             <td colspan="3">
-              <a id="addGivingLinksButton" href="" ng-click="$ctrl.givingLinks.push({})"><i
-                class="fa fa-plus-circle"></i> Add another Giving Link</a>
+              <a id="addGivingLinksButton" href="" ng-click="$ctrl.givingLinks.push({})">
+                <i class="fa fa-plus-circle"></i> Add Giving Link</a>
             </td>
           </tr>
           </tfoot>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -59,7 +59,7 @@
           <tr>
             <td colspan="3">
               <a id="addGivingLinksButton" href="" ng-click="$ctrl.givingLinks.push({})">
-                <i class="fa fa-plus-circle"></i> Add Giving Link</a>
+                <i class="fa fa-plus-circle"></i> Add another Giving Link</a>
             </td>
           </tr>
           </tfoot>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -55,7 +55,7 @@
           <tfoot>
           <tr>
             <td colspan="3">
-              <a id="addSuggestedAmountButton" href="" ng-click="$ctrl.givingLinks.push({})"><i
+              <a id="addGivingLinksButton" href="" ng-click="$ctrl.givingLinks.push({})"><i
                 class="fa fa-plus-circle"></i> Add another Giving Link</a>
             </td>
           </tr>

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -131,6 +131,7 @@ class ProductConfigFormController {
         },
         () => {
           this.analyticsFactory.giveGiftModal(this.code);
+          this.loading = false;
           // Show givingLinks if they exist and it isn't an edit
           if(this.givingLinks.length > 0 && !this.isEdit) {
             this.showGivingLinks = true;
@@ -138,7 +139,6 @@ class ProductConfigFormController {
           } else {
             this.onStateChange({ state: 'unsubmitted' });
           }
-          this.loading = false;
         });
   }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -33,10 +33,11 @@ const componentName = 'productConfigForm';
 class ProductConfigFormController {
 
   /* @ngInject */
-  constructor( $scope, $log, $filter, designationsService, cartService, commonService, analyticsFactory ) {
+  constructor( $scope, $log, $filter, $window, designationsService, cartService, commonService, analyticsFactory ) {
     this.$scope = $scope;
     this.$log = $log;
     this.$filter = $filter;
+    this.$window = $window;
     this.designationsService = designationsService;
     this.cartService = cartService;
     this.commonService = commonService;
@@ -115,7 +116,12 @@ class ProductConfigFormController {
         this.useSuggestedAmounts = !isEmpty(this.suggestedAmounts);
       });
 
-    Observable.merge(productLookupObservable, nextDrawDateObservable, suggestedAmountsObservable)
+    const givingLinksObservable = this.designationsService.givingLinks(this.code)
+      .do(givingLinks => {
+        this.givingLinks = givingLinks || [];
+      });
+
+    Observable.merge(productLookupObservable, nextDrawDateObservable, suggestedAmountsObservable, givingLinksObservable)
       .subscribe(null,
         error => {
           this.errorLoading = true;
@@ -125,8 +131,14 @@ class ProductConfigFormController {
         },
         () => {
           this.analyticsFactory.giveGiftModal(this.code);
+          // Show givingLinks if they exist and it isn't an edit
+          if(this.givingLinks.length > 0 && !this.isEdit) {
+            this.showGivingLinks = true;
+            this.onStateChange({ state: 'givingLinks' });
+          } else {
+            this.onStateChange({ state: 'unsubmitted' });
+          }
           this.loading = false;
-          this.onStateChange({ state: 'unsubmitted' });
         });
   }
 
@@ -287,6 +299,15 @@ class ProductConfigFormController {
 
   suggestedAmount(amount) {
     return this.$filter('currency')(amount, '$', `${amount}`.indexOf('.') > -1 ? 2 : 0);
+  }
+
+  giveLink(url) {
+    if(typeof url === 'undefined') {
+      this.showGivingLinks = false;
+      this.onStateChange({state: 'unsubmitted'});
+    } else {
+      this.$window.location = url;
+    }
   }
 }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -36,7 +36,8 @@ describe( 'product config form component', function () {
       uri: 'uri',
       defaultFrequency: 'MON',
       updateQueryParam: jasmine.createSpy('updateQueryParam'),
-      onStateChange: jasmine.createSpy('onStateChange')
+      onStateChange: jasmine.createSpy('onStateChange'),
+      $window: {location: '/'}
     } );
   } ) );
 
@@ -103,9 +104,11 @@ describe( 'product config form component', function () {
       spyOn($ctrl.commonService, 'getNextDrawDate').and.returnValue(Observable.of('2016-10-02'));
 
       spyOn($ctrl.designationsService, 'suggestedAmounts').and.returnValue(Observable.of([ { amount: 5 }, { amount: 10 } ]));
+
+      spyOn($ctrl.designationsService, 'givingLinks').and.returnValue(Observable.of([]));
     });
 
-    it( 'should get productData, nextDrawDate, and suggestedAmounts', () => {
+    it( 'should get productData, nextDrawDate, suggestedAmounts and givingLinks', () => {
       $ctrl.loadData();
 
       expect( $ctrl.showRecipientComments ).toEqual(false);
@@ -121,6 +124,8 @@ describe( 'product config form component', function () {
 
       expect( $ctrl.suggestedAmounts ).toEqual([ { amount: 5 }, { amount: 10 } ]);
       expect( $ctrl.useSuggestedAmounts ).toEqual(true);
+
+      expect( $ctrl.givingLinks ).toEqual([]);
 
       expect( $ctrl.loading ).toEqual(false);
       expect( $ctrl.onStateChange ).toHaveBeenCalledWith({ state: 'unsubmitted' });
@@ -140,6 +145,16 @@ describe( 'product config form component', function () {
       expect( $ctrl.$log.error.logs[0] ).toEqual(['Error loading data for product config form', 'some error']);
       expect( $ctrl.loading ).toEqual(false);
     } );
+
+    it( 'should show givingLinks if present', () => {
+      $ctrl.designationsService.givingLinks.and.returnValue(Observable.of([{name: 'Name', url: 'http://example.com'}]));
+      $ctrl.loadData();
+      expect( $ctrl.givingLinks ).toEqual([{name: 'Name', url: 'http://example.com'}]);
+
+      expect( $ctrl.loading ).toEqual(false);
+      expect( $ctrl.showGivingLinks ).toEqual(true);
+      expect( $ctrl.onStateChange ).toHaveBeenCalledWith({ state: 'givingLinks' });
+    });
   } );
 
   describe( 'setDefaultAmount', () => {
@@ -453,6 +468,21 @@ describe( 'product config form component', function () {
       expect($ctrl.suggestedAmount(123.4)).toEqual('$123.40');
       expect($ctrl.suggestedAmount(123)).toEqual('$123');
       expect($ctrl.suggestedAmount(1234)).toEqual('$1,234');
+    });
+  });
+
+  describe('giveLink( url )', () => {
+    beforeEach(() => {
+      $ctrl.showGivingLinks = true;
+    });
+    it('should proceed to product config', () => {
+      $ctrl.giveLink();
+      expect($ctrl.showGivingLinks).toEqual(false);
+      expect($ctrl.onStateChange).toHaveBeenCalledWith({ state: 'unsubmitted' });
+    });
+    it('should navigate to other giving link', () => {
+      $ctrl.giveLink('https://example.com');
+      expect($ctrl.$window.location).toEqual('https://example.com');
     });
   });
 } );

--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -25,7 +25,7 @@
   <div class="panel panel-default panel-plain mt" ng-if="$ctrl.showGivingLinks">
     <div class="panel panel-default give-modal-panel">
       <h4 class="panel-title border-bottom-small" translate>
-        How would you like to give?
+        Through which country would you like to give?
       </h4>
       <div class="panel-body pt0">
         <div class="row">
@@ -33,13 +33,13 @@
             <button class="btn btn-block btn-primary"
                     type="button"
                     ng-click="$ctrl.giveLink()"
-                    translate>Continue giving at give.cru.org</button>
+                    translate>Give through US give site</button>
           </div>
           <div class="col-xs-6 col-xs-offset-3 pt-" ng-repeat="link in $ctrl.givingLinks">
             <button class="btn btn-block btn-default"
                     type="button"
                     ng-click="$ctrl.giveLink(link.url)"
-                    translate>{{link.name}}</button>
+                    translate>Give through {{link.name}} give site</button>
           </div>
         </div>
       </div>

--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -22,105 +22,129 @@
     <p translate>There was an error loading the details needed to configure your gift. You may <a href ng-click="$ctrl.loadData()">try again</a>. If you continue to experience issues, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
   </div>
 
-  <div class="panel panel-default panel-plain mt" ng-if="!$ctrl.loading && !$ctrl.errorLoading">
+  <div class="panel panel-default panel-plain mt" ng-if="$ctrl.showGivingLinks">
     <div class="panel panel-default give-modal-panel">
-
-      <div ng-if="$ctrl.errorChangingFrequency" class="alert alert-danger" role="alert">
-        <p translate>There was an error configuring the frequency of your gift. You may try changing the frequency again but if you continue to experience issues, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
-      </div>
-
-      <div ng-if="$ctrl.errorSavingGeneric" role="alert" class="alert alert-danger">
-        <p translate>There was an unknown error adding your gift to the cart. Please verify all your info and try again. If you are still seeing this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
-      </div>
-
-      <div ng-if="$ctrl.errorAlreadyInCart" class="alert alert-warning" role="alert">
-        <p translate>You already have this gift in your cart.</p>
-      </div>
-
       <h4 class="panel-title border-bottom-small" translate>
-        Gift Amount
+        How would you like to give?
       </h4>
       <div class="panel-body pt0">
-        <div ng-if="$ctrl.useSuggestedAmounts">
-          <div class="radio radio-custom-amount"
-               ng-repeat="suggested in $ctrl.suggestedAmounts | orderBy:'order'">
-            <label>
-              <input name="suggestedAmount"
-                     type="radio"
-                     ng-click="$ctrl.changeAmount(suggested.amount)"
-                     ng-checked="!$ctrl.customInputActive && $ctrl.itemConfig.amount === suggested.amount">
-              {{$ctrl.suggestedAmount(suggested.amount)}} {{suggested.label}}
-            </label>
+        <div class="row">
+          <div class="col-xs-6 col-xs-offset-3">
+            <button class="btn btn-block btn-primary"
+                    type="button"
+                    ng-click="$ctrl.giveLink()"
+                    translate>Continue giving at give.cru.org</button>
           </div>
-          <div class="radio radio-custom-amount form-inline" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">
-            <div class="form-group">
+          <div class="col-xs-6 col-xs-offset-3 pt-" ng-repeat="link in $ctrl.givingLinks">
+            <button class="btn btn-block btn-default"
+                    type="button"
+                    ng-click="$ctrl.giveLink(link.url)"
+                    translate>{{link.name}}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div ng-if="!$ctrl.loading && !$ctrl.errorLoading && !$ctrl.showGivingLinks">
+    <div class="panel panel-default panel-plain mt">
+
+        <div ng-if="$ctrl.errorChangingFrequency" class="alert alert-danger" role="alert">
+          <p translate>There was an error configuring the frequency of your gift. You may try changing the frequency again but if you continue to experience issues, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
+        </div>
+
+        <div ng-if="$ctrl.errorSavingGeneric" role="alert" class="alert alert-danger">
+          <p translate>There was an unknown error adding your gift to the cart. Please verify all your info and try again. If you are still seeing this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
+        </div>
+
+        <div ng-if="$ctrl.errorAlreadyInCart" class="alert alert-warning" role="alert">
+          <p translate>You already have this gift in your cart.</p>
+        </div>
+
+        <h4 class="panel-title border-bottom-small" translate>
+          Gift Amount
+        </h4>
+        <div class="panel-body pt0">
+          <div ng-if="$ctrl.useSuggestedAmounts">
+            <div class="radio radio-custom-amount"
+                 ng-repeat="suggested in $ctrl.suggestedAmounts | orderBy:'order'">
               <label>
                 <input name="suggestedAmount"
                        type="radio"
-                       ng-checked="$ctrl.customInputActive">
-                <input class="form-control form-control-subtle"
-                       name="amount"
-                       type="text"
-                       step="1"
-                       tabindex="-1"
-                       ng-model="$ctrl.customAmount"
-                       ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
-                       ng-focus="$ctrl.customInputActive = true;"
-                       ng-required="$ctrl.customInputActive"
-                       placeholder="{{'Other' | translate}}">
+                       ng-click="$ctrl.changeAmount(suggested.amount)"
+                       ng-checked="!$ctrl.customInputActive && $ctrl.itemConfig.amount === suggested.amount">
+                {{$ctrl.suggestedAmount(suggested.amount)}} {{suggested.label}}
               </label>
-              <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
-                   ng-if="($ctrl.itemConfigForm.amount | showErrors)">
-                <div class="help-block" ng-message="pattern" translate>Your gift must be a valid dollar amount</div>
-                <div class="help-block" ng-message="required" translate>Amount must be not empty</div>
-                <div class="help-block" ng-message="minimum" translate>Amount must be at least {{ 1 | currency }}</div>
-                <div class="help-block" ng-message="maximum" translate>
-                  Amount must be less than {{ 10000000 | currency }}
+            </div>
+            <div class="radio radio-custom-amount form-inline" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">
+              <div class="form-group">
+                <label>
+                  <input name="suggestedAmount"
+                         type="radio"
+                         ng-checked="$ctrl.customInputActive">
+                  <input class="form-control form-control-subtle"
+                         name="amount"
+                         type="text"
+                         step="1"
+                         tabindex="-1"
+                         ng-model="$ctrl.customAmount"
+                         ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
+                         ng-focus="$ctrl.customInputActive = true;"
+                         ng-required="$ctrl.customInputActive"
+                         placeholder="{{'Other' | translate}}">
+                </label>
+                <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
+                     ng-if="($ctrl.itemConfigForm.amount | showErrors)">
+                  <div class="help-block" ng-message="pattern" translate>Your gift must be a valid dollar amount</div>
+                  <div class="help-block" ng-message="required" translate>Amount must be not empty</div>
+                  <div class="help-block" ng-message="minimum" translate>Amount must be at least {{ 1 | currency }}</div>
+                  <div class="help-block" ng-message="maximum" translate>
+                    Amount must be less than {{ 10000000 | currency }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div data-toggle="buttons"
-             ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}"
-             ng-if="!$ctrl.useSuggestedAmounts">
-          <label class="btn btn-radio"
-                 ng-click="$ctrl.changeAmount(a)"
-                 ng-class="{'active': $ctrl.itemConfig.amount === a && !$ctrl.customInputActive}"
-                 ng-repeat-start="a in $ctrl.selectableAmounts">
-            <span class="number">${{a}}</span>
-          </label>
-          <span ng-repeat-end></span>
-          <label
-            ng-class="{active: $ctrl.customInputActive}"
-            class="btn btn-default-form u-textLeft custom-amount">
-            <div class="form-group form-group-default u-inline">
-              <input class="form-control form-control-subtle number"
-                     name="amount"
-                     type="text"
-                     step="1"
-                     ng-required="$ctrl.customInputActive"
-                     ng-model="$ctrl.customAmount"
-                     ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
-                     ng-focus="$ctrl.customInputActive = true;"
-                     tabindex="-1"
-                     placeholder="{{'Other' | translate}}"
-                     required>
-            </div>
-          </label>
-          <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
-               ng-if="($ctrl.itemConfigForm.amount | showErrors)">
-            <div class="help-block" ng-message="pattern" translate>Your gift must be a valid dollar amount</div>
-            <div class="help-block" ng-message="required" translate>Amount must be not empty</div>
-            <div class="help-block" ng-message="minimum" translate>Amount must be at least {{ 1 | currency }}</div>
-            <div class="help-block" ng-message="maximum" translate>
-              Amount must be less than {{ 10000000 | currency }}
+          <div data-toggle="buttons"
+               ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}"
+               ng-if="!$ctrl.useSuggestedAmounts">
+            <label class="btn btn-radio"
+                   ng-click="$ctrl.changeAmount(a)"
+                   ng-class="{'active': $ctrl.itemConfig.amount === a && !$ctrl.customInputActive}"
+                   ng-repeat-start="a in $ctrl.selectableAmounts">
+              <span class="number">${{a}}</span>
+            </label>
+            <span ng-repeat-end></span>
+            <label
+              ng-class="{active: $ctrl.customInputActive}"
+              class="btn btn-default-form u-textLeft custom-amount">
+              <div class="form-group form-group-default u-inline">
+                <input class="form-control form-control-subtle number"
+                       name="amount"
+                       type="text"
+                       step="1"
+                       ng-required="$ctrl.customInputActive"
+                       ng-model="$ctrl.customAmount"
+                       ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
+                       ng-focus="$ctrl.customInputActive = true;"
+                       tabindex="-1"
+                       placeholder="{{'Other' | translate}}"
+                       required>
+              </div>
+            </label>
+            <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
+                 ng-if="($ctrl.itemConfigForm.amount | showErrors)">
+              <div class="help-block" ng-message="pattern" translate>Your gift must be a valid dollar amount</div>
+              <div class="help-block" ng-message="required" translate>Amount must be not empty</div>
+              <div class="help-block" ng-message="minimum" translate>Amount must be at least {{ 1 | currency }}</div>
+              <div class="help-block" ng-message="maximum" translate>
+                Amount must be less than {{ 10000000 | currency }}
+              </div>
             </div>
           </div>
-        </div>
-      </div><!-- // panel-body -->
-    </div><!-- // panel -->
+        </div><!-- // panel-body -->
+      </div><!-- // panel -->
     <div class="panel panel-default give-modal-panel">
       <h4 class="panel-title border-bottom-small mt" translate>
         Gift Frequency

--- a/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
@@ -22,7 +22,7 @@
   <div class="container-fluid">
     <button class="btn btn-md btn-primary btn-block-xs pull-right"
             type="button"
-            ng-if="$ctrl.state !== 'errorAlreadyInCart'"
+            ng-if="$ctrl.state !== 'errorAlreadyInCart' && $ctrl.state != 'givingLinks'"
             tabindex="-1"
             ng-switch="$ctrl.isEdit"
             ng-click="$ctrl.submitted = true"

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import map from 'lodash/map';
 import toFinite from 'lodash/toFinite';
+import startsWith from 'lodash/startsWith';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
@@ -225,11 +226,13 @@ class DesignationsService {
           // Map giving links
           if (data.data['jcr:content'].givingLinks) {
             angular.forEach(data.data['jcr:content'].givingLinks, (v, k) => {
-              if (toFinite(k) > 0 || k.includes('item')) givingLinks.push({
-                name: v.name,
-                url: v.url,
-                order: toFinite(k) > 0 ? toFinite(k) : Number(k.substring(4))
-              });
+              if (toFinite(k) > 0 || startsWith(k, 'item')) {
+                givingLinks.push({
+                  name: v.name,
+                  url: v.url,
+                  order: toFinite(k) > 0 ? toFinite(k) : Number(k.substring(4))
+                });
+              }
             });
           }
         }

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -214,6 +214,28 @@ class DesignationsService {
         return data.data['jcr:content']['facebookPixelId'];
       });
   }
+
+  givingLinks(code) {
+    let c = code.split( '' ).slice( 0, 5 ).join( '/' ),
+      path = `/content/give/us/en/designations/${c}/${code}.infinity.json`;
+    return Observable.from(this.$http.get( this.envService.read('apiUrl') + path ))
+      .map( ( data ) => {
+        let givingLinks = [];
+        if ( data.data['jcr:content'] ) {
+          // Map giving links
+          if (data.data['jcr:content'].givingLinks) {
+            angular.forEach(data.data['jcr:content'].givingLinks, (v, k) => {
+              if (toFinite(k) > 0 || k.includes('item')) givingLinks.push({
+                name: v.name,
+                url: v.url,
+                order: toFinite(k) > 0 ? toFinite(k) : Number(k.substring(4))
+              });
+            });
+          }
+        }
+        return givingLinks;
+      });
+  }
 }
 
 export default angular

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -179,4 +179,18 @@ describe('designation service', () => {
       self.$httpBackend.flush();
     });
   });
+
+  describe('givingLinks', () => {
+    it('should load givingLinks from JCR', () => {
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/content/give/us/en/designations/0/1/2/3/4/0123456.infinity.json')
+        .respond(200, designationResponse);
+      self.designationsService.givingLinks('0123456')
+        .subscribe(givingLinks => {
+          expect(givingLinks).toEqual([
+            {name: 'Name', url: 'https://example.com', order: 0}
+            ]);
+        });
+      self.$httpBackend.flush();
+    });
+  });
 });

--- a/src/common/services/fixtures/designation.infinity.fixture.js
+++ b/src/common/services/fixtures/designation.infinity.fixture.js
@@ -13,6 +13,7 @@ export default {
     "cq:template":             "/apps/Give/templates/campaign",
     "secondaryPhoto":          "/content/dam/give/designations/0/1/2/3/4/0123456/CMS1_085319.jpg",
     "psText":                  "",
+    "givingLinks":             {"jcr:primaryType":"nt:unstructured","item0":{"jcr:primaryType":"nt:unstructured","url":"https://example.com","name":"Name"}},
     "organizationId":          "1-103-1",
     "parentDesignationNumber": "",
     "paragraphText":           "<p>Sample Text</p>",


### PR DESCRIPTION
This adds a "Personal Options" section to the designation editor that allows adding additional giving links for staff who raise support through multiple give sites (US / UK / France ...). https://jira.cru.org/browse/EP-2131

It also adds an interrupt in the productConfig modal to display the additional giving links to a donor when set. https://jira.cru.org/browse/EP-2129

Functionality is complete, but I'm still waiting on the final wording/layout of the components.