### PR TITLE
[#EP-2131] allow newsletter signup

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -156,12 +156,15 @@ class DesignationEditorController {
       resolve: {
         giveDomain: () => { return this.giveDomain },
         designationNumber: () => { return this.designationNumber },
-        givingLinks: () => { return this.designationContent.givingLinks }
+        designationType: () => { return this.designationContent.designationType },
+        givingLinks: () => { return this.designationContent.givingLinks },
+        showNewsletterForm: () => { return this.designationContent.showNewsletterForm }
       }
     }
     this.$uibModal.open(modalOptions).result
       .then((data) => {
         this.designationContent.givingLinks = data.givingLinks
+        this.designationContent.showNewsletterForm = data.showNewsletterForm
         this.save()
       }, angular.noop)
   }

--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -157,6 +157,7 @@ class DesignationEditorController {
         giveDomain: () => { return this.giveDomain },
         designationNumber: () => { return this.designationNumber },
         designationType: () => { return this.designationContent.designationType },
+        hasNewsletter: this.designationEditorService.hasNewsletter(this.designationNumber),
         givingLinks: () => { return this.designationContent.givingLinks },
         showNewsletterForm: () => { return this.designationContent.showNewsletterForm }
       }

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -234,9 +234,10 @@ describe('Designation Editor', function () {
       beforeEach(inject((_$q_) => {
         modalPromise = _$q_.defer()
         jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: modalPromise.promise })
+        jest.spyOn($ctrl.designationEditorService, 'hasNewsletter').mockResolvedValue(true)
       }))
 
-      it('should open modal', () => {
+      it('should open modal', async () => {
         $ctrl.designationNumber = '000555'
         $ctrl.giveDomain = 'https://give.example.com'
         $ctrl.designationContent = designationSecurityResponse
@@ -247,6 +248,7 @@ describe('Designation Editor', function () {
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.designationNumber()).toEqual(designationSecurityResponse.designationNumber)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.giveDomain()).toEqual($ctrl.giveDomain)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.designationType()).toEqual(designationSecurityResponse.designationType)
+        await expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.hasNewsletter).resolves.toBe(true)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.givingLinks()).toEqual(designationSecurityResponse.givingLinks)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.showNewsletterForm()).toEqual(designationSecurityResponse.showNewsletterForm)
 

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -38,7 +38,8 @@ const designationSecurityResponse = {
   secondaryMiddleName: '',
   secondaryLastName: '',
   secondaryMaidenName: '',
-  secondarySuffix: ''
+  secondarySuffix: '',
+  showNewsletterForm: true
 }
 
 describe('Designation Editor', function () {
@@ -245,14 +246,18 @@ describe('Designation Editor', function () {
         expect($ctrl.$uibModal.open).toHaveBeenCalled()
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.designationNumber()).toEqual(designationSecurityResponse.designationNumber)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.giveDomain()).toEqual($ctrl.giveDomain)
+        expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.designationType()).toEqual(designationSecurityResponse.designationType)
         expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.givingLinks()).toEqual(designationSecurityResponse.givingLinks)
+        expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.showNewsletterForm()).toEqual(designationSecurityResponse.showNewsletterForm)
 
         modalPromise.resolve({
-          givingLinks: []
+          givingLinks: [],
+          showNewsletterForm: false
         })
         $rootScope.$digest()
 
         expect($ctrl.designationContent.suggestedAmounts).toEqual([])
+        expect($ctrl.designationContent.showNewsletterForm).toEqual(false)
       })
     })
 

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
@@ -6,11 +6,13 @@ const controllerName = 'personalOptionsCtrl'
 
 class ModalInstanceCtrl {
   /* @ngInject */
-  constructor (designationNumber, designationType, giveDomain, givingLinks, showNewsletterForm) {
+  constructor ($scope, designationNumber, designationType, giveDomain, hasNewsletter, givingLinks, showNewsletterForm) {
+    this.$scope = $scope
     this.designationNumber = designationNumber
     this.designationType = designationType
     this.giveDomain = giveDomain
     this.showNewsletterForm = showNewsletterForm
+    this.hasNewsletter = hasNewsletter
 
     this.givingLinks = transform(givingLinks, (result, value, key) => {
       if (key === 'jcr:primaryType') { return }
@@ -30,6 +32,13 @@ class ModalInstanceCtrl {
       delete value.order
       result[i + 1] = value
     }, {})
+  }
+
+  saveChanges () {
+    this.$scope.$close({
+      givingLinks: this.transformGivingLinks(),
+      showNewsletterForm: this.showNewsletterForm
+    })
   }
 }
 

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
@@ -6,9 +6,11 @@ const controllerName = 'personalOptionsCtrl'
 
 class ModalInstanceCtrl {
   /* @ngInject */
-  constructor (designationNumber, giveDomain, givingLinks) {
+  constructor (designationNumber, designationType, giveDomain, givingLinks, showNewsletterForm) {
     this.designationNumber = designationNumber
+    this.designationType = designationType
     this.giveDomain = giveDomain
+    this.showNewsletterForm = showNewsletterForm
 
     this.givingLinks = transform(givingLinks, (result, value, key) => {
       if (key === 'jcr:primaryType') { return }
@@ -19,6 +21,8 @@ class ModalInstanceCtrl {
       })
     }, [])
     this.givingLinks = sortBy(this.givingLinks, 'order')
+
+    this.tab = 'newsletter'
   }
 
   transformGivingLinks () {

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
@@ -11,10 +11,13 @@ describe('Designation Editor Personal Options', function () {
 
     $ctrl = $controller(module.name, {
       designationNumber: '000555',
+      designationType: 'Staff',
       giveDomain: 'https://give.cru.org',
-      givingLinks: { 'jcr:primaryType': 'nt:unstructured',
+      givingLinks: {
+        'jcr:primaryType': 'nt:unstructured',
         1: { 'jcr:primaryType': 'nt:unstructured', url: 'https://example.com', name: 'Name' }
       },
+      showNewsletterForm: true,
       $scope: $scope
     })
   }))
@@ -25,7 +28,9 @@ describe('Designation Editor Personal Options', function () {
 
   it('to define modal resolves', function () {
     expect($ctrl.designationNumber).toEqual('000555')
+    expect($ctrl.designationType).toEqual('Staff')
     expect($ctrl.givingLinks).toEqual([{ name: 'Name', url: 'https://example.com', order: 1 }])
+    expect($ctrl.showNewsletterForm).toEqual(true)
   })
 
   it('transforms giving links', function () {

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
@@ -7,7 +7,7 @@ describe('Designation Editor Personal Options', function () {
   var $ctrl
 
   beforeEach(inject(function ($rootScope, $controller) {
-    var $scope = $rootScope.$new()
+    const $scope = $rootScope.$new()
 
     $ctrl = $controller(module.name, {
       designationNumber: '000555',
@@ -18,8 +18,10 @@ describe('Designation Editor Personal Options', function () {
         1: { 'jcr:primaryType': 'nt:unstructured', url: 'https://example.com', name: 'Name' }
       },
       showNewsletterForm: true,
+      hasNewsletter: true,
       $scope: $scope
     })
+    $scope.$close = jest.fn()
   }))
 
   it('to be defined', function () {
@@ -36,6 +38,17 @@ describe('Designation Editor Personal Options', function () {
   it('transforms giving links', function () {
     expect($ctrl.transformGivingLinks()).toEqual({
       1: { name: 'Name', url: 'https://example.com' }
+    })
+  })
+
+  describe('saveChanges()', () => {
+    it('should close modal and provide updated properties', () => {
+      $ctrl.showNewsletterForm = false
+      $ctrl.saveChanges()
+      expect($ctrl.$scope.$close).toHaveBeenCalledWith({
+        givingLinks: { 1: { name: 'Name', url: 'https://example.com' } },
+        showNewsletterForm: false
+      })
     })
   })
 })

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -1,9 +1,13 @@
 <div class="modal-body">
   <form name="personalForm">
     <!-- Nav tabs -->
-    <ul class="nav nav-tabs" ng-init="$ctrl.tab = 'givingLinks'">
+    <ul class="nav nav-tabs">
       <li ng-class="{'active': $ctrl.tab === 'givingLinks'}">
-        <a href="" ng-click="$ctrl.tab = 'givingLinks'">
+        <a href="" ng-click="$ctrl.tab = 'newsletter'">
+          Newsletter <span class="xs-hide">Form</span>
+        </a>
+        <a href="" ng-click="$ctrl.tab = 'givingLinks'"
+           ng-if="$ctrl.designationType === 'National Staff'">
           Giving Links
         </a>
       </li>
@@ -11,7 +15,9 @@
 
     <!-- Tab panes -->
     <div class="tab-content">
-      <div class="tab-pane active" ng-if="$ctrl.tab === 'givingLinks'">
+      <div class="tab-pane"
+           ng-class="{active: $ctrl.tab === 'givingLinks'}"
+           ng-if="$ctrl.tab === 'givingLinks' && $ctrl.designationType === 'National Staff'">
         <div class="form-group">
           <span class="help-block">Setup additional country giving links.</span>
         </div>
@@ -65,7 +71,15 @@
           </tfoot>
         </table>
       </div>
-
+      <div class="tab-pane"
+           ng-class="{active: $ctrl.tab === 'newsletter'}"
+           ng-if="$ctrl.tab === 'newsletter'">
+        <div class="form-group">
+          <label>
+            <input type="checkbox" ng-checked="$ctrl.showNewsletterForm" /> Display Newsletter Sign Up Form.
+          </label>
+        </div>
+      </div>
     </div>
   </form>
 </div>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -6,8 +6,7 @@
         <a href="" ng-click="$ctrl.tab = 'newsletter'">
           MPDX Newsletter <span class="xs-hide">Form</span>
         </a>
-        <a href="" ng-click="$ctrl.tab = 'givingLinks'"
-           ng-if="$ctrl.designationType === 'National Staff'">
+        <a href="" ng-click="$ctrl.tab = 'givingLinks'">
           Giving Links
         </a>
       </li>
@@ -17,7 +16,7 @@
     <div class="tab-content">
       <div class="tab-pane"
            ng-class="{active: $ctrl.tab === 'givingLinks'}"
-           ng-if="$ctrl.tab === 'givingLinks' && $ctrl.designationType === 'National Staff'">
+           ng-if="$ctrl.tab === 'givingLinks'">
         <div class="form-group">
           <span class="help-block">Setup additional country giving links.</span>
         </div>
@@ -84,7 +83,7 @@
         </div>
         <div class="form-group">
           <h6 ng-if="$ctrl.hasNewsletter">This form will allow donors to subscribe to your MPDX newsletter.</h6>
-          <h6 ng-if="!$ctrl.hasNewsletter">This option is disabled because you do not have an MPDX account. To sign up for one, visit <a href="mpdx.org" target="_blank">mpdx.org</a>.</h6>
+          <h6 ng-if="!$ctrl.hasNewsletter">This option is disabled because you do not have an MPDX account. To sign up for one, visit <a href="https://mpdx.org" target="_blank">mpdx.org</a>.</h6>
         </div>
       </div>
     </div>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -4,7 +4,7 @@
     <ul class="nav nav-tabs">
       <li ng-class="{'active': $ctrl.tab === 'givingLinks'}">
         <a href="" ng-click="$ctrl.tab = 'newsletter'">
-          Newsletter <span class="xs-hide">Form</span>
+          MPDX Newsletter <span class="xs-hide">Form</span>
         </a>
         <a href="" ng-click="$ctrl.tab = 'givingLinks'"
            ng-if="$ctrl.designationType === 'National Staff'">
@@ -76,8 +76,13 @@
            ng-if="$ctrl.tab === 'newsletter'">
         <div class="form-group">
           <label>
-            <input type="checkbox" ng-checked="$ctrl.showNewsletterForm" /> Display Newsletter Sign Up Form.
+            <input type="checkbox"
+                   ng-disabled="!$ctrl.hasNewsletter"
+                   ng-checked="$ctrl.showNewsletterForm" /> Display Newsletter Form?
           </label>
+        </div>
+        <div class="form-group">
+          <span class="help-block">This option will be disabled if your designation number is not active in MPDX.</span>
         </div>
       </div>
     </div>
@@ -87,9 +92,7 @@
   <button id="saveChangesButton"
           type="button"
           class="btn btn-primary pull-right"
-          ng-click="$close({
-            givingLinks: $ctrl.transformGivingLinks()
-          })"
+          ng-click="$ctrl.saveChanges()"
           ng-disabled="!personalForm.$valid">
     Save &amp; Close
   </button>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -83,7 +83,8 @@
           </label>
         </div>
         <div class="form-group">
-          <span class="help-block">This option will be disabled if your designation number is not active in MPDX.</span>
+          <h6 ng-if="$ctrl.hasNewsletter">This form will allow donors to subscribe to your MPDX newsletter.</h6>
+          <h6 ng-if="!$ctrl.hasNewsletter">This option is disabled because you do not have an MPDX account. To sign up for one, visit <a href="mpdx.org" target="_blank">mpdx.org</a>.</h6>
         </div>
       </div>
     </div>

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -78,7 +78,8 @@
           <label>
             <input type="checkbox"
                    ng-disabled="!$ctrl.hasNewsletter"
-                   ng-checked="$ctrl.showNewsletterForm" /> Display Newsletter Form?
+                   ng-checked="$ctrl.showNewsletterForm"
+                   ng-model="$ctrl.showNewsletterForm"/> Display Newsletter Form?
           </label>
         </div>
         <div class="form-group">

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
@@ -3,21 +3,19 @@ import designationEditorService from 'common/services/api/designationEditor.serv
 import loading from 'common/components/loading/loading.component'
 import addressForm from 'common/components/addressForm/addressForm.component'
 import forEach from 'lodash/forEach'
+import map from 'lodash/map'
+import compact from 'lodash/compact'
 
 import './newsletterModal.scss'
 
 const controllerName = 'newsletterModal'
-
 const addressPropertyMap = {
   country: 'country',
-  streetAddress: 'street',
-  extendedAddress: 'street2',
-  intAddressLine3: 'street3',
-  intAddressLine4: 'street4',
   locality: 'city',
   postalCode: 'postal_code',
   region: 'state'
 }
+const streetFields = ['streetAddress', 'extendedAddress', 'intAddressLine3', 'intAddressLine4']
 
 class NewsletterModalController {
   /* @ngInject */
@@ -39,10 +37,12 @@ class NewsletterModalController {
     if (this.step === 2) {
       this.progress = true
 
-      // Map address properties to attributes properties
-      forEach(this.address, (value, key) => {
-        this.attributes[addressPropertyMap[key]] = value
+      forEach(addressPropertyMap, (value, key) => {
+        this.attributes[value] = this.address[key]
       })
+
+      // Concatenate all defined street fields
+      this.attributes['street'] = compact(map(streetFields, key => this.address[key])).join(`\n`)
 
       this.designationEditorService.subscribeToNewsletter(this.designationNumber, this.attributes).then(() => {
         this.success = true
@@ -52,6 +52,7 @@ class NewsletterModalController {
         forEach(addressPropertyMap, (value) => {
           delete this.attributes[value]
         })
+        delete this.attributes['street']
       }).finally(() => {
         this.step = 3
         this.progress = false

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
@@ -1,0 +1,59 @@
+import angular from 'angular'
+import designationEditorService from 'common/services/api/designationEditor.service'
+import loading from 'common/components/loading/loading.component'
+
+import './newsletterModal.scss'
+
+const controllerName = 'newsletterModal'
+
+class NewsletterModalController {
+  /* @ngInject */
+  constructor (designationEditorService, designationNumber, displayName) {
+    this.designationEditorService = designationEditorService
+    this.designationNumber = designationNumber
+    this.displayName = displayName
+
+    this.step = 1
+    this.attributes = {
+      send_newsletter: 'Email'
+    }
+  }
+
+  next () {
+    if (this.step === 2) {
+      this.progress = true
+      this.designationEditorService.subscribeToNewsletter(this.designationNumber, this.attributes).then(() => {
+        // TODO: Handle success and failure
+        // Success
+        this.success = true
+      }, error => {
+        this.error = error
+      }).finally(() => {
+        this.step = 3
+        this.progress = false
+      })
+    } else {
+      this.step++
+    }
+  }
+
+  prev () {
+    this.step--
+    this.error = false
+  }
+
+  get includeEmailField () {
+    return ['Email', 'Both'].includes(this.attributes.send_newsletter)
+  }
+
+  get includeAddressFields () {
+    return ['Physical', 'Both'].includes(this.attributes.send_newsletter)
+  }
+}
+
+export default angular
+  .module(controllerName, [
+    designationEditorService.name,
+    loading.name
+  ])
+  .controller(controllerName, NewsletterModalController)

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.js
@@ -1,10 +1,23 @@
 import angular from 'angular'
 import designationEditorService from 'common/services/api/designationEditor.service'
 import loading from 'common/components/loading/loading.component'
+import addressForm from 'common/components/addressForm/addressForm.component'
+import forEach from 'lodash/forEach'
 
 import './newsletterModal.scss'
 
 const controllerName = 'newsletterModal'
+
+const addressPropertyMap = {
+  country: 'country',
+  streetAddress: 'street',
+  extendedAddress: 'street2',
+  intAddressLine3: 'street3',
+  intAddressLine4: 'street4',
+  locality: 'city',
+  postalCode: 'postal_code',
+  region: 'state'
+}
 
 class NewsletterModalController {
   /* @ngInject */
@@ -17,17 +30,28 @@ class NewsletterModalController {
     this.attributes = {
       send_newsletter: 'Email'
     }
+    this.address = {
+      country: 'US'
+    }
   }
 
   next () {
     if (this.step === 2) {
       this.progress = true
+
+      // Map address properties to attributes properties
+      forEach(this.address, (value, key) => {
+        this.attributes[addressPropertyMap[key]] = value
+      })
+
       this.designationEditorService.subscribeToNewsletter(this.designationNumber, this.attributes).then(() => {
-        // TODO: Handle success and failure
-        // Success
         this.success = true
       }, error => {
         this.error = error
+        // Remove attributes keys on error, they will be rewritten on subsequent submits.
+        forEach(addressPropertyMap, (value) => {
+          delete this.attributes[value]
+        })
       }).finally(() => {
         this.step = 3
         this.progress = false
@@ -54,6 +78,7 @@ class NewsletterModalController {
 export default angular
   .module(controllerName, [
     designationEditorService.name,
-    loading.name
+    loading.name,
+    addressForm.name
   ])
   .controller(controllerName, NewsletterModalController)

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
@@ -25,6 +25,9 @@ describe('NewsletterModalController', function () {
     expect($ctrl.attributes).toEqual({
       send_newsletter: 'Email'
     })
+    expect($ctrl.address).toEqual({
+      country: 'US'
+    })
   })
 
   describe('get includeEmailField', () => {
@@ -76,6 +79,15 @@ describe('NewsletterModalController', function () {
       let newsletterPromise
       beforeEach(inject((_$q_) => {
         newsletterPromise = _$q_.defer()
+        $ctrl.address = {
+          country: 'country',
+          streetAddress: 'street',
+          extendedAddress: 'street2',
+          intAddressLine3: 'street3',
+          locality: 'city',
+          postalCode: 'zip',
+          region: 'state'
+        }
       }))
 
       it('subscribes to newsletter', () => {
@@ -83,7 +95,16 @@ describe('NewsletterModalController', function () {
         $ctrl.step = 2
         $ctrl.next()
         expect($ctrl.progress).toEqual(true)
-        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, $ctrl.attributes)
+        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, {
+          send_newsletter: 'Email',
+          country: 'country',
+          street: 'street',
+          street2: 'street2',
+          street3: 'street3',
+          city: 'city',
+          postal_code: 'zip',
+          state: 'state'
+        })
 
         newsletterPromise.resolve({})
         $rootScope.$digest()
@@ -98,7 +119,9 @@ describe('NewsletterModalController', function () {
         $ctrl.step = 2
         $ctrl.next()
         expect($ctrl.progress).toEqual(true)
-        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, $ctrl.attributes)
+        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, expect.objectContaining({
+          send_newsletter: 'Email'
+        }))
 
         newsletterPromise.reject(new Error('error'))
         $rootScope.$digest()
@@ -107,6 +130,7 @@ describe('NewsletterModalController', function () {
         expect($ctrl.progress).toBe(false)
         expect($ctrl.step).toEqual(3)
         expect($ctrl.error).toBeInstanceOf(Error)
+        expect($ctrl.attributes).toEqual({ send_newsletter: 'Email' })
       })
     })
   })

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
@@ -1,0 +1,113 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './newsletter.modal'
+
+describe('NewsletterModalController', function () {
+  beforeEach(angular.mock.module(module.name))
+  let $ctrl, $rootScope
+
+  beforeEach(inject(function (_$rootScope_, $controller) {
+    $rootScope = _$rootScope_
+
+    $ctrl = $controller(module.name, {
+      designationNumber: '0123456',
+      displayName: 'Rev. Mortimer and Gertrude Tuttle',
+      $scope: $rootScope.$new()
+    })
+  }))
+
+  it('to be defined', function () {
+    expect($ctrl).toBeDefined()
+    expect($ctrl.designationEditorService).toBeDefined()
+    expect($ctrl.designationNumber).toEqual('0123456')
+    expect($ctrl.displayName).toEqual('Rev. Mortimer and Gertrude Tuttle')
+    expect($ctrl.step).toEqual(1)
+    expect($ctrl.attributes).toEqual({
+      send_newsletter: 'Email'
+    })
+  })
+
+  describe('get includeEmailField', () => {
+    it('should be true if send_newsletter includes Email option', () => {
+      $ctrl.attributes.send_newsletter = 'Email'
+      expect($ctrl.includeEmailField).toEqual(true)
+      $ctrl.attributes.send_newsletter = 'Both'
+      expect($ctrl.includeEmailField).toEqual(true)
+    })
+
+    it('should be false if send_newsletter excludes Email option', () => {
+      $ctrl.attributes.send_newsletter = 'Physical'
+      expect($ctrl.includeEmailField).toEqual(false)
+    })
+  })
+
+  describe('get includeAddressFields', () => {
+    it('should be true if send_newsletter includes Physical option', () => {
+      $ctrl.attributes.send_newsletter = 'Physical'
+      expect($ctrl.includeAddressFields).toEqual(true)
+      $ctrl.attributes.send_newsletter = 'Both'
+      expect($ctrl.includeAddressFields).toEqual(true)
+    })
+
+    it('should be false if send_newsletter excludes Physical option', () => {
+      $ctrl.attributes.send_newsletter = 'Email'
+      expect($ctrl.includeAddressFields).toEqual(false)
+    })
+  })
+
+  describe('prev()', () => {
+    it('should go to previous step', () => {
+      $ctrl.step = 3
+      $ctrl.error = {}
+      $ctrl.prev()
+      expect($ctrl.step).toEqual(2)
+      expect($ctrl.error).toBe(false)
+    })
+  })
+
+  describe('next()', () => {
+    it('proceeds to next step if step < 2', () => {
+      $ctrl.step = 1
+      $ctrl.next()
+      expect($ctrl.step).toEqual(2)
+    })
+
+    describe('step == 2', () => {
+      let newsletterPromise
+      beforeEach(inject((_$q_) => {
+        newsletterPromise = _$q_.defer()
+      }))
+
+      it('subscribes to newsletter', () => {
+        jest.spyOn($ctrl.designationEditorService, 'subscribeToNewsletter').mockReturnValue(newsletterPromise.promise)
+        $ctrl.step = 2
+        $ctrl.next()
+        expect($ctrl.progress).toEqual(true)
+        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, $ctrl.attributes)
+
+        newsletterPromise.resolve({})
+        $rootScope.$digest()
+
+        expect($ctrl.success).toBe(true)
+        expect($ctrl.progress).toBe(false)
+        expect($ctrl.step).toEqual(3)
+      })
+
+      it('sets an error on failure', () => {
+        jest.spyOn($ctrl.designationEditorService, 'subscribeToNewsletter').mockReturnValue(newsletterPromise.promise)
+        $ctrl.step = 2
+        $ctrl.next()
+        expect($ctrl.progress).toEqual(true)
+        expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, $ctrl.attributes)
+
+        newsletterPromise.reject(new Error('error'))
+        $rootScope.$digest()
+
+        expect($ctrl.success).toBeFalsy()
+        expect($ctrl.progress).toBe(false)
+        expect($ctrl.step).toEqual(3)
+        expect($ctrl.error).toBeInstanceOf(Error)
+      })
+    })
+  })
+})

--- a/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
+++ b/src/app/newsletterSubscription/newsletterModal/newsletter.modal.spec.js
@@ -85,8 +85,7 @@ describe('NewsletterModalController', function () {
           extendedAddress: 'street2',
           intAddressLine3: 'street3',
           locality: 'city',
-          postalCode: 'zip',
-          region: 'state'
+          postalCode: 'zip'
         }
       }))
 
@@ -98,12 +97,9 @@ describe('NewsletterModalController', function () {
         expect($ctrl.designationEditorService.subscribeToNewsletter).toHaveBeenCalledWith($ctrl.designationNumber, {
           send_newsletter: 'Email',
           country: 'country',
-          street: 'street',
-          street2: 'street2',
-          street3: 'street3',
+          street: `street\nstreet2\nstreet3`,
           city: 'city',
-          postal_code: 'zip',
-          state: 'state'
+          postal_code: 'zip'
         })
 
         newsletterPromise.resolve({})

--- a/src/app/newsletterSubscription/newsletterModal/newsletterModal.scss
+++ b/src/app/newsletterSubscription/newsletterModal/newsletterModal.scss
@@ -1,0 +1,42 @@
+.newsletter-modal {
+  .modal-progress {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    .badge {
+      padding: 10px 13px;
+      border-radius: 17px;
+      &.active {
+        background-color: #f8ae0c;
+      }
+    }
+    .spanner {
+      flex-grow: 3;
+      margin: 13px;
+      border: 3px solid #777;
+      border-radius: 3px;
+      &.active {
+        border-color: #f8ae0c;
+      }
+    }
+  }
+
+  .modal-navigation {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+
+    .left {
+      align-self: flex-start;
+    }
+  }
+
+  h6 {
+    text-align: center;
+  }
+
+  .jumbotron {
+    text-align: center;
+    padding: 20px;
+  }
+}

--- a/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
+++ b/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
@@ -58,48 +58,12 @@
                type="email"
                class="form-control"
                ng-model="$ctrl.attributes.email"
-               required>
+               required />
       </div>
 
-      <div class="form-group" ng-if="$ctrl.includeAddressFields">
-        <label for="nmStreet">Street Address</label>
-        <input name="street"
-               id="nmStreet"
-               type="text"
-               class="form-control"
-               ng-model="$ctrl.attributes.street"
-               required>
-      </div>
-
-      <div class="form-group" ng-if="$ctrl.includeAddressFields">
-        <label for="nmCity">City</label>
-        <input name="city"
-               id="nmCity"
-               type="text"
-               class="form-control"
-               ng-model="$ctrl.attributes.city"
-               required>
-      </div>
-
-      <div class="form-group" ng-if="$ctrl.includeAddressFields">
-        <label for="nmState">State</label>
-        <input name="state"
-               id="nmState"
-               type="text"
-               class="form-control"
-               ng-model="$ctrl.attributes.state"
-               required>
-      </div>
-
-      <div class="form-group" ng-if="$ctrl.includeAddressFields">
-        <label for="nmPostalCode">Postal Code</label>
-        <input name="postal_code"
-               id="nmPostalCode"
-               type="text"
-               class="form-control"
-               ng-model="$ctrl.attributes.postal_code"
-               required>
-      </div>
+      <address-form ng-if="$ctrl.includeAddressFields"
+                    parent-form="$ctrl.detailsForm"
+                    address="$ctrl.address"></address-form>
 
     </div>
     <div ng-switch-when="3">

--- a/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
+++ b/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
@@ -51,7 +51,7 @@
       <div>
         <h6>Sign-up to the Newsletter of {{$ctrl.displayName}}.</h6>
       </div>
-      <div class="form-group" ng-if="$ctrl.includeEmailField">
+      <div class="form-group">
         <label for="nmEmail">Email Address</label>
         <input name="email"
                id="nmEmail"

--- a/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
+++ b/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
@@ -1,0 +1,134 @@
+<div class="newsletter-modal">
+  <div class="modal-header">
+    <div class="modal-progress">
+      <span class="badge active">1</span>
+      <div class="spanner" ng-class="{active: $ctrl.step > 1}"></div>
+      <span class="badge" ng-class="{active: $ctrl.step > 1}">2</span>
+      <div class="spanner" ng-class="{active: $ctrl.step > 2}"></div>
+      <span class="badge" ng-class="{active: $ctrl.step > 2}">3</span>
+    </div>
+  </div>
+  <div class="modal-body" ng-switch="$ctrl.step">
+    <div ng-form="$ctrl.identityForm" ng-switch-when="1">
+      <div>
+        <h6>Sign-up to the Newsletter of {{$ctrl.displayName}}.</h6>
+      </div>
+      <div class="form-group">
+        <label for="nmFirstName">First Name</label>
+        <input name="firstName"
+               id="nmFirstName"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.first_name"
+               required>
+      </div>
+
+      <div class="form-group">
+        <label for="nmLastName">Last Name</label>
+        <input name="lastName"
+               id="nmLastName"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.last_name"
+               required>
+      </div>
+
+      <div class="form-group">
+        <label for="nmSendNewletter" translate>Newsletter Preference</label>
+        <select name="sendNewletter"
+                id="nmSendNewletter"
+                class="form-control"
+                ng-model="$ctrl.attributes.send_newsletter"
+                required>
+          <option value="Email">Email</option>
+          <option value="Physical">Physical</option>
+          <option value="Both">Both</option>
+        </select>
+      </div>
+    </div>
+    <div ng-form="$ctrl.detailsForm" ng-switch-when="2">
+      <loading type="overlay" ng-if="$ctrl.progress"/>
+      <div>
+        <h6>Sign-up to the Newsletter of {{$ctrl.displayName}}.</h6>
+      </div>
+      <div class="form-group" ng-if="$ctrl.includeEmailField">
+        <label for="nmEmail">Email Address</label>
+        <input name="email"
+               id="nmEmail"
+               type="email"
+               class="form-control"
+               ng-model="$ctrl.attributes.email"
+               required>
+      </div>
+
+      <div class="form-group" ng-if="$ctrl.includeAddressFields">
+        <label for="nmStreet">Street Address</label>
+        <input name="street"
+               id="nmStreet"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.street"
+               required>
+      </div>
+
+      <div class="form-group" ng-if="$ctrl.includeAddressFields">
+        <label for="nmCity">City</label>
+        <input name="city"
+               id="nmCity"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.city"
+               required>
+      </div>
+
+      <div class="form-group" ng-if="$ctrl.includeAddressFields">
+        <label for="nmState">State</label>
+        <input name="state"
+               id="nmState"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.state"
+               required>
+      </div>
+
+      <div class="form-group" ng-if="$ctrl.includeAddressFields">
+        <label for="nmPostalCode">Postal Code</label>
+        <input name="postal_code"
+               id="nmPostalCode"
+               type="text"
+               class="form-control"
+               ng-model="$ctrl.attributes.postal_code"
+               required>
+      </div>
+
+    </div>
+    <div ng-switch-when="3">
+      <div class="jumbotron" ng-if="$ctrl.success">
+        <h1>Congratulations!</h1>
+        <p>You've successfully signed up to receive the newsletter of {{$ctrl.displayName}}.</p>
+        <p>
+          <button type="button" class="btn btn-primary btn-lg" ng-click="$dismiss()">Close</button>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button"
+            class="btn btn-default"
+            ng-click="$dismiss()"
+            translate>Cancel
+    </button>
+    <div class="modal-navigation pull-right" ng-if="!$ctrl.success">
+      <button type="button"
+              class="btn btn-secondary"
+              ng-disabled="$ctrl.step == 1 || $ctrl.progress"
+              ng-click="$ctrl.prev()">Back
+      </button>
+      <button type="button"
+              class="btn btn-primary"
+              ng-disabled="($ctrl.step == 1 && !$ctrl.identityForm.$valid) || ($ctrl.step == 2 && !$ctrl.detailsForm.$valid) || $ctrl.progress || $ctrl.error"
+              ng-click="$ctrl.next()">Next
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
+++ b/src/app/newsletterSubscription/newsletterModal/newsletterModal.tpl.html
@@ -110,6 +110,10 @@
           <button type="button" class="btn btn-primary btn-lg" ng-click="$dismiss()">Close</button>
         </p>
       </div>
+      <div ng-if="$ctrl.error">
+        <h5>Something went wrong with your request.</h5>
+        <p>Check that the information you've entered is correct. If the problem persists, please contact <a href="mailto:apps@cru.org">apps@cru.org</a> for assistance.</p>
+      </div>
     </div>
   </div>
   <div class="modal-footer">

--- a/src/app/newsletterSubscription/newsletterSubscription.component.js
+++ b/src/app/newsletterSubscription/newsletterSubscription.component.js
@@ -1,4 +1,5 @@
 import angular from 'angular'
+import uibModal from 'angular-ui-bootstrap/src/modal'
 import template from './newsletterSubscription.tpl.html'
 import commonModule from 'common/common.module'
 
@@ -30,7 +31,7 @@ export default angular
   .module(componentName, [
     commonModule.name,
     newsletterModalController.name,
-    'ui.bootstrap'
+    uibModal
   ])
   .component(componentName, {
     controller: NewsletterSubscriptionController,

--- a/src/app/newsletterSubscription/newsletterSubscription.component.js
+++ b/src/app/newsletterSubscription/newsletterSubscription.component.js
@@ -1,0 +1,42 @@
+import angular from 'angular'
+import template from './newsletterSubscription.tpl.html'
+import commonModule from 'common/common.module'
+
+import newsletterModalController from './newsletterModal/newsletter.modal'
+import newsletterModalTemplate from './newsletterModal/newsletterModal.tpl.html'
+
+const componentName = 'newsletterSubscription'
+
+class NewsletterSubscriptionController {
+  /* @ngInject */
+  constructor ($uibModal) {
+    this.$uibModal = $uibModal
+  }
+
+  openNewsletterModal () {
+    this.$uibModal.open({
+      templateUrl: newsletterModalTemplate,
+      controller: newsletterModalController.name,
+      controllerAs: '$ctrl',
+      resolve: {
+        designationNumber: () => this.designationNumber,
+        displayName: () => this.displayName
+      }
+    })
+  }
+}
+
+export default angular
+  .module(componentName, [
+    commonModule.name,
+    newsletterModalController.name,
+    'ui.bootstrap'
+  ])
+  .component(componentName, {
+    controller: NewsletterSubscriptionController,
+    templateUrl: template,
+    bindings: {
+      designationNumber: '@',
+      displayName: '@'
+    }
+  })

--- a/src/app/newsletterSubscription/newsletterSubscription.component.spec.js
+++ b/src/app/newsletterSubscription/newsletterSubscription.component.spec.js
@@ -1,0 +1,41 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './newsletterSubscription.component'
+
+describe('newsletterSubscription', function () {
+  beforeEach(angular.mock.module(module.name))
+  let $ctrl, $rootScope
+
+  beforeEach(inject(function (_$rootScope_, _$componentController_) {
+    $rootScope = _$rootScope_
+    $ctrl = _$componentController_(module.name, {}, {
+      designationNumber: '0123456',
+      displayName: 'Rev. Mortimer and Gertrude Tuttle'
+    })
+  }))
+
+  it('to be defined', function () {
+    expect($ctrl).toBeDefined()
+    expect($ctrl.designationNumber).toEqual('0123456')
+    expect($ctrl.displayName).toEqual('Rev. Mortimer and Gertrude Tuttle')
+  })
+
+  describe('openNewsletterModal', () => {
+    let modalPromise
+    beforeEach(inject((_$q_) => {
+      modalPromise = _$q_.defer()
+      jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: modalPromise.promise })
+    }))
+
+    it('should open modal', () => {
+      $ctrl.openNewsletterModal()
+
+      expect($ctrl.$uibModal.open).toHaveBeenCalled()
+      expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.designationNumber()).toEqual('0123456')
+      expect($ctrl.$uibModal.open.mock.calls[0][0].resolve.displayName()).toEqual('Rev. Mortimer and Gertrude Tuttle')
+
+      modalPromise.resolve()
+      $rootScope.$digest()
+    })
+  })
+})

--- a/src/app/newsletterSubscription/newsletterSubscription.tpl.html
+++ b/src/app/newsletterSubscription/newsletterSubscription.tpl.html
@@ -1,6 +1,6 @@
 <div>
   <button type="button"
-          class="btn btn-danger"
+          class="btn btn-secondary"
           ng-click="$ctrl.openNewsletterModal()">
     Subscribe to Newsletter
   </button>

--- a/src/app/newsletterSubscription/newsletterSubscription.tpl.html
+++ b/src/app/newsletterSubscription/newsletterSubscription.tpl.html
@@ -1,0 +1,7 @@
+<div>
+  <button type="button"
+          class="btn btn-danger"
+          ng-click="$ctrl.openNewsletterModal()">
+    Subscribe to Newsletter
+  </button>
+</div>

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -9,7 +9,7 @@ const appConfig = /* @ngInject */ function (envServiceProvider, $compileProvider
   envServiceProvider.config({
     domains: {
       development: ['localhost', 'localhost.cru.org', 'cru-givedev.s3-website-us-east-1.amazonaws.com'],
-      staging: ['give-stage2.cru.org', 'stage.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org', 'uatdisp.aws.cru.org'],
+      staging: ['give-stage2.cru.org', 'stage.cru.org', 'dev.aws.cru.org', 'devauth.aws.cru.org', 'devpub.aws.cru.org', 'uatauth.aws.cru.org', 'uatpub.aws.cru.org', 'uatdisp.aws.cru.org', 'cru-givestage.s3-website-us-east-1.amazonaws.com'],
       production: []
     },
     vars: {

--- a/src/common/services/api/designationEditor.constants.js
+++ b/src/common/services/api/designationEditor.constants.js
@@ -1,4 +1,6 @@
 export default {
   designationEndpoint: '/bin/crugive/designation',
-  designationImagesEndpoint: '/bin/crugive/image'
+  designationImagesEndpoint: '/bin/crugive/image',
+  designationNewsletter: '/bin/crugive/newsletter/distributor',
+  designationNewsletterSubscription: '/bin/crugive/newsletter/subscription'
 }

--- a/src/common/services/api/designationEditor.constants.js
+++ b/src/common/services/api/designationEditor.constants.js
@@ -1,6 +1,6 @@
 export default {
   designationEndpoint: '/bin/crugive/designation',
   designationImagesEndpoint: '/bin/crugive/image',
-  designationNewsletter: '/bin/crugive/newsletter/distributor',
-  designationNewsletterSubscription: '/bin/crugive/newsletter/subscription'
+  designationNewsletter: '/bin/crugive/newsletter/signup.json',
+  designationNewsletterSubscription: '/bin/crugive/newsletter/signup.json'
 }

--- a/src/common/services/api/designationEditor.service.js
+++ b/src/common/services/api/designationEditor.service.js
@@ -56,7 +56,7 @@ class designationEditorService {
   subscribeToNewsletter (designationNumber, attributes) {
     return this.$http.post(designationConstants.designationNewsletterSubscription,
       {
-        designationNumber,
+        designation_number: designationNumber,
         ...attributes
       }, {
         withCredentials: true

--- a/src/common/services/api/designationEditor.service.js
+++ b/src/common/services/api/designationEditor.service.js
@@ -42,7 +42,10 @@ class designationEditorService {
   }
 
   hasNewsletter (designationNumber) {
-    return this.$http.get(`${designationConstants.designationNewsletter}/${designationNumber}`, {
+    return this.$http.get(designationConstants.designationNewsletter, {
+      params: {
+        designationNumber: designationNumber
+      },
       withCredentials: true
     }).then(
       result => result.data.user_exists === true,
@@ -51,8 +54,11 @@ class designationEditorService {
   }
 
   subscribeToNewsletter (designationNumber, attributes) {
-    return this.$http.post(`${designationConstants.designationNewsletterSubscription}/${designationNumber}`,
-      attributes, {
+    return this.$http.post(designationConstants.designationNewsletterSubscription,
+      {
+        designationNumber,
+        ...attributes
+      }, {
         withCredentials: true
       })
   }

--- a/src/common/services/api/designationEditor.service.js
+++ b/src/common/services/api/designationEditor.service.js
@@ -41,6 +41,15 @@ class designationEditorService {
     })
   }
 
+  hasNewsletter (designationNumber) {
+    return this.$http.get(`${designationConstants.designationNewsletter}/${designationNumber}`, {
+      withCredentials: true
+    }).then(
+      result => result.data.user_exists === true,
+      errorResponse => false // TODO: check errorResponse json
+    )
+  }
+
   save (designationContent, designationNumber, campaignPage) {
     return this.$http.post(designationConstants.designationEndpoint, designationContent, {
       withCredentials: true,
@@ -53,6 +62,5 @@ class designationEditorService {
 }
 
 export default angular
-  .module(serviceName, [
-  ])
+  .module(serviceName, [])
   .service(serviceName, designationEditorService)

--- a/src/common/services/api/designationEditor.service.js
+++ b/src/common/services/api/designationEditor.service.js
@@ -50,6 +50,13 @@ class designationEditorService {
     )
   }
 
+  subscribeToNewsletter (designationNumber, attributes) {
+    return this.$http.post(`${designationConstants.designationNewsletterSubscription}/${designationNumber}`,
+      attributes, {
+        withCredentials: true
+      })
+  }
+
   save (designationContent, designationNumber, campaignPage) {
     return this.$http.post(designationConstants.designationEndpoint, designationContent, {
       withCredentials: true,

--- a/src/common/services/api/designationEditor.service.spec.js
+++ b/src/common/services/api/designationEditor.service.spec.js
@@ -6,7 +6,9 @@ import designationConstants from './designationEditor.constants'
 
 describe('donation editor service', () => {
   beforeEach(angular.mock.module(module.name))
-  let designationEditorService; let $httpBackend; const designationNumber = '000555'
+  let designationEditorService
+  let $httpBackend
+  const designationNumber = '000555'
 
   beforeEach(inject((_designationEditorService_, _$httpBackend_) => {
     designationEditorService = _designationEditorService_
@@ -74,5 +76,41 @@ describe('donation editor service', () => {
 
     designationEditorService.save({})
     $httpBackend.flush()
+  })
+
+  describe('hasNewsletter (designationNumber)', () => {
+    it('should succeed if designationNumber has a newsletter', () => {
+      $httpBackend
+        .expectGET(`${designationConstants.designationNewsletter}/${designationNumber}`)
+        .respond(200, { user_exists: true })
+
+      const result = designationEditorService.hasNewsletter(designationNumber)
+      $httpBackend.flush()
+      expect(result).resolves.toBe(true)
+    })
+
+    it('should fail if designationNumber does not exist', () => {
+      $httpBackend
+        .expectGET(`${designationConstants.designationNewsletter}/${designationNumber}`)
+        .respond(404, { user_exists: false })
+
+      const result = designationEditorService.hasNewsletter(designationNumber)
+      $httpBackend.flush()
+      expect(result).resolves.toBe(false)
+    })
+  })
+
+  describe('subscribeToNewsletter (designationNumber, attributes)', () => {
+    it('should post attributes', () => {
+      $httpBackend
+        .expectPOST(`${designationConstants.designationNewsletterSubscription}/${designationNumber}`, {
+          first_name: 'Bob',
+          last_name: 'Montgomery'
+        })
+        .respond(200)
+
+      designationEditorService.subscribeToNewsletter(designationNumber, { first_name: 'Bob', last_name: 'Montgomery' })
+      $httpBackend.flush()
+    })
   })
 })

--- a/src/common/services/api/designationEditor.service.spec.js
+++ b/src/common/services/api/designationEditor.service.spec.js
@@ -104,7 +104,7 @@ describe('donation editor service', () => {
     it('should post attributes', () => {
       $httpBackend
         .expectPOST(designationConstants.designationNewsletterSubscription, {
-          designationNumber,
+          designation_number: designationNumber,
           first_name: 'Bob',
           last_name: 'Montgomery'
         })

--- a/src/common/services/api/designationEditor.service.spec.js
+++ b/src/common/services/api/designationEditor.service.spec.js
@@ -81,7 +81,7 @@ describe('donation editor service', () => {
   describe('hasNewsletter (designationNumber)', () => {
     it('should succeed if designationNumber has a newsletter', () => {
       $httpBackend
-        .expectGET(`${designationConstants.designationNewsletter}/${designationNumber}`)
+        .expectGET(`${designationConstants.designationNewsletter}?designationNumber=${designationNumber}`)
         .respond(200, { user_exists: true })
 
       const result = designationEditorService.hasNewsletter(designationNumber)
@@ -91,7 +91,7 @@ describe('donation editor service', () => {
 
     it('should fail if designationNumber does not exist', () => {
       $httpBackend
-        .expectGET(`${designationConstants.designationNewsletter}/${designationNumber}`)
+        .expectGET(`${designationConstants.designationNewsletter}?designationNumber=${designationNumber}`)
         .respond(404, { user_exists: false })
 
       const result = designationEditorService.hasNewsletter(designationNumber)
@@ -103,7 +103,8 @@ describe('donation editor service', () => {
   describe('subscribeToNewsletter (designationNumber, attributes)', () => {
     it('should post attributes', () => {
       $httpBackend
-        .expectPOST(`${designationConstants.designationNewsletterSubscription}/${designationNumber}`, {
+        .expectPOST(designationConstants.designationNewsletterSubscription, {
+          designationNumber,
           first_name: 'Bob',
           last_name: 'Montgomery'
         })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,8 @@ const entryPoints = {
     'app/profile/profile.component.js',
     'app/profile/receipts/receipts.component.js',
     'app/profile/payment-methods/payment-methods.component.js',
-    'app/designationEditor/designationEditor.component.js'
+    'app/designationEditor/designationEditor.component.js',
+    'app/newsletterSubscription/newsletterSubscription.component.js'
   ],
   give: 'assets/scss/styles.scss',
   'branded-checkout': [


### PR DESCRIPTION
This adds a checkbox to the personal options modal to enable the newsletter form.
This will require a boolean field called `showNewsletterForm` added to aem / JCR.

This is built on top of the multiple giving links branch since it added the personal modal.