### PR TITLE
Change-Code-To-DesignationNumber

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -215,7 +215,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
       const cartObject = cart.items.map((cartItem) => {
         return {
           name: cartItem.displayName.toLowerCase(),
-          id: cartItem.code,
+          id: cartItem.designationNumber,
           price: cartItem.amount.toString(),
           branch: 'cru',
           category: cartItem.designationType.toLowerCase(),
@@ -531,7 +531,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
             purchaseTotal += cartItem.amount
             return {
               name: cartItem.displayName.toLowerCase(),
-              id: cartItem.code,
+              id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
               brand: 'cru',
               category: cartItem.designationType.toLowerCase(),


### PR DESCRIPTION
These were missed in the initial implementation. Good thing is, they are not relying on this data yet and can still utilize AA until this is fully ready. I made sure to get all instances of ```.code``` and change it to ```.designationNumber``` this time inside the analyticsFactory.