### PR TITLE
HS-404215 - Update landing page for Cru greatest needs

### DIFF
--- a/src/app/searchResults/searchResults.ministries.js
+++ b/src/app/searchResults/searchResults.ministries.js
@@ -2,7 +2,7 @@ export default [
   {
     name: 'Cru Greatest Needs',
     designationNumber: '0763355',
-    path: '/0763355',
+    path: '/cru-greatestneeds',
     facet: 'ministry'
   },
   {


### PR DESCRIPTION
This PR updates the landing page of Cru's Greatest Needs from `/0763355` to `/cru-greatestneeds`. See [Helpscout](https://secure.helpscout.net/conversation/1057542051/404215?folderId=381778)