### PR TITLE
Add translation sanitization strategy

### DIFF
--- a/src/app/searchResults/searchResults.tpl.html
+++ b/src/app/searchResults/searchResults.tpl.html
@@ -2,10 +2,10 @@
   <section class="is-top">
     <div class="container">
       <h1 ng-if="!$ctrl.searchParams.type || $ctrl.searchParams.type === 'people'">
-          <span translate ng-if="$ctrl.searchParams.keyword">
+          <span ng-if="$ctrl.searchParams.keyword">
             Search Results for <strong>{{$ctrl.searchParams.keyword}}</strong>
           </span>
-        <span translate ng-if="$ctrl.searchParams.first_name || $ctrl.searchParams.last_name">
+        <span ng-if="$ctrl.searchParams.first_name || $ctrl.searchParams.last_name">
             Search Results for <strong>{{$ctrl.searchParams.first_name}} {{$ctrl.searchParams.last_name}}</strong>
           </span>
         <em ng-if="$ctrl.searchResults.length">({{$ctrl.searchResults.length}} results)</em>

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -78,6 +78,7 @@ const appConfig = /* @ngInject */ function (envServiceProvider, $compileProvider
 
   $qProvider.errorOnUnhandledRejections(false)
 
+  $translateProvider.useSanitizeValueStrategy('sanitize')
   $translateProvider.translations('en', {
     GIVE_GIFT_HEADER: 'Give Gift',
     LOADING_GIFT_DETAILS: 'Loading gift details...',

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -78,7 +78,7 @@ const appConfig = /* @ngInject */ function (envServiceProvider, $compileProvider
 
   $qProvider.errorOnUnhandledRejections(false)
 
-  $translateProvider.useSanitizeValueStrategy('sanitize')
+  $translateProvider.useSanitizeValueStrategy('sanitizeParameters')
   $translateProvider.translations('en', {
     GIVE_GIFT_HEADER: 'Give Gift',
     LOADING_GIFT_DETAILS: 'Loading gift details...',


### PR DESCRIPTION
- Remove unused translate library directive from searchParam bindings

I clicked around and didn't see that this broke anything obvious. We still have 2 translation libraries running around which is great... :( ~~I pushed this to the staging branch too.~~ Looks like this broke a bunch of tests. Seems very unrelated to the errors but this is Angular after all. Guess I'll have to revisit it later.

https://rollbar.com/Cru/all/items/?offset=0&sort=last_desc&status=active&assigned_user=&framework=&date_from=&date_to=&activated_from=&activated_to=&timezone=America%2FNew_York&enc_query=ZT28xQRidC6me%2FYo595F1mriq3BFD%2B9GHu9iftuVd1Hb3IyP8RbXyXVvdQHK470e&levels=30&projects=78978&date_filtering=seen