### PR TITLE
Temporarily hardcode the help content

### DIFF
--- a/src/app/checkout/help/help.component.js
+++ b/src/app/checkout/help/help.component.js
@@ -13,11 +13,16 @@ class CheckoutHelpController {
   }
 
   $onInit () {
-    this.$http.get('/designations/jcr:content/need-help-ipar/contentfragment.html').then((response) => {
-      this.helpHTML = response.data
-    }, error => {
-      this.$log.error('Error loading give-need-help', error)
-    })
+    // this.$http.get('/designations/jcr:content/need-help-ipar/contentfragment.html').then((response) => {
+    //   this.helpHTML = response.data
+    // }, error => {
+    //   this.$log.error('Error loading give-need-help', error)
+    // })
+
+    this.helpHTML = '<div><h3 class="panel-name">Need Help?</h3>\n' +
+        '<p>Call us at <b>(888)278-7233</b> from <b>9:00 a.m. to 5:00 p.m. ET,</b> Monday-Friday, or email us at <a href="mailto:eGift@cru.org" target="_top">eGift@cru.org</a>.</p>\n' +
+        '<p>We have also compiled a list of answers to <a>Frequently Asked Questions.</a></p>\n' +
+        '</div>'
   }
 }
 

--- a/src/app/checkout/help/help.spec.js
+++ b/src/app/checkout/help/help.spec.js
@@ -16,21 +16,31 @@ describe('Checkout Help', function () {
     expect($ctrl).toBeDefined()
   })
 
-  it('get help block content from AEM', function () {
-    $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html')
-      .respond(200, '<p>Help Content</p>')
+  // it('get help block content from AEM', function () {
+  //   $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html')
+  //     .respond(200, '<p>Help Content</p>')
+  //
+  //   $ctrl.$onInit()
+  //   $httpBackend.flush()
+  //
+  //   expect($ctrl.helpHTML).toEqual('<p>Help Content</p>')
+  // })
+
+  // it('should log an error on failure', () => {
+  //   $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html').respond(500, 'some error')
+  //   $ctrl.$onInit()
+  //   $httpBackend.flush()
+  //
+  //   expect($ctrl.$log.error.logs[0]).toEqual(['Error loading give-need-help', expect.objectContaining({ data: 'some error' })])
+  // })
+
+  it('uses hardcoded help block content', function () {
 
     $ctrl.$onInit()
-    $httpBackend.flush()
 
-    expect($ctrl.helpHTML).toEqual('<p>Help Content</p>')
-  })
-
-  it('should log an error on failure', () => {
-    $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html').respond(500, 'some error')
-    $ctrl.$onInit()
-    $httpBackend.flush()
-
-    expect($ctrl.$log.error.logs[0]).toEqual(['Error loading give-need-help', expect.objectContaining({ data: 'some error' })])
+    expect($ctrl.helpHTML).toEqual('<div><h3 class="panel-name">Need Help?</h3>\n'
+      + '<p>Call us at <b>(888)278-7233</b> from <b>9:00 a.m. to 5:00 p.m. ET,</b> Monday-Friday, or email us at <a href="mailto:eGift@cru.org" target="_top">eGift@cru.org</a>.</p>\n'
+      + '<p>We have also compiled a list of answers to <a>Frequently Asked Questions.</a></p>\n'
+      + '</div>')
   })
 })


### PR DESCRIPTION
For reasons we don't understand yet,
https://give.cru.org/designations/jcr:content/need-help-ipar/contentfragment.html
is failing with a 500 internal error.

For now, we'll hardcode the message.