### PR TITLE
Change-Product-Names-To-Use-Designation-Number

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -118,7 +118,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               currencyCode: 'USD',
               add: {
                 products: [{
-                  name: productData.displayName.toLowerCase(),
+                  name: productData.designationNumber,
                   id: productData.designationNumber,
                   price: itemConfig.amount.toString(),
                   brand: 'cru',
@@ -170,7 +170,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                 currencyCode: 'USD',
                 remove: {
                   products: [{
-                    name: item.displayName.toLowerCase(),
+                    name: item.designationNumber,
                     id: item.designationNumber,
                     price: item.amount.toString(),
                     brand: 'cru',
@@ -214,7 +214,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
       }
       const cartObject = cart.items.map((cartItem) => {
         return {
-          name: cartItem.displayName.toLowerCase(),
+          name: cartItem.designationNumber,
           id: cartItem.designationNumber,
           price: cartItem.amount.toString(),
           branch: 'cru',
@@ -402,7 +402,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
             currencyCode: 'USD',
             detail: {
               products: [{
-                name: productData.displayName.toLowerCase(),
+                name: productData.designationNumber,
                 id: productData.designationNumber,
                 price: undefined,
                 brand: 'cru',
@@ -479,7 +479,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                 },
                 products: [
                   {
-                    name: product.name,
+                    name: product.designationNumber,
                     id: product.designationNumber,
                     price: undefined,
                     brand: 'cru',
@@ -530,7 +530,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
           const cartObject = transactionCart.items.map((cartItem) => {
             purchaseTotal += cartItem.amount
             return {
-              name: cartItem.displayName.toLowerCase(),
+              name: cartItem.designationNumber,
               id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
               brand: 'cru',


### PR DESCRIPTION
I know we still have a code feeze, but another pr that I'm making just to have the work done for when the freeze is over. Part of the team was a little uneasy with being able to see the names of people and how much they were getting donated. So they requested we switch to using the designation number instead.