### PR TITLE
HS-431009 - Fix Unto Org ID

### DIFF
--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -46,7 +46,7 @@ class DesignationsService {
       '1-TH-6': 'Christian Embassy - Washington, D.C.',
       '1-TH-7': 'Christian Embassy - New York',
       '1-TH-8': 'FamilyLife',
-      '1-TH-9': 'Global Aid Network USA',
+      '1-TH-9': 'Unto™',
       '1-TH-10': 'Gift and Estate Design',
       '1-TH-11': 'Global Executive Ministries',
       '1-TH-12': 'Cru Inner City',
@@ -83,8 +83,7 @@ class DesignationsService {
       '1-103-1': 'U.S. Ministries',
       '1-108-1': 'East / Southern Africa',
       '1-108-2': 'Francophone Africa',
-      '1-108-3': 'West Africa',
-      '1-2OMQSO2': 'Unto™'
+      '1-108-3': 'West Africa'
     }
 
     params = angular.copy(params)


### PR DESCRIPTION
When GAiN and Unto stopped running in parallel, and Unto was the only live name, the org IDs changed back to take over the old GAiN org ID. This change will reflect that on the featured opportunity search.

Current:
![Screen Shot 2020-03-26 at 12 25 43 PM](https://user-images.githubusercontent.com/2905714/77680852-e5275c80-6f6a-11ea-9f02-0210c36d03f9.png)

Desired:
![Screen Shot 2020-03-26 at 2 05 57 PM](https://user-images.githubusercontent.com/2905714/77680878-f1131e80-6f6a-11ea-9e2a-645a2ac9ab10.png)
