### PR TITLE
Fix issues with cover fees

### DIFF
--- a/src/common/filters/coverFees.filter.js
+++ b/src/common/filters/coverFees.filter.js
@@ -32,7 +32,7 @@ function CoverFees (orderService) {
         case TOTAL:
           return item.total
         case CART_TOTAL:
-          return item.cartTotal
+          return item.cartTotalDisplay
       }
     }
   }

--- a/src/common/filters/coverFees.filter.spec.js
+++ b/src/common/filters/coverFees.filter.spec.js
@@ -31,7 +31,8 @@ describe('coverFees filter', () => {
     frequencyTotals: [
       { frequency: 'Single', totalWithFees: priceWithFees }
     ],
-    cartTotal: price
+    cartTotal: amount,
+    cartTotalDisplay: price
   }
 
   it('should use the original price', () => {
@@ -56,7 +57,7 @@ describe('coverFees filter', () => {
 
   it('should use the original cartTotal', () => {
     jest.spyOn(self.orderService, 'retrieveCoverFeeDecision').mockImplementationOnce(() => false)
-    expect(self.$filter('coverFeesFilter')(price, item, 'cartTotal')).toEqual(item.cartTotal)
+    expect(self.$filter('coverFeesFilter')(price, item, 'cartTotal')).toEqual(item.cartTotalDisplay)
   })
 
   it('should use the cartTotal with fees', () => {

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -106,9 +106,11 @@ class Cart {
     })
 
     let cartTotal
+    let cartTotalDisplay
     const frequencyTotals = map(cartResponse.rateTotals, rateTotal => {
       if (rateTotal.recurrence.interval === 'NA') {
         cartTotal = rateTotal.cost.amount
+        cartTotalDisplay = rateTotal.cost.display
       }
       return {
         frequency: rateTotal.recurrence.display,
@@ -129,7 +131,8 @@ class Cart {
       id: this.hateoasHelperService.getLink(cartResponse.total, 'cart').split('/').pop(),
       items: items.reverse(), // Show most recent cart items first
       frequencyTotals: frequencyTotals,
-      cartTotal: cartTotal || frequencyTotals[0].amount
+      cartTotal: cartTotal || frequencyTotals[0].amount,
+      cartTotalDisplay: cartTotalDisplay
     }
   }
 

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -131,8 +131,8 @@ class Cart {
       id: this.hateoasHelperService.getLink(cartResponse.total, 'cart').split('/').pop(),
       items: items.reverse(), // Show most recent cart items first
       frequencyTotals: frequencyTotals,
-      cartTotal: cartTotal || frequencyTotals[0].amount,
-      cartTotalDisplay: cartTotalDisplay
+      cartTotal: cartTotal || (cartResponse.total && cartResponse.total.cost.amount),
+      cartTotalDisplay: cartTotalDisplay || (cartResponse.total && cartResponse.total.cost.display)
     }
   }
 

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -67,64 +67,67 @@ class Cart {
           this.setCartCountCookie(0)
           return {}
         }
+        return this.handleCartResponse(cartResponse, nextDrawDate)
+      })
+  }
 
-        const items = map(cartResponse.lineItems, item => {
-          const frequency = item.rate.recurrence.display
-          const itemConfig = omit(item.itemfields, ['self', 'links'])
-          const giftStartDate = frequency !== 'Single'
-            ? startMonth(itemConfig['recurring-day-of-month'], itemConfig['recurring-start-month'], nextDrawDate) : null
-          const giftStartDateDaysFromNow = giftStartDate ? giftStartDate.diff(new Date(), 'days') : 0
+  handleCartResponse (cartResponse, nextDrawDate) {
+    const items = map(cartResponse.lineItems, item => {
+      const frequency = item.rate.recurrence.display
+      const itemConfig = omit(item.itemfields, ['self', 'links'])
+      const giftStartDate = frequency !== 'Single'
+        ? startMonth(itemConfig['recurring-day-of-month'], itemConfig['recurring-start-month'], nextDrawDate) : null
+      const giftStartDateDaysFromNow = giftStartDate ? giftStartDate.diff(new Date(), 'days') : 0
 
-          let designationType
-          angular.forEach(item.itemDefinition['details'], (v, k) => {
-            if (v['name'] === 'designation_type') {
-              designationType = v['display-value']
-            }
-          })
-
-          return {
-            uri: item.self.uri,
-            code: item.itemCode.code,
-            displayName: item.itemDefinition['display-name'],
-            designationType: designationType,
-            price: item.rate.cost.display,
-            priceWithFees: item.rate.cost['display-with-fees'],
-            config: itemConfig,
-            frequency: frequency,
-            amount: item.rate.cost.amount,
-            amountWithFees: item.rate.cost['amount-with-fees'],
-            designationNumber: item.itemCode['product-code'],
-            productUri: item.item.self.uri,
-            giftStartDate: giftStartDate,
-            giftStartDateDaysFromNow: giftStartDateDaysFromNow,
-            giftStartDateWarning: giftStartDateDaysFromNow >= 275
-          }
-        })
-
-        let cartTotal
-        const frequencyTotals = map(cartResponse.rateTotals, rateTotal => {
-          if (rateTotal.recurrence.interval === 'NA') {
-            cartTotal = rateTotal.cost.amount
-          }
-          return {
-            frequency: rateTotal.recurrence.display,
-            amount: rateTotal.cost.amount,
-            amountWithFees: rateTotal.cost['amount-with-fees'],
-            total: rateTotal.cost.display,
-            totalWithFees: rateTotal.cost['display-with-fees']
-          }
-        })
-
-        // set cart item count cookie
-        this.setCartCountCookie(items.length)
-
-        return {
-          id: this.hateoasHelperService.getLink(cartResponse.total, 'cart').split('/').pop(),
-          items: items.reverse(), // Show most recent cart items first
-          frequencyTotals: frequencyTotals,
-          cartTotal: cartTotal || frequencyTotals[0].amount
+      let designationType
+      angular.forEach(item.itemDefinition['details'], (v, k) => {
+        if (v['name'] === 'designation_type') {
+          designationType = v['display-value']
         }
       })
+
+      return {
+        uri: item.self.uri,
+        code: item.itemCode.code,
+        displayName: item.itemDefinition['display-name'],
+        designationType: designationType,
+        price: item.rate.cost.display,
+        priceWithFees: item.rate.cost['display-with-fees'],
+        config: itemConfig,
+        frequency: frequency,
+        amount: item.rate.cost.amount,
+        amountWithFees: item.rate.cost['amount-with-fees'],
+        designationNumber: item.itemCode['product-code'],
+        productUri: item.item.self.uri,
+        giftStartDate: giftStartDate,
+        giftStartDateDaysFromNow: giftStartDateDaysFromNow,
+        giftStartDateWarning: giftStartDateDaysFromNow >= 275
+      }
+    })
+
+    let cartTotal
+    const frequencyTotals = map(cartResponse.rateTotals, rateTotal => {
+      if (rateTotal.recurrence.interval === 'NA') {
+        cartTotal = rateTotal.cost.amount
+      }
+      return {
+        frequency: rateTotal.recurrence.display,
+        amount: rateTotal.cost.amount,
+        amountWithFees: rateTotal.cost['amount-with-fees'],
+        total: rateTotal.cost.display,
+        totalWithFees: rateTotal.cost['display-with-fees']
+      }
+    })
+
+    // set cart item count cookie
+    this.setCartCountCookie(items.length)
+
+    return {
+      id: this.hateoasHelperService.getLink(cartResponse.total, 'cart').split('/').pop(),
+      items: items.reverse(), // Show most recent cart items first
+      frequencyTotals: frequencyTotals,
+      cartTotal: cartTotal || frequencyTotals[0].amount
+    }
   }
 
   getTotalQuantity () {

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -120,6 +120,8 @@ class Cart {
         totalWithFees: rateTotal.cost['display-with-fees']
       }
     })
+    // The API returns Single gift rate totals as the last item in the list, so we should move it to the first item
+    // to preserve the ordering in the UI (Single gift totals first).
     if (cartTotal) {
       frequencyTotals.unshift(frequencyTotals.pop())
     }

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -118,6 +118,9 @@ class Cart {
         totalWithFees: rateTotal.cost['display-with-fees']
       }
     })
+    if (cartTotal) {
+      frequencyTotals.unshift(frequencyTotals.pop())
+    }
 
     // set cart item count cookie
     this.setCartCountCookie(items.length)

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -117,6 +117,7 @@ describe('cart service', () => {
       expect(data.items[1].giftStartDate.toString()).toEqual(moment('2016-10-09').toString())
 
       expect(data.cartTotal).toEqual(50)
+      expect(data.cartTotalDisplay).toEqual('$50.00')
       expect(data.frequencyTotals).toEqual([
         { frequency: 'Single', amount: 50, amountWithFees: 51.2, total: '$50.00', totalWithFees: '$51.20' },
         { frequency: 'Annually', amount: 50, amountWithFees: 51.2, total: '$50.00', totalWithFees: '$51.20' },

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -95,19 +95,25 @@ describe('cart service', () => {
   })
 
   describe('handleCartResponse', () => {
+    const zoom = {
+      lineItems: 'lineitems:element[],lineitems:element:availability,lineitems:element:item,lineitems:element:item:code,lineitems:element:item:definition,lineitems:element:rate,lineitems:element:total,lineitems:element:itemfields',
+      rateTotals: 'ratetotals:element[]',
+      total: 'total,total:cost'
+    }
+    let transformedCartResponse
+
     beforeEach(() => {
       jest.spyOn(self.cartService.$cookies, 'put').mockImplementation(() => {})
       jest.spyOn(self.cartService.$cookies, 'remove').mockImplementation(() => {})
       advanceTo(moment('2016-09-01').toDate()) // Make sure current date is before next draw date
+      transformedCartResponse = self.cartService.hateoasHelperService.mapZoomElements(cartResponse, zoom)
+      transformedCartResponse.rateTotals[0].cost.amount = 51
+      transformedCartResponse.rateTotals[0].cost['amount-with-fees'] = 52.23
+      transformedCartResponse.rateTotals[0].cost.display = '$51.00'
+      transformedCartResponse.rateTotals[0].cost['display-with-fees'] = '$52.23'
     })
 
     it('should get cart, parse response, and show most recent items first', () => {
-      const zoom = {
-        lineItems: 'lineitems:element[],lineitems:element:availability,lineitems:element:item,lineitems:element:item:code,lineitems:element:item:definition,lineitems:element:rate,lineitems:element:total,lineitems:element:itemfields',
-        rateTotals: 'ratetotals:element[]',
-        total: 'total,total:cost'
-      }
-      const transformedCartResponse = self.cartService.hateoasHelperService.mapZoomElements(cartResponse, zoom)
       const data = self.cartService.handleCartResponse(transformedCartResponse, '2016-10-01')
       // verify response
       expect(data.items.length).toEqual(3)
@@ -120,11 +126,27 @@ describe('cart service', () => {
       expect(data.cartTotalDisplay).toEqual('$50.00')
       expect(data.frequencyTotals).toEqual([
         { frequency: 'Single', amount: 50, amountWithFees: 51.2, total: '$50.00', totalWithFees: '$51.20' },
-        { frequency: 'Annually', amount: 50, amountWithFees: 51.2, total: '$50.00', totalWithFees: '$51.20' },
+        { frequency: 'Annually', amount: 51, amountWithFees: 52.23, total: '$51.00', totalWithFees: '$52.23' },
         { frequency: 'Quarterly', amount: 50, amountWithFees: 51.2, total: '$50.00', totalWithFees: '$51.20' }
       ])
 
       expect(self.cartService.$cookies.put).toHaveBeenCalledWith('giveCartItemCount', 3, expect.any(Object))
+    })
+
+    it('should handle total correctly if the order changes from the API', () => {
+      transformedCartResponse.rateTotals.unshift(transformedCartResponse.rateTotals.pop())
+
+      const data = self.cartService.handleCartResponse(transformedCartResponse, '2016-10-01')
+      expect(data.cartTotal).toEqual(50)
+      expect(data.cartTotalDisplay).toEqual('$50.00')
+    })
+
+    it('should handle fallback total', () => {
+      transformedCartResponse.rateTotals.pop()
+
+      const data = self.cartService.handleCartResponse(transformedCartResponse, '2016-10-01')
+      expect(data.cartTotal).toEqual(50)
+      expect(data.cartTotalDisplay).toEqual('$50.00')
     })
   })
 


### PR DESCRIPTION
Found a couple of issues with the cover-fees code. The primary one being that the wrong amount shows up in the nav-cart (showing the numerical instead of display amount). Secondarily, the old code would show the cart total, which is based off of the one-time total, the new code showed either the cart total or the first rate total, which could be a recurring total. This PR puts that back to the way it was. Third, I added some tests to show some of these failures and fixes.