### PR TITLE
Deploy branded-checkout.html to staging for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
   global:
     - AWS_KEY=AKIAI6YF75KDZNQJBFXA
     - secure: qOF4BXNkfWCOSqZ1X+HfeToxV2YxsAeFgdJD+aY39UU6LMG800XJIRlIFbDl6MDauFsYo3DMzxIxClqN5VNSV0/5x0Yrx0oMMEMl1WHO1AIJE0u3M18v70wROUW6O7Z4+eSkh9cAVAqpo2saAmaC7Vi2Jz1UlWbhTTd2CIKWSyKZgn6ZlzE8WC55gRtwwH4NlJixDSrwe/uReRdfvoH/WhWjpLxd1WeZGGpn2LuciciKc3Y0cc//vmz2E216OXmNW2veA8AU12BMPHi1PSaA10F8NxYnljmPOU2wAQDb4wHej0Hd9cQjz53365PJ8PpJNbZepYSjufEasdnW3fzO1TRbXi8TafuMcEKbs6k6ocVMyk8XMs0ZbLOavKnh+6Vhf++KAlWKKhXCdl2GQ2f/1B0uRHAH08ph4jREBK3AdBepZK/CeXL7Ti7+u9vFFC++sHtz1qFQpjv+k5Ip15KtbMDqfDASMDJdH2h3o/dLHpz9+tCE3fFMuRet/aRnsjJkULful83ywDlfDfX+79G/JJZum6gA/OCCFm8s8l+SEKz8zqMyYcYgEHyBad062GjYpZ6vWVv4gAgpQKLcICVsyoWt2OWNRv7AUn19bQgI1bxL/lFGjRlWBXrF0zQc4axC0VqoaHaq/Hcy7DnT7Ww9vjeBnLWEyu0DOFftpXNdC2Y=
+
+before_deploy:
+  - if [ "$TRAVIS_BRANCH" == "staging" ]; then mkdir -p dist; cp branded-checkout.html dist/index.html; fi
+
 deploy:
   - provider: s3
     access_key_id: $AWS_KEY

--- a/branded-checkout.html
+++ b/branded-checkout.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!-- This file gets deployed as `index.html` on staging branch for testing of branded-checkout -->
+<html lang="en" data-framework="angularjs">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <meta name="viewport" content="width = device-width, minimal-ui, initial-scale = 1, user-scalable = no" />
+  <title>Cru | Branded Checkout</title>
+  <link rel="stylesheet" href="branded-checkout.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
+</head>
+<body>
+
+<branded-checkout designation-number="2294554" ng-cloak ng-app="brandedCheckout"></branded-checkout>
+
+<script src="branded-checkout.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
@OzzieOrca pointed out that `cru-givedev` s3 bucket had a special index.html that allowed testing branded checkout. With the change to travis deployments, we no longer deploy to that bucket.

This adds a branded-checkout.html file that is deployed to `cru-givestage` bucket as index.html, allowing branded checkout to be tested in stage environment.