### PR TITLE
Fix custom amount handling on edit

### DIFF
--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -68,7 +68,7 @@ class ProductConfigFormController {
   initItemConfig () {
     this.itemConfig = this.itemConfig || {}
 
-    const amount = parseInt(this.itemConfig.amount, 10)
+    const amount = parseFloat(this.itemConfig.amount)
     if (isNaN(amount)) {
       delete this.itemConfig.amount
     } else {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -89,6 +89,24 @@ describe('product config form component', function () {
       expect($ctrl.itemConfig['recurring-day-of-month']).toBeUndefined()
       expect($ctrl.itemConfig['recurring-start-month']).toBeUndefined()
     })
+
+    it('should handle a whole number amount', () => {
+      $ctrl.itemConfig.amount = 10
+      $ctrl.initItemConfig()
+      expect($ctrl.itemConfig.amount).toEqual(10)
+    })
+
+    it('should handle amount on first time through', () => {
+      $ctrl.itemConfig.amount = undefined
+      $ctrl.initItemConfig()
+      expect($ctrl.itemConfig.amount).toBeUndefined()
+    })
+
+    it('should handle amount with cents', () => {
+      $ctrl.itemConfig.amount = 10.25
+      $ctrl.initItemConfig()
+      expect($ctrl.itemConfig.amount).toEqual(10.25)
+    })
   })
 
   describe('$onChanges', () => {


### PR DESCRIPTION
[Jira comment](https://jira.cru.org/browse/EP-2163?focusedCommentId=89268&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-89268)

This issue was found while testing a separate new feature. Basically, the code was assuming amounts coming back into the product config modal were whole dollar amounts with no cents.