### PR TITLE
Fix cart count by replacing angular-gettext pluralize with ng-pluralize

### DIFF
--- a/src/common/components/nav/navCart/navCart.tpl.html
+++ b/src/common/components/nav/navCart/navCart.tpl.html
@@ -52,7 +52,15 @@
 
   <div class="row repeating-row sub-total" ng-if="$ctrl.hasItems">
     <div class="col-xs-9">
-      <p translate translate-n="$ctrl.cartData.items.length" translate-plural="TOTAL ({{$count}} Items)">TOTAL 1 Item</p>
+      <p>
+        <ng-pluralize
+          count="$ctrl.cartData.items.length"
+          when="{'0': 'TOTAL (0 Items)',
+                     'one': 'TOTAL (1 Item)',
+                     'other': 'TOTAL ({} Items)'}"
+        >
+        </ng-pluralize>
+      </p>
     </div>
     <div class="col-xs-3 text-right">
       <p>{{$ctrl.cartData.cartTotal | currency}}</p>


### PR DESCRIPTION
https://secure.helpscout.net/conversation/1233344938/468614/?

https://angular-gettext.rocketeer.be/dev-guide/annotate/#plurals isn't working for some reason. Maybe because we're using https://angular-translate.github.io/ as the main translation library but angular-gettext is still around. This string doesn't appear to be translated anyways.