### PR TITLE
Deploy staging branch to give-stage2 and master to preprod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: "8"
 script:
   - yarn run test -- --single-run
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "dev" ]); then yarn run build; fi
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && ([ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "staging" ]); then yarn run build; fi
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 cache:
@@ -17,18 +17,18 @@ deploy:
   - provider: s3
     access_key_id: $AWS_KEY
     secret_access_key: $AWS_SECRET
-    bucket: cru-givedev
+    bucket: cru-givestage
     acl: public_read
     cache_control: "max-age=300"
     local-dir: dist
     skip_cleanup: true
     on:
-      branch: dev
+      branch: staging
 
   - provider: s3
     access_key_id: $AWS_KEY
     secret_access_key: $AWS_SECRET
-    bucket: cru-givestage
+    bucket: cru-givepreprod
     acl: public_read
     cache_control: "max-age=3600"
     local-dir: dist


### PR DESCRIPTION
This changes the travis deployment to deploy the staging branch to `cru-givestage` and the master branch to a new s3 bucket called `cru-givepreprod`. The Jenkins prod deployment will be updated to copy from preprod to prod.

This will allow us to test changes on staging without merging to master. master will now be representative of what is deployed to production give site.