### PR TITLE
Fix-Transaction-GTM-Event

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -484,9 +484,9 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         // The purchaseId number from the last purchase
         const lastTransactionId = sessionStorage.getItem('transactionId')
         // The purchaseId number from the pruchase data being passed in
-        const currentTransactionId = purchaseData.rawData['purchase-number']
+        const currentTransactionId = purchaseData && purchaseData.rawData['purchase-number']
         // If the lastTransactionId and the current one do not match, we need to send an analytics event for the transaction
-        if (lastTransactionId !== currentTransactionId) {
+        if (purchaseData && lastTransactionId !== currentTransactionId) {
           // Set the transactionId in localStorage to be the one that is passed in
           sessionStorage.setItem('transactionId', currentTransactionId)
           const cartObject = transactionCart.items.map((cartItem) => {

--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -482,13 +482,13 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         // Parse the cart object of the last purchase
         const transactionCart = JSON.parse(localStorage.getItem('transactionCart'))
         // The purchaseId number from the last purchase
-        const lastTransactionId = localStorage.getItem('transactionId')
+        const lastTransactionId = sessionStorage.getItem('transactionId')
         // The purchaseId number from the pruchase data being passed in
         const currentTransactionId = purchaseData.rawData['purchase-number']
         // If the lastTransactionId and the current one do not match, we need to send an analytics event for the transaction
         if (lastTransactionId !== currentTransactionId) {
           // Set the transactionId in localStorage to be the one that is passed in
-          localStorage.setItem('transactionId', currentTransactionId)
+          sessionStorage.setItem('transactionId', currentTransactionId)
           const cartObject = transactionCart.items.map((cartItem) => {
             return {
               name: cartItem.displayName.toLowerCase(),

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -161,20 +161,6 @@ class Step3Controller {
       this.submissionError = isString(error && error.data) ? (error && error.data).replace(/[:].*$/, '') : 'generic error' // Keep prefix before first colon for easier ng-switch matching
       this.$window.scrollTo(0, 0)
     })
-    // Get the purchase link to load purchase data
-    const lastPurchaseLink = this.orderService.retrieveLastPurchaseLink()
-    if (!lastPurchaseLink) {
-      return
-    }
-    // Load purchase data
-    this.profileService.getPurchase(lastPurchaseLink)
-      .subscribe((data) => {
-      // Run ecommerce transaction event
-        this.analyticsFactory.transactionEvent(data, this.cartData)
-      },
-      (error) => {
-        this.$log.error('Error loading purchase data for transaction event', error)
-      })
   }
 }
 

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -324,8 +324,6 @@ describe('checkout', () => {
       beforeEach(() => {
         jest.spyOn(self.controller.orderService, 'submit')
         jest.spyOn(self.controller.profileService, 'getPurchase')
-        jest.spyOn(self.controller.analyticsFactory, 'transactionEvent').mockImplementation(() => {})
-        self.controller.cartData = 'cartData'
       })
 
       describe('another order submission in progress', () => {
@@ -340,7 +338,6 @@ describe('checkout', () => {
 
       describe('submit single order', () => {
         beforeEach(() => {
-          jest.spyOn(self.controller.orderService, 'retrieveLastPurchaseLink').mockReturnValue(Observable.of('purchaseLink'))
           jest.spyOn(self.controller.$scope, '$emit').mockImplementation(() => {})
         })
 
@@ -348,9 +345,6 @@ describe('checkout', () => {
           expect(self.controller.onSubmittingOrder).toHaveBeenCalledWith({ value: true })
           expect(self.controller.onSubmittingOrder).toHaveBeenCalledWith({ value: false })
           expect(self.controller.onSubmitted).toHaveBeenCalled()
-          expect(self.controller.orderService.retrieveLastPurchaseLink).toHaveBeenCalled()
-          expect(self.controller.profileService.getPurchase).toHaveBeenCalled()
-          expect(self.controller.analyticsFactory.transactionEvent).toHaveBeenCalledWith('purchaseData', 'cartData')
         })
 
         it('should submit the order normally if paying with a bank account', () => {
@@ -439,33 +433,6 @@ describe('checkout', () => {
 
           expect(self.controller.orderService.clearCoverFees).toHaveBeenCalled()
           expect(self.controller.orderService.clearCartData).toHaveBeenCalled()
-        })
-      })
-
-      describe('error retrieving lastPurchaseLink when submitting single order', () => {
-        beforeEach(() => {
-          jest.spyOn(self.controller.orderService, 'retrieveLastPurchaseLink').mockReturnValue(undefined)
-        })
-
-        it('should just return if no purchase link is found', () => {
-          self.controller.bankAccountPaymentDetails = {}
-          self.controller.submitOrder()
-
-          expect(self.controller.analyticsFactory.transactionEvent).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('error with getPurchase when submitting single order', () => {
-        beforeEach(() => {
-          jest.spyOn(self.controller.profileService, 'getPurchase').mockReturnValue(Observable.throw('some error'))
-        })
-
-        it('should just return if no purchase link is found', () => {
-          self.controller.bankAccountPaymentDetails = {}
-          self.controller.submitOrder()
-
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error loading purchase data for transaction event', 'some error'])
-          expect(self.controller.analyticsFactory.transactionEvent).not.toHaveBeenCalled()
         })
       })
     })

--- a/src/app/thankYou/summary/thankYouSummary.component.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.js
@@ -81,6 +81,7 @@ class ThankYouSummaryController {
 
         this.analyticsFactory.pageLoaded()
         this.analyticsFactory.setPurchaseNumber(data.rawData['purchase-number'])
+        this.analyticsFactory.transactionEvent(this.purchase)
       },
       (error) => {
         this.$log.error('Error loading purchase data for thank you component', error)

--- a/src/app/thankYou/summary/thankYouSummary.component.spec.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.spec.js
@@ -105,6 +105,7 @@ describe('thank you summary', () => {
   describe('loadLastPurchase', () => {
     it('should load all data from the last completed purchase', () => {
       jest.spyOn(self.controller.profileService, 'getPurchase')
+      jest.spyOn(self.controller.analyticsFactory, 'transactionEvent')
       self.controller.loadLastPurchase()
 
       expect(self.controller.profileService.getPurchase).toHaveBeenCalledWith('/purchases/crugive/iiydanbt=')
@@ -127,6 +128,7 @@ describe('thank you summary', () => {
       expect(self.controller.onPurchaseLoaded).toHaveBeenCalledWith({
         $event: { purchase: self.mockPurchase }
       })
+      expect(self.controller.analyticsFactory.transactionEvent).toHaveBeenCalledWith(self.mockPurchase)
     })
 
     it('should not request purchase data if lastPurchaseLink is not defined', () => {


### PR DESCRIPTION
Clark realized that transaction events aren't actually firing on give stage or prod. I think it has something to do with where the call is made, and the dataLayer being uninitialized during page loads(from review checkout to the thank you summary page). So over the weekend, I thought of a solution to prevent duplicate transaction event calls on the thank you summary page. Basically when the purchase is made I store their cart in localStorage in order for use in the transaction event. I then check localStorage for ```transactionId``` to see if it matches the purchase id coming into the function. If it doesn't I know this is a new purchase, so we need to send a transaction event and also store this purchase id in localStorage as ```transactionId```. That way if they refresh the page or something to that extent, the ```transactionId``` is set in localStorage, and the id's will now match so it won't send a duplicate transaction event. I then also remove the cart from local storage since it's no longer needed. Let me know what you think of this solution. I thought going with localStorage would be better anyway since the digitalData layer will probably go away sometime in the future.