### PR TITLE
SIEBUPG-299: Fix modal close icon

### DIFF
--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -17,7 +17,7 @@
     }
 
     button.close {
-      background: url("assets/img/close-mobile.png");
+      background: url("/assets/img/close-mobile.png");
       background-size: contain;
       width: 27px;
       height: 27px;
@@ -34,7 +34,7 @@
 
     @media (min-width: 992px) {
       button.close {
-        background: url("assets/img/close-icon.png");
+        background: url("/assets/img/close-icon.png");
         background-size: contain;
         width: 36px;
         height: 36px;


### PR DESCRIPTION
https://jira.cru.org/browse/SIEBUPG-299

These images should really be run through Webpack's file loader. I tried quickly but there's a lot of legacy AEM CSS in this project and I was having trouble wiring up all the icon font css imports.