### PR TITLE
Add Unto to ministry search results

### DIFF
--- a/src/app/searchResults/searchResults.ministries.js
+++ b/src/app/searchResults/searchResults.ministries.js
@@ -44,7 +44,7 @@ export default [
   {
     name: 'Cru Military',
     designationNumber: '2283732',
-    path: '/2283732',
+    path: '/militaryministry',
     facet: 'ministry'
   },
   {

--- a/src/app/searchResults/searchResults.ministries.js
+++ b/src/app/searchResults/searchResults.ministries.js
@@ -118,5 +118,11 @@ export default [
     designationNumber: '2852450',
     path: '/storyrunners-strategies',
     facet: 'ministry'
+  },
+  {
+    name: 'Unto™',
+    designationNumber: '1071573',
+    path: '/1071573',
+    facet: 'ministry'
   }
 ]

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -83,7 +83,8 @@ class DesignationsService {
       '1-103-1': 'U.S. Ministries',
       '1-108-1': 'East / Southern Africa',
       '1-108-2': 'Francophone Africa',
-      '1-108-3': 'West Africa'
+      '1-108-3': 'West Africa',
+      '1-2OMQSO2': 'Unto™'
     }
 
     params = angular.copy(params)


### PR DESCRIPTION
With GAiN renaming to Unto, they want to add Unto (alongside GAiN for now) onto the ministry search results page. At some point I would like this to become doable by AEM give site authors (see [Jira](https://jira.cru.org/browse/EP-2157) and [HelpScout](https://secure.helpscout.net/conversation/1006709892/385635/)).