### PR TITLE
EP-2190 - Branded checkout cover fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Add the following code to your page where appropriate. See the [Branded checkout
     day="<day>"
     default-payment-type="creditCard"
     donor-details="<window variable containing default values for donor's name and contact info>"
+    show-cover-fees="true"
     on-order-completed="$event.$window.onOrderCompleted($event.purchase)"
     on-order-failed="$event.$window.onOrderFailed($event.donorDetails)">
 </branded-checkout>
@@ -123,6 +124,7 @@ The `<branded-checkout>` element is where the branded checkout Angular app will 
         email: 'email@example.com'
     };
     ```
+- `show-cover-fees` - true if you want to show the checkbox that allows donors to cover processing fees, otherwise leave the attribute off.
 - `on-order-completed` - an Angular expression that is executed when the order was submitted successfully - *Optional* -  provides 2 variables:
   - `$event.$window` - Provides access to the browser's global `window` object. This allows you to call a custom callback function like `onOrderCompleted` in the example.
   - `$event.purchase` - contains the order's details that are loaded for the thank you page

--- a/branded-checkout.html
+++ b/branded-checkout.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 
-<branded-checkout designation-number="2294554" ng-cloak></branded-checkout>
+<branded-checkout designation-number="2294554" show-cover-fees="true" ng-cloak></branded-checkout>
 <script src="branded-checkout.v2.js"></script>
 
 </body>

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -31,7 +31,7 @@ class BrandedCheckoutController {
     this.orderService = orderService
     this.$translate = $translate
 
-    this.orderService.clearBrandedCoverFees()
+    this.orderService.clearCoverFees()
   }
 
   $onInit () {

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -136,6 +136,7 @@ export default angular
       hidePaymentTypeOptions: '@',
       onOrderCompleted: '&',
       onOrderFailed: '&',
-      language: '@'
+      language: '@',
+      showCoverFees: '@'
     }
   })

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -12,6 +12,7 @@ import step2 from './step-2/branded-checkout-step-2.component'
 import thankYouSummary from 'app/thankYou/summary/thankYouSummary.component'
 
 import sessionService from 'common/services/session/session.service'
+import orderService from 'common/services/api/order.service'
 
 import 'common/lib/fakeLocalStorage'
 
@@ -21,13 +22,16 @@ const componentName = 'brandedCheckout'
 
 class BrandedCheckoutController {
   /* @ngInject */
-  constructor ($window, analyticsFactory, tsysService, sessionService, envService, $translate) {
+  constructor ($window, analyticsFactory, tsysService, sessionService, envService, orderService, $translate) {
     this.$window = $window
     this.analyticsFactory = analyticsFactory
     this.tsysService = tsysService
     this.sessionService = sessionService
     this.envService = envService
+    this.orderService = orderService
     this.$translate = $translate
+
+    this.orderService.clearBrandedCoverFees()
   }
 
   $onInit () {
@@ -106,6 +110,7 @@ export default angular
     step2.name,
     thankYouSummary.name,
     sessionService.name,
+    orderService.name,
     uibModal,
     'environment',
     'pascalprecht.translate'

--- a/src/app/branded/branded-checkout.tpl.html
+++ b/src/app/branded/branded-checkout.tpl.html
@@ -13,6 +13,7 @@
           donor-details="$ctrl.donorDetails"
           default-payment-type="$ctrl.defaultPaymentType"
           hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
+          show-cover-fees="$ctrl.showCoverFees"
           next="$ctrl.next()"
           on-payment-failed="$ctrl.onPaymentFailed($event.donorDetails)">
         </branded-checkout-step-1>

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -6,6 +6,7 @@ import contactInfo from 'common/components/contactInfo/contactInfo.component'
 import checkoutStep2 from 'app/checkout/step-2/step-2.component'
 
 import cartService from 'common/services/api/cart.service'
+import orderService from 'common/services/api/order.service'
 
 import template from './branded-checkout-step-1.tpl.html'
 
@@ -13,9 +14,10 @@ const componentName = 'brandedCheckoutStep1'
 
 class BrandedCheckoutStep1Controller {
   /* @ngInject */
-  constructor ($log, cartService) {
+  constructor ($log, cartService, orderService) {
     this.$log = $log
     this.cartService = cartService
+    this.orderService = orderService
   }
 
   $onInit () {
@@ -62,6 +64,13 @@ class BrandedCheckoutStep1Controller {
 
         // add campaign page
         this.itemConfig['campaign-page'] = this.campaignPage
+
+        if (this.orderService.retrieveBrandedCoverFeeDecision()) {
+          this.itemConfig.priceWithFee = item.price
+          this.itemConfig.price = item.price
+          this.itemConfig.amountWithFee = item.amount
+          this.itemConfig.coverFees = true
+        }
       }
       this.loadingProductConfig = false
     },
@@ -152,7 +161,8 @@ export default angular
     productConfigForm.name,
     contactInfo.name,
     checkoutStep2.name,
-    cartService.name
+    cartService.name,
+    orderService.name
   ])
   .component(componentName, {
     controller: BrandedCheckoutStep1Controller,

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -65,7 +65,7 @@ class BrandedCheckoutStep1Controller {
         // add campaign page
         this.itemConfig['campaign-page'] = this.campaignPage
 
-        if (this.orderService.retrieveBrandedCoverFeeDecision()) {
+        if (this.orderService.retrieveCoverFeeDecision()) {
           this.itemConfig.priceWithFee = item.price
           this.itemConfig.price = item.price
           this.itemConfig.amountWithFee = item.amount

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -177,6 +177,7 @@ export default angular
       donorDetails: '<',
       defaultPaymentType: '<',
       hidePaymentTypeOptions: '<',
+      showCoverFees: '<',
       next: '&',
       onPaymentFailed: '&'
     }

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -66,8 +66,6 @@ class BrandedCheckoutStep1Controller {
         this.itemConfig['campaign-page'] = this.campaignPage
 
         if (this.orderService.retrieveCoverFeeDecision()) {
-          this.itemConfig.priceWithFee = item.price
-          this.itemConfig.price = item.price
           this.itemConfig.amountWithFee = item.amount
           this.itemConfig.coverFees = true
         }

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -45,6 +45,7 @@ class BrandedCheckoutStep1Controller {
         break
     }
     this.itemConfig['recurring-day-of-month'] = this.day
+    this.itemConfig.frequency = this.frequency
   }
 
   initCart () {

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -127,7 +127,7 @@ describe('branded checkout step 1', () => {
     })
 
     it('should set amounts that coverFees cares about', () => {
-      jest.spyOn($ctrl.orderService, 'retrieveBrandedCoverFeeDecision').mockReturnValue(true)
+      jest.spyOn($ctrl.orderService, 'retrieveCoverFeeDecision').mockReturnValue(true)
       $ctrl.initCart()
 
       expect($ctrl.itemConfig.priceWithFee).toEqual('$1.02')

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -53,6 +53,7 @@ describe('branded checkout step 1', () => {
       $ctrl.initItemConfig()
 
       expect($ctrl.defaultFrequency).toEqual('MON')
+      expect($ctrl.itemConfig.frequency).toEqual('monthly')
     })
 
     it('should initialize quarterly gifts', () => {
@@ -60,6 +61,7 @@ describe('branded checkout step 1', () => {
       $ctrl.initItemConfig()
 
       expect($ctrl.defaultFrequency).toEqual('QUARTERLY')
+      expect($ctrl.itemConfig.frequency).toEqual('quarterly')
     })
 
     it('should initialize annual gifts', () => {
@@ -67,6 +69,7 @@ describe('branded checkout step 1', () => {
       $ctrl.initItemConfig()
 
       expect($ctrl.defaultFrequency).toEqual('ANNUAL')
+      expect($ctrl.itemConfig.frequency).toEqual('annually')
     })
 
     it('should validate campaignCode (too long)', () => {

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -130,8 +130,6 @@ describe('branded checkout step 1', () => {
       jest.spyOn($ctrl.orderService, 'retrieveCoverFeeDecision').mockReturnValue(true)
       $ctrl.initCart()
 
-      expect($ctrl.itemConfig.priceWithFee).toEqual('$1.02')
-      expect($ctrl.itemConfig.price).toEqual('$1.02')
       expect($ctrl.itemConfig.amountWithFee).toEqual(1.02)
     })
   })

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -87,7 +87,8 @@ describe('branded checkout step 1', () => {
 
   describe('initCart', () => {
     beforeEach(() => {
-      jest.spyOn($ctrl.cartService, 'get').mockReturnValue(Observable.of({ items: [{ code: '1234567', config: {} }] }))
+      jest.spyOn($ctrl.cartService, 'get')
+        .mockReturnValue(Observable.of({ items: [{ code: '1234567', config: {}, price: '$1.02', amount: 1.02 }] }))
       $ctrl.donorDetails = { mailingAddress: {} }
     })
 
@@ -123,6 +124,15 @@ describe('branded checkout step 1', () => {
       expect($ctrl.loadingProductConfig).toEqual(false)
       expect($ctrl.errorLoadingProductConfig).toEqual(true)
       expect($ctrl.$log.error.logs[0]).toEqual(['Error loading cart data for branded checkout step 1', 'some error'])
+    })
+
+    it('should set amounts that coverFees cares about', () => {
+      jest.spyOn($ctrl.orderService, 'retrieveBrandedCoverFeeDecision').mockReturnValue(true)
+      $ctrl.initCart()
+
+      expect($ctrl.itemConfig.priceWithFee).toEqual('$1.02')
+      expect($ctrl.itemConfig.price).toEqual('$1.02')
+      expect($ctrl.itemConfig.amountWithFee).toEqual(1.02)
     })
   })
 

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -35,7 +35,7 @@
                        mailing-address="$ctrl.donorDetails.mailingAddress"
                        default-payment-type="$ctrl.defaultPaymentType"
                        hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
-                       branded-checkout-item="$ctrl.itemConfig">
+                       branded-checkout-item="$ctrl.showCoverFees === 'true' ? $ctrl.itemConfig : undefined">
       </checkout-step-2>
     </div>
   </div>

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -11,7 +11,8 @@
                          submitted="$ctrl.submitted"
                          on-state-change="$ctrl.onGiftConfigStateChange(state)"
                          disable-session-restart="true"
-                         ng-if="!$ctrl.loadingProductConfig && !$ctrl.errorLoadingProductConfig">
+                         ng-if="!$ctrl.loadingProductConfig && !$ctrl.errorLoadingProductConfig"
+                         is-branded-checkout="true">
     </product-config-form>
     <div ng-if="$ctrl.errorLoadingProductConfig" class="alert alert-danger" role="alert">
       <p translate='LOADING_ERROR' translate-values="{loadData: '$ctrl.loadData()'}" translate-compile></p>

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -34,7 +34,7 @@
                        mailing-address="$ctrl.donorDetails.mailingAddress"
                        default-payment-type="$ctrl.defaultPaymentType"
                        hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
-                       branded-checkout-item="$ctrl.item">
+                       branded-checkout-item="$ctrl.itemConfig">
       </checkout-step-2>
     </div>
   </div>

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -33,7 +33,8 @@
                        on-state-change="$ctrl.onPaymentStateChange(state)"
                        mailing-address="$ctrl.donorDetails.mailingAddress"
                        default-payment-type="$ctrl.defaultPaymentType"
-                       hide-payment-type-options="$ctrl.hidePaymentTypeOptions">
+                       hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
+                       branded-checkout-item="$ctrl.item">
       </checkout-step-2>
     </div>
   </div>

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -11,8 +11,7 @@
                          submitted="$ctrl.submitted"
                          on-state-change="$ctrl.onGiftConfigStateChange(state)"
                          disable-session-restart="true"
-                         ng-if="!$ctrl.loadingProductConfig && !$ctrl.errorLoadingProductConfig"
-                         is-branded-checkout="true">
+                         ng-if="!$ctrl.loadingProductConfig && !$ctrl.errorLoadingProductConfig">
     </product-config-form>
     <div ng-if="$ctrl.errorLoadingProductConfig" class="alert alert-danger" role="alert">
       <p translate='LOADING_ERROR' translate-values="{loadData: '$ctrl.loadData()'}" translate-compile></p>

--- a/src/app/cart/cart.component.spec.js
+++ b/src/app/cart/cart.component.spec.js
@@ -160,7 +160,7 @@ describe('cart', () => {
     })
 
     it('should recognize when a donor has covered fees', () => {
-      self.controller.cartService.get.mockReturnValue(Observable.of({}))
+      self.controller.cartService.get.mockReturnValue(Observable.of({ items: [] }))
       jest.spyOn(self.controller.orderService, 'retrieveCartData').mockImplementation(() => null)
       jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
       self.controller.loadCart(true)

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -167,6 +167,7 @@ export default angular
       defaultPaymentType: '<',
       hidePaymentTypeOptions: '<',
       cartData: '<',
+      brandedCheckoutItem: '<',
       onPaymentFormStateChange: '&',
       onLoad: '&'
     }

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -10,10 +10,10 @@
     </div>
 
     <div class="panel panel-default tab-toggle mb0 mt"
-         ng-if="$ctrl.cartData && $ctrl.cartData.items && $ctrl.selectedPaymentMethod && $ctrl.selectedPaymentMethod['card-type']">
+         ng-if="(($ctrl.cartData && $ctrl.cartData.items) || $ctrl.brandedCheckoutItem) && $ctrl.selectedPaymentMethod && $ctrl.selectedPaymentMethod['card-type']">
       <div class="panel-title panel-heading" translate>{{'OPTIONAL'}}</div>
       <div class="panel-body">
-        <cover-fees cart-data="$ctrl.cartData"></cover-fees>
+        <cover-fees cart-data="$ctrl.cartData" branded-checkout-item="$ctrl.brandedCheckoutItem"></cover-fees>
       </div>
     </div>
 

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -73,7 +73,10 @@ class Step2Controller {
       request.subscribe(() => {
         if (this.cartData) {
           this.orderService.storeFeesApplied(true)
+        } else if (this.brandedCheckoutItem) {
+          this.orderService.storeBrandedFeesApplied(true)
         }
+
         if (!$event.stayOnStep) {
           this.changeStep({ newStep: 'review' })
           this.onStateChange({ state: 'submitted' })

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -123,6 +123,7 @@ export default angular
       defaultPaymentType: '<',
       hidePaymentTypeOptions: '<',
       cartData: '<',
+      brandedCheckoutItem: '<',
       changeStep: '&',
       onStateChange: '&'
     }

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -74,7 +74,7 @@ class Step2Controller {
         if (this.cartData) {
           this.orderService.storeFeesApplied(true)
         } else if (this.brandedCheckoutItem) {
-          this.orderService.storeBrandedFeesApplied(true)
+          this.orderService.storeFeesApplied(true)
         }
 
         if (!$event.stayOnStep) {

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -208,6 +208,25 @@ describe('checkout', () => {
         expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'review' })
         expect(self.controller.orderService.updatePaymentMethod).toHaveBeenCalledWith('selected payment method', { creditCard: {} })
       })
+
+      it('should set feesApplied for standard checkout', () => {
+        jest.spyOn(self.controller.orderService, 'updatePaymentMethod').mockReturnValue(Observable.of(''))
+        self.controller.cartData = {}
+        jest.spyOn(self.controller.orderService, 'storeFeesApplied')
+
+        self.controller.onPaymentFormStateChange({ state: 'loading', payload: { creditCard: {} }, update: true, paymentMethodToUpdate: 'selected payment method' })
+        expect(self.controller.orderService.storeFeesApplied).toHaveBeenCalledWith(true)
+      })
+
+      it('should set feesApplied for branded checkout', () => {
+        jest.spyOn(self.controller.orderService, 'updatePaymentMethod').mockReturnValue(Observable.of(''))
+        self.controller.cartData = undefined
+        self.controller.brandedCheckoutItem = {}
+        jest.spyOn(self.controller.orderService, 'storeBrandedFeesApplied')
+
+        self.controller.onPaymentFormStateChange({ state: 'loading', payload: { creditCard: {} }, update: true, paymentMethodToUpdate: 'selected payment method' })
+        expect(self.controller.orderService.storeBrandedFeesApplied).toHaveBeenCalledWith(true)
+      })
     })
   })
 })

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -222,10 +222,10 @@ describe('checkout', () => {
         jest.spyOn(self.controller.orderService, 'updatePaymentMethod').mockReturnValue(Observable.of(''))
         self.controller.cartData = undefined
         self.controller.brandedCheckoutItem = {}
-        jest.spyOn(self.controller.orderService, 'storeBrandedFeesApplied')
+        jest.spyOn(self.controller.orderService, 'storeFeesApplied')
 
         self.controller.onPaymentFormStateChange({ state: 'loading', payload: { creditCard: {} }, update: true, paymentMethodToUpdate: 'selected payment method' })
-        expect(self.controller.orderService.storeBrandedFeesApplied).toHaveBeenCalledWith(true)
+        expect(self.controller.orderService.storeFeesApplied).toHaveBeenCalledWith(true)
       })
     })
   })

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -29,7 +29,8 @@
       mailing-address="$ctrl.mailingAddress"
       default-payment-type="$ctrl.defaultPaymentType"
       hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
-      cart-data="$ctrl.cartData">
+      cart-data="$ctrl.cartData"
+      branded-checkout-item="$ctrl.brandedCheckoutItem">
     </checkout-existing-payment-methods>
   </div>
 </div>

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -15,7 +15,8 @@
       mailing-address="$ctrl.mailingAddress"
       default-payment-type="$ctrl.defaultPaymentType"
       hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
-      cart-data="$ctrl.cartData">
+      cart-data="$ctrl.cartData"
+      branded-checkout-item="$ctrl.brandedCheckoutItem">
     </payment-method-form>
   </div>
 

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -143,7 +143,6 @@ class Step3Controller {
       this.orderService.clearCardSecurityCodes()
       this.orderService.clearCoverFees()
       this.orderService.clearCartData()
-      this.orderService.clearBrandedCoverFees()
       this.onSubmitted()
       this.$scope.$emit(cartUpdatedEvent)
       this.changeStep({ newStep: 'thankYou' })

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -143,6 +143,7 @@ class Step3Controller {
       this.orderService.clearCardSecurityCodes()
       this.orderService.clearCoverFees()
       this.orderService.clearCartData()
+      this.orderService.clearBrandedCoverFees()
       this.onSubmitted()
       this.$scope.$emit(cartUpdatedEvent)
       this.changeStep({ newStep: 'thankYou' })

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -38,8 +38,7 @@ describe('checkout', () => {
           retrieveCardSecurityCode: () => self.storedCvv,
           clearCardSecurityCodes: jest.fn(),
           clearCoverFees: jest.fn(),
-          clearCartData: jest.fn(),
-          clearBrandedCoverFees: jest.fn()
+          clearCartData: jest.fn()
         },
         $window: {
           scrollTo: jest.fn()
@@ -429,7 +428,6 @@ describe('checkout', () => {
 
           expect(self.controller.orderService.clearCoverFees).toHaveBeenCalled()
           expect(self.controller.orderService.clearCartData).toHaveBeenCalled()
-          expect(self.controller.orderService.clearBrandedCoverFees).toHaveBeenCalled()
         })
       })
     })

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -422,6 +422,15 @@ describe('checkout', () => {
           expect(self.controller.submissionError).toEqual('Current payment type is unknown')
           expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0)
         })
+
+        it('should clear out cover fee data', () => {
+          self.controller.creditCardPaymentDetails = {}
+          self.controller.submitOrder()
+
+          expect(self.controller.orderService.clearCoverFees).toHaveBeenCalled()
+          expect(self.controller.orderService.clearCartData).toHaveBeenCalled()
+          expect(self.controller.orderService.clearBrandedCoverFees).toHaveBeenCalled()
+        })
       })
     })
   })

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -38,7 +38,8 @@ describe('checkout', () => {
           retrieveCardSecurityCode: () => self.storedCvv,
           clearCardSecurityCodes: jest.fn(),
           clearCoverFees: jest.fn(),
-          clearCartData: jest.fn()
+          clearCartData: jest.fn(),
+          clearBrandedCoverFees: jest.fn()
         },
         $window: {
           scrollTo: jest.fn()

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -31,6 +31,8 @@ import { giveGiftParams } from '../giveGiftParams'
 import loading from 'common/components/loading/loading.component'
 import analyticsFactory from 'app/analytics/analytics.factory'
 
+import { brandedCheckoutAmountUpdatedEvent } from 'common/components/paymentMethods/coverFees/coverFees.component'
+
 import template from './productConfigForm.tpl.html'
 
 export const brandedCoverFeeCheckedEvent = 'brandedCoverFeeCheckedEvent'
@@ -67,9 +69,9 @@ class ProductConfigFormController {
     this.$rootScope.$on(brandedCoverFeeCheckedEvent, () => {
       this.initItemConfig()
       if (this.selectableAmounts.includes(this.itemConfig.amount)) {
-        this.changeAmount(this.itemConfig.amount)
+        this.changeAmount(this.itemConfig.amount, true)
       } else {
-        this.changeCustomAmount(this.itemConfig.amount)
+        this.changeCustomAmount(this.itemConfig.amount, true)
       }
     })
   }
@@ -249,20 +251,30 @@ class ProductConfigFormController {
     }
   }
 
-  changeAmount (amount) {
+  changeAmount (amount, retainCoverFees) {
     this.itemConfigForm.$setDirty()
     this.checkAmountChanged(amount)
     this.itemConfig.amount = amount
     this.customAmount = ''
     this.customInputActive = false
+    if (!retainCoverFees && this.amountChanged) {
+      this.orderService.clearBrandedCoverFees()
+      this.itemConfig.coverFees = false
+      this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
+    }
     this.updateQueryParam({ key: giveGiftParams.amount, value: amount })
   }
 
-  changeCustomAmount (amount) {
+  changeCustomAmount (amount, retainCoverFees) {
     this.checkAmountChanged(amount)
     this.itemConfig.amount = amount
     this.customAmount = amount
     this.customInputActive = true
+    if (!retainCoverFees && this.amountChanged) {
+      this.orderService.clearBrandedCoverFees()
+      this.itemConfig.coverFees = false
+      this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
+    }
     this.updateQueryParam({ key: giveGiftParams.amount, value: amount })
   }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -210,6 +210,11 @@ class ProductConfigFormController {
     this.errorChangingFrequency = false
     const lastFrequency = this.productData.frequency
     this.productData.frequency = product.name
+
+    if (this.isBrandedCheckout) {
+      this.itemConfig.frequency = product.display
+    }
+
     this.updateQueryParam({ key: giveGiftParams.frequency, value: product.name })
     if (product.selectAction) {
       this.changingFrequency = true
@@ -351,6 +356,7 @@ export default angular
       isEdit: '<',
       uri: '<',
       defaultFrequency: '<',
+      isBrandedCheckout: '<',
       disableSessionRestart: '@',
       updateQueryParam: '&',
       submitted: '<',

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -283,6 +283,9 @@ class ProductConfigFormController {
     if (this.itemConfig.amount && amount) {
       this.amountChanged = this.itemConfig.amount !== amount
     }
+    if (!this.itemConfig.amount && amount) {
+      this.amountChanged = true
+    }
   }
 
   changeStartDay (day, month) {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -259,7 +259,7 @@ class ProductConfigFormController {
     this.customAmount = ''
     this.customInputActive = false
     if (!retainCoverFees && this.amountChanged) {
-      this.orderService.clearBrandedCoverFees()
+      this.orderService.clearCoverFees()
       this.itemConfig.coverFees = false
       this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
     }
@@ -272,7 +272,7 @@ class ProductConfigFormController {
     this.customAmount = amount
     this.customInputActive = true
     if (!retainCoverFees && this.amountChanged) {
-      this.orderService.clearBrandedCoverFees()
+      this.orderService.clearCoverFees()
       this.itemConfig.coverFees = false
       this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
     }

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -33,11 +33,14 @@ import analyticsFactory from 'app/analytics/analytics.factory'
 
 import template from './productConfigForm.tpl.html'
 
+export const brandedCoverFeeCheckedEvent = 'brandedCoverFeeCheckedEvent'
+
 const componentName = 'productConfigForm'
 
 class ProductConfigFormController {
   /* @ngInject */
-  constructor ($scope, $log, $filter, $window, designationsService, cartService, orderService, commonService, analyticsFactory) {
+  constructor ($rootScope, $scope, $log, $filter, $window, designationsService, cartService, orderService, commonService, analyticsFactory) {
+    this.$rootScope = $rootScope
     this.$scope = $scope
     this.$log = $log
     this.$filter = $filter
@@ -60,6 +63,15 @@ class ProductConfigFormController {
     this.initItemConfig()
     this.loadData()
     this.waitForFormInitialization()
+
+    this.$rootScope.$on(brandedCoverFeeCheckedEvent, () => {
+      this.initItemConfig()
+      if (this.selectableAmounts.includes(this.itemConfig.amount)) {
+        this.changeAmount(this.itemConfig.amount)
+      } else {
+        this.changeCustomAmount(this.itemConfig.amount)
+      }
+    })
   }
 
   $onChanges (changes) {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -41,7 +41,7 @@ const componentName = 'productConfigForm'
 
 class ProductConfigFormController {
   /* @ngInject */
-  constructor ($rootScope, $scope, $log, $filter, $window, designationsService, cartService, orderService, commonService, analyticsFactory) {
+  constructor ($rootScope, $scope, $log, $filter, $window, designationsService, cartService, orderService, commonService, analyticsFactory, envService) {
     this.$rootScope = $rootScope
     this.$scope = $scope
     this.$log = $log
@@ -56,6 +56,7 @@ class ProductConfigFormController {
     this.startDate = startDate
     this.startMonth = startMonth
     this.analyticsFactory = analyticsFactory
+    this.envService = envService
     this.amountChanged = false
 
     this.selectableAmounts = [50, 100, 250, 500, 1000, 5000]
@@ -225,7 +226,7 @@ class ProductConfigFormController {
     const lastFrequency = this.productData.frequency
     this.productData.frequency = product.name
 
-    if (this.isBrandedCheckout) {
+    if (this.envService.read('isBrandedCheckout')) {
       this.itemConfig.frequency = product.display
     }
 
@@ -380,7 +381,6 @@ export default angular
       isEdit: '<',
       uri: '<',
       defaultFrequency: '<',
-      isBrandedCheckout: '<',
       disableSessionRestart: '@',
       updateQueryParam: '&',
       submitted: '<',

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -396,6 +396,12 @@ describe('product config form component', function () {
       expect($ctrl.changingFrequency).toEqual(false)
       expect($ctrl.onStateChange).toHaveBeenCalledWith({ state: 'unsubmitted' })
     })
+
+    it('should expose the frequency display value to the itemConfig on branded checkout', () => {
+      $ctrl.isBrandedCheckout = true
+      $ctrl.changeFrequency({ name: 'NA', selectAction: '/a', display: 'Single' })
+      expect($ctrl.itemConfig.frequency).toEqual('Single')
+    })
   })
 
   describe('changeAmount()', () => {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -9,6 +9,7 @@ import 'rxjs/add/observable/throw'
 import module, { brandedCoverFeeCheckedEvent } from './productConfigForm.component'
 import { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
 import { giveGiftParams } from '../giveGiftParams'
+import { brandedCheckoutAmountUpdatedEvent } from '../../../common/components/paymentMethods/coverFees/coverFees.component'
 
 describe('product config form component', function () {
   beforeEach(angular.mock.module(module.name))
@@ -414,6 +415,45 @@ describe('product config form component', function () {
       expect($ctrl.customInputActive).toEqual(false)
       expect($ctrl.updateQueryParam).toHaveBeenCalledWith({ key: giveGiftParams.amount, value: 100 })
     })
+
+    it('should clear cover fees if we are not explicitly retaining them and the amount changed', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 50
+      $ctrl.changeAmount(100)
+
+      expect($ctrl.amountChanged).toEqual(true)
+      expect($ctrl.itemConfig.coverFees).toEqual(false)
+      expect($ctrl.$scope.$emit).toHaveBeenCalledWith(brandedCheckoutAmountUpdatedEvent)
+    })
+
+    it('should not clear cover fees if we are explicitly retaining them and the amount changed', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 50
+      $ctrl.changeAmount(100, true)
+
+      expect($ctrl.amountChanged).toEqual(true)
+      expect($ctrl.itemConfig.coverFees).toEqual(true)
+      expect($ctrl.$scope.$emit).not.toHaveBeenCalled()
+    })
+
+    it('should not clear cover fees if we did not change the amount', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 50
+      $ctrl.changeAmount(50)
+
+      expect($ctrl.amountChanged).toEqual(false)
+      expect($ctrl.itemConfig.coverFees).toEqual(true)
+      expect($ctrl.$scope.$emit).not.toHaveBeenCalled()
+    })
   })
 
   describe('changeCustomAmount()', () => {
@@ -425,6 +465,45 @@ describe('product config form component', function () {
       expect($ctrl.customAmount).toEqual(300)
       expect($ctrl.customInputActive).toEqual(true)
       expect($ctrl.updateQueryParam).toHaveBeenCalledWith({ key: giveGiftParams.amount, value: 300 })
+    })
+
+    it('should clear cover fees if we are not explicitly retaining them and the amount changed', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 51.2
+      $ctrl.changeCustomAmount(1)
+
+      expect($ctrl.amountChanged).toEqual(true)
+      expect($ctrl.itemConfig.coverFees).toEqual(false)
+      expect($ctrl.$scope.$emit).toHaveBeenCalledWith(brandedCheckoutAmountUpdatedEvent)
+    })
+
+    it('should not clear cover fees if we are explicitly retaining them and the amount changed', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 51.2
+      $ctrl.changeCustomAmount(1, true)
+
+      expect($ctrl.amountChanged).toEqual(true)
+      expect($ctrl.itemConfig.coverFees).toEqual(true)
+      expect($ctrl.$scope.$emit).not.toHaveBeenCalled()
+    })
+
+    it('should not clear cover fees if we did not change the amount', () => {
+      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
+
+      $ctrl.itemConfig.coverFees = true
+      $ctrl.itemConfig.amount = 5
+      $ctrl.changeAmount(5)
+
+      expect($ctrl.amountChanged).toEqual(false)
+      expect($ctrl.itemConfig.coverFees).toEqual(true)
+      expect($ctrl.$scope.$emit).not.toHaveBeenCalled()
     })
   })
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -420,7 +420,7 @@ describe('product config form component', function () {
     })
 
     it('should clear cover fees if we are not explicitly retaining them and the amount changed', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true
@@ -433,7 +433,7 @@ describe('product config form component', function () {
     })
 
     it('should not clear cover fees if we are explicitly retaining them and the amount changed', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true
@@ -446,7 +446,7 @@ describe('product config form component', function () {
     })
 
     it('should not clear cover fees if we did not change the amount', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true
@@ -471,7 +471,7 @@ describe('product config form component', function () {
     })
 
     it('should clear cover fees if we are not explicitly retaining them and the amount changed', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true
@@ -484,7 +484,7 @@ describe('product config form component', function () {
     })
 
     it('should not clear cover fees if we are explicitly retaining them and the amount changed', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true
@@ -497,7 +497,7 @@ describe('product config form component', function () {
     })
 
     it('should not clear cover fees if we did not change the amount', () => {
-      jest.spyOn($ctrl.orderService, 'clearBrandedCoverFees').mockImplementation(() => {})
+      jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})
 
       $ctrl.itemConfig.coverFees = true

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
 
-import module from './productConfigForm.component'
+import module, { brandedCoverFeeCheckedEvent } from './productConfigForm.component'
 import { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
 import { giveGiftParams } from '../giveGiftParams'
 
@@ -47,6 +47,7 @@ describe('product config form component', function () {
   })
 
   it('to be defined', () => {
+    expect($ctrl.$rootScope).toBeDefined()
     expect($ctrl.$scope).toBeDefined()
     expect($ctrl.$log).toBeDefined()
     expect($ctrl.designationsService).toBeDefined()
@@ -56,15 +57,43 @@ describe('product config form component', function () {
   })
 
   describe('$onInit', () => {
-    it('should call the initialization functions', () => {
+    beforeEach(() => {
       jest.spyOn($ctrl, 'initItemConfig').mockImplementation(() => {})
       jest.spyOn($ctrl, 'loadData').mockImplementation(() => {})
       jest.spyOn($ctrl, 'waitForFormInitialization').mockImplementation(() => {})
+    })
+
+    it('should call the initialization functions', () => {
+      jest.spyOn($ctrl.$rootScope, '$on').mockImplementation(() => {})
       $ctrl.$onInit()
 
       expect($ctrl.initItemConfig).toHaveBeenCalled()
       expect($ctrl.loadData).toHaveBeenCalled()
       expect($ctrl.waitForFormInitialization).toHaveBeenCalled()
+      expect($ctrl.$rootScope.$on).toHaveBeenCalledWith(brandedCoverFeeCheckedEvent, expect.any(Function))
+      $ctrl.$rootScope.$on.mock.calls[0][1]()
+    })
+
+    it('should handle brandedCoverFeeCheckedEvent for selectable amounts', () => {
+      jest.spyOn($ctrl, 'initItemConfig').mockImplementation(() => {})
+      jest.spyOn($ctrl, 'changeAmount').mockImplementation(() => {})
+      $ctrl.itemConfig.amount = 50
+
+      $ctrl.$onInit()
+      $ctrl.$rootScope.$emit(brandedCoverFeeCheckedEvent)
+      expect($ctrl.initItemConfig).toHaveBeenCalled()
+      expect($ctrl.changeAmount).toHaveBeenCalledWith(50, true)
+    })
+
+    it('should handle brandedCoverFeeCheckedEvent for custom amounts', () => {
+      jest.spyOn($ctrl, 'initItemConfig').mockImplementation(() => {})
+      jest.spyOn($ctrl, 'changeCustomAmount').mockImplementation(() => {})
+      $ctrl.itemConfig.amount = 1.02
+
+      $ctrl.$onInit()
+      $ctrl.$rootScope.$emit(brandedCoverFeeCheckedEvent)
+      expect($ctrl.initItemConfig).toHaveBeenCalled()
+      expect($ctrl.changeCustomAmount).toHaveBeenCalledWith(1.02, true)
     })
   })
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -397,7 +397,12 @@ describe('product config form component', function () {
     })
 
     it('should expose the frequency display value to the itemConfig on branded checkout', () => {
-      $ctrl.isBrandedCheckout = true
+      jest.spyOn($ctrl.envService, 'read').mockImplementation((key) => {
+        if (key === 'isBrandedCheckout') {
+          return true
+        }
+        return false
+      })
       $ctrl.changeFrequency({ name: 'NA', selectAction: '/a', display: 'Single' })
       expect($ctrl.itemConfig.frequency).toEqual('Single')
     })

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -522,6 +522,12 @@ describe('product config form component', function () {
       $ctrl.checkAmountChanged(2)
       expect($ctrl.amountChanged).toEqual(false)
     })
+
+    it('returns true if the item config amount was not defined but the amount is', () => {
+      $ctrl.itemConfig = {}
+      $ctrl.checkAmountChanged(5)
+      expect($ctrl.amountChanged).toEqual(true)
+    })
   })
 
   describe('changeStartDay()', () => {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -76,7 +76,6 @@ describe('product config form component', function () {
     })
 
     it('should handle brandedCoverFeeCheckedEvent for selectable amounts', () => {
-      jest.spyOn($ctrl, 'initItemConfig').mockImplementation(() => {})
       jest.spyOn($ctrl, 'changeAmount').mockImplementation(() => {})
       $ctrl.itemConfig.amount = 50
 
@@ -87,7 +86,6 @@ describe('product config form component', function () {
     })
 
     it('should handle brandedCoverFeeCheckedEvent for custom amounts', () => {
-      jest.spyOn($ctrl, 'initItemConfig').mockImplementation(() => {})
       jest.spyOn($ctrl, 'changeCustomAmount').mockImplementation(() => {})
       $ctrl.itemConfig.amount = 1.02
 

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -6,11 +6,14 @@ import cartService from '../../../services/api/cart.service'
 import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
 import { brandedCoverFeeCheckedEvent } from 'app/productConfig/productConfigForm/productConfigForm.component'
 
+export const brandedCheckoutAmountUpdatedEvent = 'brandedCheckoutAmountUpdatedEvent'
+
 const componentName = 'coverFees'
 
 class CoverFeesController {
   /* @ngInject */
-  constructor ($log, $scope, orderService, cartService) {
+  constructor ($rootScope, $log, $scope, orderService, cartService) {
+    this.$rootScope = $rootScope
     this.$log = $log
     this.$scope = $scope
     this.orderService = orderService
@@ -21,6 +24,11 @@ class CoverFeesController {
   }
 
   $onInit () {
+    this.$rootScope.$on(brandedCheckoutAmountUpdatedEvent, () => {
+      this.feesCalculated = false
+      this.$onInit()
+    })
+
     if (this.cartData) {
       const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
       const feesApplied = this.orderService.retrieveFeesApplied()

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -4,6 +4,7 @@ import template from './coverFees.tpl.html'
 import angular from 'angular'
 import cartService from '../../../services/api/cart.service'
 import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { brandedCoverFeeCheckedEvent } from 'app/productConfig/productConfigForm/productConfigForm.component'
 
 const componentName = 'coverFees'
 
@@ -66,6 +67,7 @@ class CoverFeesController {
   updatePrice () {
     this.orderService.storeBrandedCoverFeeDecision(this.brandedCheckoutItem.coverFees)
     this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
+    this.$scope.$emit(brandedCoverFeeCheckedEvent)
   }
 }
 

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -29,31 +29,25 @@ class CoverFeesController {
   }
 
   $onInit () {
+    const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
+    const feesApplied = this.orderService.retrieveFeesApplied()
     if (this.cartData) {
-      const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
-      const feesApplied = this.orderService.retrieveFeesApplied()
-      this.determineFeesCalculated(sessionCoverFees, this.cartData, this.cartData.items, feesApplied)
-
-      // Intentionally using == null here to avoid checking both null and undefined
-      if (sessionCoverFees !== undefined && this.cartData.coverFees == null) {
-        this.cartData.coverFees = sessionCoverFees
-        this.updatePrices()
-      } else if (this.cartData.coverFees !== null) {
-        this.orderService.storeCoverFeeDecision(this.cartData.coverFees)
-      }
+      this.initializeData(sessionCoverFees, this.cartData, this.cartData.items, feesApplied)
       this.orderService.storeCartData(this.cartData)
     } else if (this.brandedCheckoutItem) {
-      const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
-      const feesApplied = this.orderService.retrieveFeesApplied()
-      this.determineFeesCalculated(sessionCoverFees, this.brandedCheckoutItem, [this.brandedCheckoutItem], feesApplied)
+      this.initializeData(sessionCoverFees, this.brandedCheckoutItem, [this.brandedCheckoutItem], feesApplied)
+    }
+  }
 
-      // Intentionally using == null here to avoid checking both null and undefined
-      if (sessionCoverFees !== undefined && this.brandedCheckoutItem.coverFees == null) {
-        this.brandedCheckoutItem.coverFees = sessionCoverFees
-        this.updatePrice()
-      } else if (this.brandedCheckoutItem.coverFees !== null) {
-        this.orderService.storeCoverFeeDecision(this.brandedCheckoutItem.coverFees)
-      }
+  initializeData (sessionCoverFees, container, items, feesApplied) {
+    this.determineFeesCalculated(sessionCoverFees, container, items, feesApplied)
+
+    // Intentionally using == null here to avoid checking both null and undefined
+    if (sessionCoverFees !== undefined && container.coverFees == null) {
+      container.coverFees = sessionCoverFees
+      this.updatePrices()
+    } else if (container.coverFees !== null) {
+      this.orderService.storeCoverFeeDecision(container.coverFees)
     }
   }
 
@@ -68,14 +62,14 @@ class CoverFeesController {
   }
 
   updatePrices () {
-    this.orderService.updatePrices(this.cartData)
-    this.$scope.$emit(cartUpdatedEvent)
-  }
-
-  updatePrice () {
-    this.orderService.storeCoverFeeDecision(this.brandedCheckoutItem.coverFees)
-    this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
-    this.$scope.$emit(brandedCoverFeeCheckedEvent)
+    if (this.brandedCheckoutItem) {
+      this.orderService.storeCoverFeeDecision(this.brandedCheckoutItem.coverFees)
+      this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
+      this.$scope.$emit(brandedCoverFeeCheckedEvent)
+    } else if (this.cartData) {
+      this.orderService.updatePrices(this.cartData)
+      this.$scope.$emit(cartUpdatedEvent)
+    }
   }
 }
 

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -22,14 +22,9 @@ class CoverFeesController {
   $onInit () {
     if (this.cartData) {
       const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
-      if (!this.feesCalculated) {
-        if (!this.cartData.coverFees && !sessionCoverFees) {
-          this.feesCalculated = this.orderService.calculatePricesWithFees(false, this.cartData.items)
-        } else if (this.cartData.coverFees || sessionCoverFees) {
-          const feesApplied = this.orderService.retrieveFeesApplied()
-          this.feesCalculated = this.orderService.calculatePricesWithFees(feesApplied, this.cartData.items)
-        }
-      }
+      const feesApplied = this.orderService.retrieveFeesApplied()
+      this.determineFeesCalculated(sessionCoverFees, this.cartData, this.cartData.items, feesApplied)
+
       // Intentionally using == null here to avoid checking both null and undefined
       if (sessionCoverFees !== undefined && this.cartData.coverFees == null) {
         this.cartData.coverFees = sessionCoverFees
@@ -38,6 +33,28 @@ class CoverFeesController {
         this.orderService.storeCoverFeeDecision(this.cartData.coverFees)
       }
       this.orderService.storeCartData(this.cartData)
+    } else if (this.brandedCheckoutItem) {
+      const sessionCoverFees = this.orderService.retrieveBrandedCoverFeeDecision()
+      const feesApplied = this.orderService.retrieveBrandedFeesApplied()
+      this.determineFeesCalculated(sessionCoverFees, this.brandedCheckoutItem, [this.brandedCheckoutItem], feesApplied)
+
+      // Intentionally using == null here to avoid checking both null and undefined
+      if (sessionCoverFees !== undefined && this.brandedCheckoutItem.coverFees == null) {
+        this.brandedCheckoutItem.coverFees = sessionCoverFees
+        this.updatePrice()
+      } else if (this.brandedCheckoutItem.coverFees !== null) {
+        this.orderService.storeBrandedCoverFeeDecision(this.brandedCheckoutItem.coverFees)
+      }
+    }
+  }
+
+  determineFeesCalculated (sessionCoverFees, container, items, feesApplied) {
+    if (!this.feesCalculated) {
+      if (!container.coverFees && !sessionCoverFees) {
+        this.feesCalculated = this.orderService.calculatePricesWithFees(false, items)
+      } else if (container.coverFees || sessionCoverFees) {
+        this.feesCalculated = this.orderService.calculatePricesWithFees(feesApplied, items)
+      }
     }
   }
 

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -45,6 +45,11 @@ class CoverFeesController {
     this.orderService.updatePrices(this.cartData)
     this.$scope.$emit(cartUpdatedEvent)
   }
+
+  updatePrice () {
+    this.orderService.storeBrandedCoverFeeDecision(this.brandedCheckoutItem.coverFees)
+    this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
+  }
 }
 
 export default angular

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -32,9 +32,13 @@ class CoverFeesController {
     const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
     const feesApplied = this.orderService.retrieveFeesApplied()
     if (this.cartData) {
+      if (this.cartData.items && this.cartData.items.length === 1) {
+        this.item = this.cartData.items[0]
+      }
       this.initializeData(sessionCoverFees, this.cartData, this.cartData.items, feesApplied)
       this.orderService.storeCartData(this.cartData)
     } else if (this.brandedCheckoutItem) {
+      this.item = this.brandedCheckoutItem
       this.initializeData(sessionCoverFees, this.brandedCheckoutItem, [this.brandedCheckoutItem], feesApplied)
     }
   }
@@ -45,6 +49,9 @@ class CoverFeesController {
     // Intentionally using == null here to avoid checking both null and undefined
     if (sessionCoverFees !== undefined && container.coverFees == null) {
       container.coverFees = sessionCoverFees
+      if (this.item) {
+        this.item.coverFees = container.coverFees
+      }
       this.updatePrices()
     } else if (container.coverFees !== null) {
       this.orderService.storeCoverFeeDecision(container.coverFees)
@@ -67,6 +74,9 @@ class CoverFeesController {
       this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
       this.$scope.$emit(brandedCoverFeeCheckedEvent)
     } else if (this.cartData) {
+      if (this.item) {
+        this.cartData.coverFees = this.item.coverFees
+      }
       this.orderService.updatePrices(this.cartData)
       this.$scope.$emit(cartUpdatedEvent)
     }

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -43,8 +43,8 @@ class CoverFeesController {
       }
       this.orderService.storeCartData(this.cartData)
     } else if (this.brandedCheckoutItem) {
-      const sessionCoverFees = this.orderService.retrieveBrandedCoverFeeDecision()
-      const feesApplied = this.orderService.retrieveBrandedFeesApplied()
+      const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
+      const feesApplied = this.orderService.retrieveFeesApplied()
       this.determineFeesCalculated(sessionCoverFees, this.brandedCheckoutItem, [this.brandedCheckoutItem], feesApplied)
 
       // Intentionally using == null here to avoid checking both null and undefined
@@ -52,7 +52,7 @@ class CoverFeesController {
         this.brandedCheckoutItem.coverFees = sessionCoverFees
         this.updatePrice()
       } else if (this.brandedCheckoutItem.coverFees !== null) {
-        this.orderService.storeBrandedCoverFeeDecision(this.brandedCheckoutItem.coverFees)
+        this.orderService.storeCoverFeeDecision(this.brandedCheckoutItem.coverFees)
       }
     }
   }
@@ -73,7 +73,7 @@ class CoverFeesController {
   }
 
   updatePrice () {
-    this.orderService.storeBrandedCoverFeeDecision(this.brandedCheckoutItem.coverFees)
+    this.orderService.storeCoverFeeDecision(this.brandedCheckoutItem.coverFees)
     this.orderService.updatePrice(this.brandedCheckoutItem, this.brandedCheckoutItem.coverFees)
     this.$scope.$emit(brandedCoverFeeCheckedEvent)
   }

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -56,6 +56,7 @@ export default angular
     controller: CoverFeesController,
     templateUrl: template,
     bindings: {
-      cartData: '<'
+      cartData: '<',
+      brandedCheckoutItem: '<'
     }
   })

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -20,15 +20,15 @@ class CoverFeesController {
     this.cartService = cartService
     this.feesCalculated = false
 
-    this.$onInit()
-  }
-
-  $onInit () {
     this.$rootScope.$on(brandedCheckoutAmountUpdatedEvent, () => {
       this.feesCalculated = false
       this.$onInit()
     })
 
+    this.$onInit()
+  }
+
+  $onInit () {
     if (this.cartData) {
       const sessionCoverFees = this.orderService.retrieveCoverFeeDecision()
       const feesApplied = this.orderService.retrieveFeesApplied()

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
@@ -154,13 +154,6 @@ describe('coverFees', () => {
       expect(self.controller.cartData.cartTotal).toEqual(25000)
     })
 
-    it('should listen for changes on amount in branded checkout', () => {
-      jest.spyOn(self.controller.$rootScope, '$on').mockImplementation(() => {})
-      self.controller.$onInit()
-      expect(self.controller.$rootScope.$on).toHaveBeenCalledWith(brandedCheckoutAmountUpdatedEvent, expect.any(Function))
-      self.controller.$rootScope.$on.mock.calls[0][1]()
-    })
-
     it('should reload the cover fees component if gift amount changed in branded checkout', () => {
       jest.spyOn(self.controller, '$onInit')
       self.controller.feesCalculated = true

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
@@ -22,16 +22,16 @@ describe('coverFees', () => {
     })
 
     it('should do nothing if cart data and brandedCheckoutItem is not defined', () => {
-      jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
+      jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'storeCartData').mockImplementation(() => {})
       jest.spyOn(self.controller, 'updatePrices').mockImplementation(() => {})
       self.controller.cartData = undefined
       self.controller.brandedCheckoutItem = undefined
 
       self.controller.$onInit()
 
-      expect(self.controller.orderService.calculatePricesWithFees).not.toHaveBeenCalled()
-      expect(self.controller.orderService.retrieveCoverFeeDecision).not.toHaveBeenCalled()
-      expect(self.controller.orderService.retrieveFeesApplied).not.toHaveBeenCalled()
+      expect(self.controller.orderService.storeCoverFeeDecision).not.toHaveBeenCalled()
+      expect(self.controller.orderService.storeCartData).not.toHaveBeenCalled()
       expect(self.controller.updatePrices).not.toHaveBeenCalled()
     })
 
@@ -97,14 +97,14 @@ describe('coverFees', () => {
 
     it('should synchronize the brandedCheckoutItem when there is a fee decision in the session', () => {
       jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
-      jest.spyOn(self.controller, 'updatePrice').mockImplementation(() => {})
+      jest.spyOn(self.controller, 'updatePrices').mockImplementation(() => {})
       self.controller.cartData = undefined
       self.controller.brandedCheckoutItem = { coverFees: null }
 
       self.controller.$onInit()
 
       expect(self.controller.brandedCheckoutItem.coverFees).toEqual(true)
-      expect(self.controller.updatePrice).toHaveBeenCalled()
+      expect(self.controller.updatePrices).toHaveBeenCalled()
     })
 
     it('should synchronize the session if there is a fee decision in the cart data', () => {
@@ -178,30 +178,28 @@ describe('coverFees', () => {
       self.controller.updatePrices()
       expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
     })
-  })
 
-  describe('updatePrice', () => {
-    beforeEach(() => {
+    it('should update the price for branded checkout', () => {
       self.controller.brandedCheckoutItem = { coverFees: true }
-    })
-    it('should update the price', () => {
       jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
-      self.controller.updatePrice()
+      self.controller.updatePrices()
       expect(self.controller.orderService.updatePrice)
         .toHaveBeenCalledWith(self.controller.brandedCheckoutItem, self.controller.brandedCheckoutItem.coverFees)
     })
 
     it('should store cover fee decision', () => {
+      self.controller.brandedCheckoutItem = { coverFees: true }
       jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
       jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
-      self.controller.updatePrice()
+      self.controller.updatePrices()
       expect(self.controller.orderService.storeCoverFeeDecision).toHaveBeenCalledWith(true)
     })
 
     it('should notify listeners that the checkbox was checked', () => {
+      self.controller.brandedCheckoutItem = { coverFees: true }
       jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
       jest.spyOn(self.controller.$scope, '$emit').mockImplementation(() => {})
-      self.controller.updatePrice()
+      self.controller.updatePrices()
       expect(self.controller.$scope.$emit).toHaveBeenCalledWith(brandedCoverFeeCheckedEvent)
     })
   })

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
@@ -49,7 +49,7 @@ describe('coverFees', () => {
     })
 
     it('should take prior fee application into account when doing calculation when covering fees - BC', () => {
-      jest.spyOn(self.controller.orderService, 'retrieveBrandedFeesApplied').mockImplementation(() => true)
+      jest.spyOn(self.controller.orderService, 'retrieveFeesApplied').mockImplementation(() => true)
       self.controller.brandedCheckoutItem = { coverFees: true }
       self.controller.cartData = undefined
       self.controller.$onInit()
@@ -68,8 +68,8 @@ describe('coverFees', () => {
     })
 
     it('should take prior fee application into account when doing calculation when session covering fees - BC', () => {
-      jest.spyOn(self.controller.orderService, 'retrieveBrandedCoverFeeDecision').mockImplementation(() => true)
-      jest.spyOn(self.controller.orderService, 'retrieveBrandedFeesApplied').mockImplementation(() => true)
+      jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
+      jest.spyOn(self.controller.orderService, 'retrieveFeesApplied').mockImplementation(() => true)
 
       self.controller.brandedCheckoutItem = { coverFees: false }
       self.controller.cartData = undefined
@@ -96,7 +96,7 @@ describe('coverFees', () => {
     })
 
     it('should synchronize the brandedCheckoutItem when there is a fee decision in the session', () => {
-      jest.spyOn(self.controller.orderService, 'retrieveBrandedCoverFeeDecision').mockImplementation(() => true)
+      jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
       jest.spyOn(self.controller, 'updatePrice').mockImplementation(() => {})
       self.controller.cartData = undefined
       self.controller.brandedCheckoutItem = { coverFees: null }
@@ -118,14 +118,14 @@ describe('coverFees', () => {
     })
 
     it('should synchronize the session if there is a fee decision in the brandedCheckoutItem', () => {
-      jest.spyOn(self.controller.orderService, 'retrieveBrandedCoverFeeDecision').mockImplementation(() => undefined)
-      jest.spyOn(self.controller.orderService, 'storeBrandedCoverFeeDecision').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => undefined)
+      jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
       self.controller.brandedCheckoutItem = { coverFees: true }
       self.controller.cartData = undefined
 
       self.controller.$onInit()
 
-      expect(self.controller.orderService.storeBrandedCoverFeeDecision).toHaveBeenCalledWith(true)
+      expect(self.controller.orderService.storeCoverFeeDecision).toHaveBeenCalledWith(true)
     })
 
     it('should store the cart data on page load', () => {
@@ -193,9 +193,9 @@ describe('coverFees', () => {
 
     it('should store cover fee decision', () => {
       jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
-      jest.spyOn(self.controller.orderService, 'storeBrandedCoverFeeDecision').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
       self.controller.updatePrice()
-      expect(self.controller.orderService.storeBrandedCoverFeeDecision).toHaveBeenCalledWith(true)
+      expect(self.controller.orderService.storeCoverFeeDecision).toHaveBeenCalledWith(true)
     })
 
     it('should notify listeners that the checkbox was checked', () => {

--- a/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
+++ b/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
@@ -11,7 +11,7 @@
       <span ng-bind="$ctrl.brandedCheckoutItem.priceWithFee">
 
       </span><span class="text-lowercase"
-                   ng-if="$ctrl.brandedCheckoutItem.frequency !== 'Single'">
+                   ng-if="$ctrl.brandedCheckoutItem.frequency && $ctrl.brandedCheckoutItem.frequency.toLowerCase() !== 'single'">
         {{$ctrl.brandedCheckoutItem.frequency}}.
       </span>
     </span>

--- a/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
+++ b/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
@@ -8,10 +8,9 @@
     <span class="cover-fees-text">
       I want my gift to go even further for ministry!
       To help cover credit/debit card processing fees, please adjust my gift amount to
-      <span ng-bind="$ctrl.brandedCheckoutItem.priceWithFee">
-
-      </span><span class="text-lowercase"
-                   ng-if="$ctrl.brandedCheckoutItem.frequency && $ctrl.brandedCheckoutItem.frequency.toLowerCase() !== 'single'">
+      {{$ctrl.brandedCheckoutItem.amountWithFee | currency}}
+      <span class="text-lowercase"
+            ng-if="$ctrl.brandedCheckoutItem.frequency && $ctrl.brandedCheckoutItem.frequency.toLowerCase() !== 'single'">
         {{$ctrl.brandedCheckoutItem.frequency}}.
       </span>
     </span>
@@ -25,10 +24,9 @@
     <span class="cover-fees-text">
       I want my gift to go even further for ministry!
       To help cover credit/debit card processing fees, please adjust my gift amount to
-      <span ng-bind="$ctrl.cartData.items[0].priceWithFee">
-
-      </span><span class="text-lowercase"
-                   ng-if="$ctrl.cartData.items[0].frequency !== 'Single'">
+      {{$ctrl.cartData.items[0].amountWithFee | currency}}
+      <span class="text-lowercase"
+            ng-if="$ctrl.cartData.items[0].frequency !== 'Single'">
         {{$ctrl.cartData.items[0].frequency}}.
       </span>
     </span>
@@ -47,7 +45,7 @@
     </label>
     <ul>
       <li ng-repeat="cartItem in $ctrl.cartData.items">
-        <span ng-bind="cartItem.priceWithFee"></span>
+        {{cartItem.amountWithFee | currency}}
         <span class="text-lowercase" ng-if="cartItem.frequency !== 'Single'">
           {{cartItem.frequency}}
         </span>

--- a/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
+++ b/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
@@ -1,33 +1,17 @@
 <div class="checkbox checkbox-inline">
-  <label ng-if="$ctrl.brandedCheckoutItem">
+  <label ng-if="$ctrl.item">
     <input type="checkbox"
            name="coverFees"
-           ng-model="$ctrl.brandedCheckoutItem.coverFees"
+           ng-model="$ctrl.item.coverFees"
            ng-value="true"
            ng-change="$ctrl.updatePrices()">
     <span class="cover-fees-text">
       I want my gift to go even further for ministry!
       To help cover credit/debit card processing fees, please adjust my gift amount to
-      {{$ctrl.brandedCheckoutItem.amountWithFee | currency}}
+      {{$ctrl.item.amountWithFee | currency}}
       <span class="text-lowercase"
-            ng-if="$ctrl.brandedCheckoutItem.frequency && $ctrl.brandedCheckoutItem.frequency.toLowerCase() !== 'single'">
-        {{$ctrl.brandedCheckoutItem.frequency}}.
-      </span>
-    </span>
-  </label>
-  <label ng-if="$ctrl.cartData.items.length === 1">
-    <input type="checkbox"
-           name="coverFees"
-           ng-model="$ctrl.cartData.coverFees"
-           ng-value="true"
-           ng-change="$ctrl.updatePrices()">
-    <span class="cover-fees-text">
-      I want my gift to go even further for ministry!
-      To help cover credit/debit card processing fees, please adjust my gift amount to
-      {{$ctrl.cartData.items[0].amountWithFee | currency}}
-      <span class="text-lowercase"
-            ng-if="$ctrl.cartData.items[0].frequency !== 'Single'">
-        {{$ctrl.cartData.items[0].frequency}}.
+            ng-if="$ctrl.item.frequency && $ctrl.item.frequency.toLowerCase() !== 'single'">
+        {{$ctrl.item.frequency}}.
       </span>
     </span>
   </label>

--- a/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
+++ b/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
@@ -1,4 +1,21 @@
 <div class="checkbox checkbox-inline">
+  <label ng-if="$ctrl.brandedCheckoutItem">
+    <input type="checkbox"
+           name="coverFees"
+           ng-model="$ctrl.brandedCheckoutItem.coverFees"
+           ng-value="true"
+           ng-change="$ctrl.updatePrice()">
+    <span class="cover-fees-text">
+      I want my gift to go even further for ministry!
+      To help cover credit/debit card processing fees, please adjust my gift amount to
+      <span ng-bind="$ctrl.brandedCheckoutItem.priceWithFee">
+
+      </span><span class="text-lowercase"
+                   ng-if="$ctrl.brandedCheckoutItem.frequency !== 'Single'">
+        {{$ctrl.brandedCheckoutItem.frequency}}.
+      </span>
+    </span>
+  </label>
   <label ng-if="$ctrl.cartData.items.length === 1">
     <input type="checkbox"
            name="coverFees"

--- a/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
+++ b/src/common/components/paymentMethods/coverFees/coverFees.tpl.html
@@ -4,7 +4,7 @@
            name="coverFees"
            ng-model="$ctrl.brandedCheckoutItem.coverFees"
            ng-value="true"
-           ng-change="$ctrl.updatePrice()">
+           ng-change="$ctrl.updatePrices()">
     <span class="cover-fees-text">
       I want my gift to go even further for ministry!
       To help cover credit/debit card processing fees, please adjust my gift amount to

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -196,6 +196,7 @@ export default angular
       hideCvv: '<',
       mailingAddress: '<',
       cartData: '<',
+      brandedCheckoutItem: '<',
       onPaymentFormStateChange: '&'
     }
   })

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -147,11 +147,11 @@
   </div>
 
   <div class="panel panel-default mt mb0"
-       ng-if="$ctrl.cartData && $ctrl.cartData.items">
+       ng-if="($ctrl.cartData && $ctrl.cartData.items) || $ctrl.brandedCheckoutItem">
     <div class="panel-body">
       <div class="mb">
         <h4 class="panel-title border-bottom-small" translate>{{'OPTIONAL'}}</h4>
-        <cover-fees cart-data="$ctrl.cartData"></cover-fees>
+        <cover-fees cart-data="$ctrl.cartData" branded-checkout-item="$ctrl.brandedCheckoutItem"></cover-fees>
       </div>
     </div>
   </div>

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -6,13 +6,15 @@ import creditCardForm from '../creditCardForm/creditCardForm.component'
 import orderService from '../../../services/api/order.service'
 
 import template from './paymentMethodForm.tpl.html'
+import { brandedCoverFeeCheckedEvent } from '../../../../app/productConfig/productConfigForm/productConfigForm.component'
 
 const componentName = 'paymentMethodForm'
 
 class PaymentMethodFormController {
   /* @ngInject */
-  constructor ($log, envService, orderService) {
+  constructor ($log, $scope, envService, orderService) {
     this.$log = $log
+    this.$scope = $scope
 
     this.paymentType = 'bankAccount'
     this.imgDomain = envService.read('imgDomain')
@@ -36,6 +38,7 @@ class PaymentMethodFormController {
       this.brandedCheckoutItem.coverFees = false
       this.orderService.storeBrandedCoverFeeDecision(false)
       this.orderService.updatePrice(this.brandedCheckoutItem, false)
+      this.$scope.$emit(brandedCoverFeeCheckedEvent)
     }
     this.paymentType = type
     this.onPaymentFormStateChange({

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -36,7 +36,7 @@ class PaymentMethodFormController {
     }
     if (this.brandedCheckoutItem && type === 'bankAccount') {
       this.brandedCheckoutItem.coverFees = false
-      this.orderService.storeBrandedCoverFeeDecision(false)
+      this.orderService.storeCoverFeeDecision(false)
       this.orderService.updatePrice(this.brandedCheckoutItem, false)
       this.$scope.$emit(brandedCoverFeeCheckedEvent)
     }

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -32,6 +32,11 @@ class PaymentMethodFormController {
       this.cartData.coverFees = false
       this.orderService.updatePrices(this.cartData)
     }
+    if (this.brandedCheckoutItem && type === 'bankAccount') {
+      this.brandedCheckoutItem.coverFees = false
+      this.orderService.storeBrandedCoverFeeDecision(false)
+      this.orderService.updatePrice(this.brandedCheckoutItem, false)
+    }
     this.paymentType = type
     this.onPaymentFormStateChange({
       $event: {

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -61,6 +61,7 @@ export default angular
       defaultPaymentType: '<',
       hidePaymentTypeOptions: '<',
       cartData: '<',
+      brandedCheckoutItem: '<',
       onPaymentFormStateChange: '&'
     }
   })

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
@@ -1,6 +1,7 @@
 import angular from 'angular'
 import 'angular-mocks'
 import module from './paymentMethodForm.component.js'
+import { brandedCoverFeeCheckedEvent } from '../../../../app/productConfig/productConfigForm/productConfigForm.component'
 
 describe('paymentMethodForm', () => {
   beforeEach(angular.mock.module(module.name))
@@ -44,6 +45,8 @@ describe('paymentMethodForm', () => {
     beforeEach(() => {
       jest.spyOn(self.controller, 'onPaymentFormStateChange').mockImplementation(() => {})
       jest.spyOn(self.controller.orderService, 'updatePrices').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'storeBrandedCoverFeeDecision').mockImplementation(() => {})
     })
 
     it('should set the payment type to credit card', () => {
@@ -70,6 +73,7 @@ describe('paymentMethodForm', () => {
 
     it('should not update prices when setting payment type to bank account', () => {
       self.controller.cartData = undefined
+      self.controller.brandedCheckoutItem = undefined
       self.controller.changePaymentType('bankAccount')
 
       expect(self.controller.orderService.updatePrices).not.toHaveBeenCalled()
@@ -80,6 +84,28 @@ describe('paymentMethodForm', () => {
       self.controller.changePaymentType('creditCard')
 
       expect(self.controller.orderService.updatePrices).not.toHaveBeenCalled()
+    })
+
+    it('should update price when setting payment type to bank account', () => {
+      jest.spyOn(self.controller.$scope, '$emit').mockImplementation(() => {})
+      self.controller.cartData = undefined
+      self.controller.brandedCheckoutItem = { coverFees: true }
+      self.controller.changePaymentType('bankAccount')
+
+      expect(self.controller.brandedCheckoutItem.coverFees).toEqual(false)
+      expect(self.controller.orderService.storeBrandedCoverFeeDecision).toHaveBeenCalledWith(false)
+      expect(self.controller.orderService.updatePrice).toHaveBeenCalledWith(self.controller.brandedCheckoutItem, false)
+      expect(self.controller.$scope.$emit).toHaveBeenCalledWith(brandedCoverFeeCheckedEvent)
+    })
+
+    it('should not update price when setting payment type to credit card', () => {
+      self.controller.cartData = undefined
+      self.controller.brandedCheckoutItem = { coverFees: true }
+      self.controller.changePaymentType('creditCard')
+
+      expect(self.controller.brandedCheckoutItem.coverFees).toEqual(true)
+      expect(self.controller.orderService.storeBrandedCoverFeeDecision).not.toHaveBeenCalled()
+      expect(self.controller.orderService.updatePrice).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
@@ -46,7 +46,7 @@ describe('paymentMethodForm', () => {
       jest.spyOn(self.controller, 'onPaymentFormStateChange').mockImplementation(() => {})
       jest.spyOn(self.controller.orderService, 'updatePrices').mockImplementation(() => {})
       jest.spyOn(self.controller.orderService, 'updatePrice').mockImplementation(() => {})
-      jest.spyOn(self.controller.orderService, 'storeBrandedCoverFeeDecision').mockImplementation(() => {})
+      jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
     })
 
     it('should set the payment type to credit card', () => {
@@ -93,7 +93,7 @@ describe('paymentMethodForm', () => {
       self.controller.changePaymentType('bankAccount')
 
       expect(self.controller.brandedCheckoutItem.coverFees).toEqual(false)
-      expect(self.controller.orderService.storeBrandedCoverFeeDecision).toHaveBeenCalledWith(false)
+      expect(self.controller.orderService.storeCoverFeeDecision).toHaveBeenCalledWith(false)
       expect(self.controller.orderService.updatePrice).toHaveBeenCalledWith(self.controller.brandedCheckoutItem, false)
       expect(self.controller.$scope.$emit).toHaveBeenCalledWith(brandedCoverFeeCheckedEvent)
     })
@@ -104,7 +104,7 @@ describe('paymentMethodForm', () => {
       self.controller.changePaymentType('creditCard')
 
       expect(self.controller.brandedCheckoutItem.coverFees).toEqual(true)
-      expect(self.controller.orderService.storeBrandedCoverFeeDecision).not.toHaveBeenCalled()
+      expect(self.controller.orderService.storeCoverFeeDecision).not.toHaveBeenCalled()
       expect(self.controller.orderService.updatePrice).not.toHaveBeenCalled()
     })
   })

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.tpl.html
@@ -56,6 +56,7 @@
                     disable-card-number="$ctrl.disableCardNumber"
                     hide-cvv="$ctrl.hideCvv"
                     mailing-address="$ctrl.mailingAddress"
-                    cart-data="$ctrl.cartData"></credit-card-form>
+                    cart-data="$ctrl.cartData"
+                    branded-checkout-item="$ctrl.brandedCheckoutItem"></credit-card-form>
 
 </div>

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -352,6 +352,27 @@ class Order {
     return cartData
   }
 
+  storeBrandedCoverFeeDecision (coverFees) {
+    this.localStorage.setItem('brandedCoverFees', angular.toJson(coverFees))
+  }
+
+  retrieveBrandedCoverFeeDecision () {
+    return angular.fromJson(this.localStorage.getItem('brandedCoverFees'))
+  }
+
+  storeBrandedFeesApplied (feesApplied) {
+    this.localStorage.setItem('brandedFeesApplied', angular.toJson(feesApplied))
+  }
+
+  retrieveBrandedFeesApplied () {
+    return angular.fromJson(this.localStorage.getItem('brandedFeesApplied'))
+  }
+
+  clearBrandedCoverFees () {
+    this.localStorage.removeItem('brandedCoverFees')
+    this.localStorage.removeItem('brandedFeesApplied')
+  }
+
   turnDateStringsToDates (cartData) {
     cartData.items.map(item => {
       if (item.frequency !== 'Single') {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -352,27 +352,6 @@ class Order {
     return cartData
   }
 
-  storeBrandedCoverFeeDecision (coverFees) {
-    this.localStorage.setItem('brandedCoverFees', angular.toJson(coverFees))
-  }
-
-  retrieveBrandedCoverFeeDecision () {
-    return angular.fromJson(this.localStorage.getItem('brandedCoverFees'))
-  }
-
-  storeBrandedFeesApplied (feesApplied) {
-    this.localStorage.setItem('brandedFeesApplied', angular.toJson(feesApplied))
-  }
-
-  retrieveBrandedFeesApplied () {
-    return angular.fromJson(this.localStorage.getItem('brandedFeesApplied'))
-  }
-
-  clearBrandedCoverFees () {
-    this.localStorage.removeItem('brandedCoverFees')
-    this.localStorage.removeItem('brandedFeesApplied')
-  }
-
   turnDateStringsToDates (cartData) {
     cartData.items.map(item => {
       if (item.frequency !== 'Single') {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -412,13 +412,8 @@ class Order {
 
   updatePrices (cartData) {
     this.storeCoverFeeDecision(cartData.coverFees)
-    let newTotal = 0
 
-    angular.forEach(cartData.items, (item) => {
-      newTotal += this.updatePrice(item, cartData.coverFees)
-    })
-
-    cartData.cartTotal = newTotal
+    cartData.cartTotal = cartData.items.reduce((total, item) => total + this.updatePrice(item, cartData.coverFees), 0)
     this.recalculateFrequencyTotals(cartData)
     this.storeCartData(cartData)
   }

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -443,25 +443,29 @@ class Order {
     let newTotal = 0
 
     angular.forEach(cartData.items, (item) => {
-      let newAmount
-      if (cartData.coverFees) {
-        newAmount = item.amountWithFee
-      } else {
-        if (parseFloat(item.amount) === parseFloat(item.amountWithFee)) {
-          newAmount = this.calculateAmountWithoutFees(item.amount)
-        } else {
-          newAmount = item.amount
-        }
-      }
-
-      item.amount = round(parseFloat(newAmount), 2)
-      item.price = `$${this.$filter('number')(newAmount, 2)}`
-      newTotal += item.amount
+      newTotal += this.updatePrice(item, cartData.coverFees)
     })
 
     cartData.cartTotal = newTotal
     this.recalculateFrequencyTotals(cartData)
     this.storeCartData(cartData)
+  }
+
+  updatePrice (item, coverFees) {
+    let newAmount
+    if (coverFees) {
+      newAmount = item.amountWithFee
+    } else {
+      if (parseFloat(item.amount) === parseFloat(item.amountWithFee)) {
+        newAmount = this.calculateAmountWithoutFees(item.amount)
+      } else {
+        newAmount = item.amount
+      }
+    }
+
+    item.amount = round(parseFloat(newAmount), 2)
+    item.price = `$${this.$filter('number')(newAmount, 2)}`
+    return item.amount
   }
 
   recalculateFrequencyTotals (cartData) {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -398,18 +398,11 @@ class Order {
     angular.forEach(cartItems, (item) => {
       if (feesApplied) {
         item.amountWithFee = item.amount
-        item.priceWithFee = item.price
       } else {
         item.amountWithFee = round(this.calculateAmountWithFees(item.amount), 2)
-        item.priceWithFee = this.calculatePriceWithFees(item.amount)
       }
     })
     return true
-  }
-
-  calculatePriceWithFees (originalAmount) {
-    const newAmount = this.calculateAmountWithFees(originalAmount)
-    return `$${this.$filter('number')(newAmount, 2)}`
   }
 
   calculateAmountWithFees (originalAmount) {

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -1050,20 +1050,14 @@ describe('order service', () => {
         { amount: 3 }
       ]
 
-      jest.spyOn(self.orderService, 'calculateAmountWithFees').mockImplementation(input => input)
-
       expect(cartItems[0].amountWithFee).not.toBeDefined()
       expect(cartItems[1].amountWithFee).not.toBeDefined()
       expect(cartItems[2].amountWithFee).not.toBeDefined()
       self.orderService.calculatePricesWithFees(false, cartItems)
 
-      expect(cartItems[0].amountWithFee).toBeDefined()
-      expect(cartItems[1].amountWithFee).toBeDefined()
-      expect(cartItems[2].amountWithFee).toBeDefined()
-
-      expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(2)
-      expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(1)
-      expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(3)
+      expect(cartItems[0].amountWithFee).toEqual(2.05)
+      expect(cartItems[1].amountWithFee).toEqual(1.02)
+      expect(cartItems[2].amountWithFee).toEqual(3.07)
     })
 
     it('Should recognize that the current amount is the amount with fees', () => {

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -1050,7 +1050,6 @@ describe('order service', () => {
         { amount: 3 }
       ]
 
-      jest.spyOn(self.orderService, 'calculatePriceWithFees').mockImplementation(input => input)
       jest.spyOn(self.orderService, 'calculateAmountWithFees').mockImplementation(input => input)
 
       expect(cartItems[0].amountWithFee).not.toBeDefined()
@@ -1062,9 +1061,6 @@ describe('order service', () => {
       expect(cartItems[1].amountWithFee).toBeDefined()
       expect(cartItems[2].amountWithFee).toBeDefined()
 
-      expect(self.orderService.calculatePriceWithFees).toHaveBeenCalledWith(2)
-      expect(self.orderService.calculatePriceWithFees).toHaveBeenCalledWith(1)
-      expect(self.orderService.calculatePriceWithFees).toHaveBeenCalledWith(3)
       expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(2)
       expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(1)
       expect(self.orderService.calculateAmountWithFees).toHaveBeenCalledWith(3)
@@ -1081,23 +1077,6 @@ describe('order service', () => {
       expect(cartItems[0].amountWithFee).toEqual(2.05)
       expect(cartItems[1].amountWithFee).toEqual(1.02)
       expect(cartItems[2].amountWithFee).toEqual(3.07)
-    })
-  })
-
-  describe('calculatePriceWithFees', () => {
-    it('Should calculate the proper amount', () => {
-      let priceWithFees = self.orderService.calculatePriceWithFees(2)
-      expect(priceWithFees).toEqual('$2.05')
-      priceWithFees = self.orderService.calculatePriceWithFees(10)
-      expect(priceWithFees).toEqual('$10.24')
-      priceWithFees = self.orderService.calculatePriceWithFees(100)
-      expect(priceWithFees).toEqual('$102.41')
-      priceWithFees = self.orderService.calculatePriceWithFees(1000)
-      expect(priceWithFees).toEqual('$1,024.07')
-      priceWithFees = self.orderService.calculatePriceWithFees(10000)
-      expect(priceWithFees).toEqual('$10,240.66')
-      priceWithFees = self.orderService.calculatePriceWithFees(100000)
-      expect(priceWithFees).toEqual('$102,406.55')
     })
   })
 


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2190)
[OKR - Improve online giving experience, and provide more giving and engagement opportunities: Encourage generous giving from our donors](https://docs.google.com/presentation/d/1zOAeUeY0F_FgjJmsejfsdVGJ3UL9H26pt__z6N2CmU8/edit?ts=5f43dd6f&pli=1#slide=id.g928c48312d_1_198)

This PR adds the "cover fees" checkbox to branded checkout as an opt-in. We went with an opt-in solution because adding a new section to the branded checkout might look bad on individual client implementations depending on how they did their styling.

This uses a separate set of local storage variables in order to not affect the standard checkout.