### PR TITLE
SIEBUPG-296 - Fix edit recurring gift checkout

### DIFF
--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -185,6 +185,11 @@ class DesignationsService {
       .slice(0, 5)
       .join('/')
 
+    const underscorePosition = code.indexOf('_')
+    if (underscorePosition > 0) {
+      code = code.substring(0, underscorePosition)
+    }
+
     return campaignPage
       ? `/content/give/us/en/campaigns/${c}/${code}/${campaignPage}.infinity.json`
       : `/content/give/us/en/designations/${c}/${code}.infinity.json`

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -185,14 +185,11 @@ class DesignationsService {
       .slice(0, 5)
       .join('/')
 
-    const underscorePosition = code.indexOf('_')
-    if (underscorePosition > 0) {
-      code = code.substring(0, underscorePosition)
-    }
+    const [designationNumber] = code.split('_')
 
     return campaignPage
-      ? `/content/give/us/en/campaigns/${c}/${code}/${campaignPage}.infinity.json`
-      : `/content/give/us/en/designations/${c}/${code}.infinity.json`
+      ? `/content/give/us/en/campaigns/${c}/${designationNumber}/${campaignPage}.infinity.json`
+      : `/content/give/us/en/designations/${c}/${designationNumber}.infinity.json`
   }
 
   suggestedAmounts (code, itemConfig) {

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -209,4 +209,36 @@ describe('designation service', () => {
       self.$httpBackend.flush()
     })
   })
+
+  describe('generatePath', () => {
+    it('should return the proper path for one time gift to non-campaign', () => {
+      const productCode = '0123456'
+
+      const path = self.designationsService.generatePath(productCode)
+      expect(path).toEqual('/content/give/us/en/designations/0/1/2/3/4/0123456.infinity.json')
+    })
+
+    it('should return the proper path for one time gift to campaign', () => {
+      const productCode = '0123456'
+      const campaignPage = 'some-campaign'
+
+      const path = self.designationsService.generatePath(productCode, campaignPage)
+      expect(path).toEqual('/content/give/us/en/campaigns/0/1/2/3/4/0123456/some-campaign.infinity.json')
+    })
+
+    it('should return the proper path for recurring gift to non-campaign', () => {
+      const productCode = '0123456_mon'
+
+      const path = self.designationsService.generatePath(productCode)
+      expect(path).toEqual('/content/give/us/en/designations/0/1/2/3/4/0123456.infinity.json')
+    })
+
+    it('should return the proper path for recurring gift to campaign', () => {
+      const productCode = '0123456_mon'
+      const campaignPage = 'some-campaign'
+
+      const path = self.designationsService.generatePath(productCode, campaignPage)
+      expect(path).toEqual('/content/give/us/en/campaigns/0/1/2/3/4/0123456/some-campaign.infinity.json')
+    })
+  })
 })


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/SIEBUPG-296)

Currently (in production) the code is not accounting for the fact that recurring donations have a code of `{designationNumber}_{frequency}` and try to lookup the infinity.json of a non-existing AEM node. This removes the frequency when calculating the path in AEM.