### PR TITLE
Add babel polyfill for IE 11 Promise support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,11 @@
 // File required for jest, webpack includes different babel config
 module.exports = {
   presets: [
-    '@babel/preset-env'
+    ['@babel/preset-env', {
+      targets: {
+        browsers: ['last 1 version', 'ie >= 11']
+      }
+    }]
   ],
   plugins: [
     '@babel/plugin-transform-runtime'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "give-web",
   "version": "1.0.0",
   "dependencies": {
+    "@babel/polyfill": "^7.7.0",
     "@babel/runtime-corejs2": "^7.0.0",
     "angular": "1.7.9",
     "angular-cookies": "^1.7.8",

--- a/src/loaders/branded.js
+++ b/src/loaders/branded.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill'
 import Loader from './loader'
 
 (function () {

--- a/src/loaders/dev.js
+++ b/src/loaders/dev.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill'
 import Loader from './loader'
 
 (function () {

--- a/src/loaders/give.js
+++ b/src/loaders/give.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill'
 import Loader from './loader'
 
 // Polyfill for IE 9+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,12 @@ const sharedConfig = {
         use: [{
           loader: 'babel-loader',
           options: {
-            presets: [['@babel/preset-env', { modules: false }]],
+            presets: [['@babel/preset-env', {
+              modules: false,
+              targets: {
+                browsers: ['last 1 version', 'ie >= 11']
+              }
+            }]],
             plugins: [
               '@babel/plugin-transform-runtime',
               'angularjs-annotate'

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,14 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
+"@babel/polyfill@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.7.0.tgz#e1066e251e17606ec7908b05617f9b7f8180d8f3"
+  integrity sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.5.5":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.6.0.tgz#aae4141c506100bb2bfaa4ac2a5c12b395619e50"


### PR DESCRIPTION
This adds a polyfill for IE11 by following this: https://stackoverflow.com/questions/52470124/promise-is-undefined-in-ie11-using-babel-polyfill

This has been confirmed working by Scott in IE 11.