### PR TITLE
Revert "Temporarily hardcode the help content"

### DIFF
--- a/src/app/checkout/help/help.component.js
+++ b/src/app/checkout/help/help.component.js
@@ -13,16 +13,11 @@ class CheckoutHelpController {
   }
 
   $onInit () {
-    // this.$http.get('/designations/jcr:content/need-help-ipar/contentfragment.html').then((response) => {
-    //   this.helpHTML = response.data
-    // }, error => {
-    //   this.$log.error('Error loading give-need-help', error)
-    // })
-
-    this.helpHTML = '<div><h3 class="panel-name">Need Help?</h3>\n' +
-        '<p>Call us at <b>(888)278-7233</b> from <b>9:00 a.m. to 5:00 p.m. ET,</b> Monday-Friday, or email us at <a href="mailto:eGift@cru.org" target="_top">eGift@cru.org</a>.</p>\n' +
-        '<p>We have also compiled a list of answers to <a>Frequently Asked Questions.</a></p>\n' +
-        '</div>'
+    this.$http.get('/designations/jcr:content/need-help-ipar/contentfragment.html').then((response) => {
+      this.helpHTML = response.data
+    }, error => {
+      this.$log.error('Error loading give-need-help', error)
+    })
   }
 }
 

--- a/src/app/checkout/help/help.spec.js
+++ b/src/app/checkout/help/help.spec.js
@@ -16,31 +16,21 @@ describe('Checkout Help', function () {
     expect($ctrl).toBeDefined()
   })
 
-  // it('get help block content from AEM', function () {
-  //   $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html')
-  //     .respond(200, '<p>Help Content</p>')
-  //
-  //   $ctrl.$onInit()
-  //   $httpBackend.flush()
-  //
-  //   expect($ctrl.helpHTML).toEqual('<p>Help Content</p>')
-  // })
-
-  // it('should log an error on failure', () => {
-  //   $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html').respond(500, 'some error')
-  //   $ctrl.$onInit()
-  //   $httpBackend.flush()
-  //
-  //   expect($ctrl.$log.error.logs[0]).toEqual(['Error loading give-need-help', expect.objectContaining({ data: 'some error' })])
-  // })
-
-  it('uses hardcoded help block content', function () {
+  it('get help block content from AEM', function () {
+    $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html')
+      .respond(200, '<p>Help Content</p>')
 
     $ctrl.$onInit()
+    $httpBackend.flush()
 
-    expect($ctrl.helpHTML).toEqual('<div><h3 class="panel-name">Need Help?</h3>\n'
-      + '<p>Call us at <b>(888)278-7233</b> from <b>9:00 a.m. to 5:00 p.m. ET,</b> Monday-Friday, or email us at <a href="mailto:eGift@cru.org" target="_top">eGift@cru.org</a>.</p>\n'
-      + '<p>We have also compiled a list of answers to <a>Frequently Asked Questions.</a></p>\n'
-      + '</div>')
+    expect($ctrl.helpHTML).toEqual('<p>Help Content</p>')
+  })
+
+  it('should log an error on failure', () => {
+    $httpBackend.expectGET('/designations/jcr:content/need-help-ipar/contentfragment.html').respond(500, 'some error')
+    $ctrl.$onInit()
+    $httpBackend.flush()
+
+    expect($ctrl.$log.error.logs[0]).toEqual(['Error loading give-need-help', expect.objectContaining({ data: 'some error' })])
   })
 })


### PR DESCRIPTION
Reverts CruGlobal/give-web#810

The fix was deployed this morning to no longer need this workaround. See https://github.com/CruGlobal/cru-aem-commons/pull/9