### PR TITLE
Update CCP public keys

### DIFF
--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -1,14 +1,14 @@
 // These CCP keys are used as backup keys if a network request for one fails.
 // They should be updated annually (around mid-April) as CCP rotates encryption keys.
-// Last updated 06/22/2017
+// Last updated 07/01/2021
 const ccpKey = '-----BEGIN PUBLIC KEY-----' +
-  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnY7iTAnM/B1uFZ2AH0yj' +
-  'pmwiBzzk7p6aFBfScpJ9ZMPwD3PjujTzobZpRm2pXF2XoaWqccZQyQ02TW6IfnFT' +
-  '/+6/y/hmsMv2E3Lr7kILpJbHwAitFt2jNCXFYH25o0azq46Cy429tTHyVYDzrm27' +
-  'pAvHwblPLTiS+/urMAOoBeq4Quk8P/9xP0Ia5z7hrL85sPxBRSIqzOtNmw2ce/V4' +
-  'LsYri8058wDNaeLPSUamUtjI6g7CP1UcLFB69NM3ZeCauUTp1BTUuLykOfu9GTF3' +
-  'UjMD24Ez0avvTzMHqPEBPXfslqulqSERQ7b1E6CwXonFwYMEEcek8CWYd7YJGQ8b' +
-  'HQIDAQAB' +
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvmjduk8T8riKsMGoX3Hm' +
+  'eQxCtUcRYqAUlsr5sVVu8ZFWAZC-JPbaNIGrzngZZin6J6E4DByk_rjKU9yKnSAo' +
+  'qJrl3ad7aYyCEQOoa3zi7JOFxA9s4hFs4w8UFkGS35aOEZ0m3l7tA7CV0lCeZ8IQ' +
+  '_Niltz72ulfW6RdTrCkL30zmx2f_UdaSwtgnHVi-YkV4VZUGu42jLFYGVjQsXRNq' +
+  'KRv92Y1vZ7FXlyTra5sije4ywxHmPntEKPEoKQbcdPmO8bUR9NwM_pvyx1SDysye' +
+  '4vS1vJn6VV80tudOegMT3jeQqY8xOLSZcr9Vx5lK0UDY1cAKGyA14TLgXB0qtdC7' +
+  'LQIDAQAB' +
   '-----END PUBLIC KEY-----'
 
 const ccpStagingKey = '-----BEGIN PUBLIC KEY-----' +

--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -12,13 +12,13 @@ const ccpKey = '-----BEGIN PUBLIC KEY-----' +
   '-----END PUBLIC KEY-----'
 
 const ccpStagingKey = '-----BEGIN PUBLIC KEY-----' +
-  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1wOCSLbKrlAJKa21iWZa' +
-  '4KwkEbTW1DIJLZ7kULHqOq//0TOUjIfW6DX4dULSND25uWi2hHQA2+q8uuaYCVfC' +
-  'h2IvOUygOwJyNRTwpQtlIKgq1C7xnsnO4COA8hmnkr2aAxTX1aynGWw/3gvsx2y/' +
-  'pML4UM+LeiHdrVv7zSaW92MZd+bhf4Lu3CA2doyY6uobq/+P087dLqBXS61OZSAR' +
-  'xMCKF2BquwQfEq8GyblHpjWI2SXWmB276NdKrCp/ZKH3vFoBSlLoPdVT4Qbd4sKi' +
-  'PNnKvxIBooLPQLBOO0QGv6AIgyL4Jss+dAvn5O6lckwip9QRMfINNBX3Clhq53xE' +
-  'FwIDAQAB' +
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAn7LClo93AYVUhsWlPyo1' +
+  'hT5xWKDtH8yjjPUyMRGanZQS2ZMypqDbzDD4a1fwK6YaA1OXeURaJs2Z9xUZW5Fr' +
+  'DxQSlJkocASRnUNvlSao4RGbZJmzdjPWBwKYGUno0BeCEVmABwe4dvmpyY-SNL1P' +
+  'mDB07t9X-XBj-a07Libf3RYB-1TDqdtmqPn93ERn1BoweZQXBBAIDlnI_s6ug5IK' +
+  'z7Ye8G7B_sKQ5w9kbLR8RaTRACm3i00TnCIWAKUmr9LxQSsXxXnYhIjrjEZ314-O' +
+  'y8obUvshcr8TckfhXtrisla1jorLCHA7h1CoPf8B52CGkihQVSTxFTvUde5IZhOJ' +
+  '_QIDAQAB' +
   '-----END PUBLIC KEY-----'
 
 const cortexScope = 'crugive'


### PR DESCRIPTION
This PR came about from [this Rollbar error](https://rollbar.com/Cru/ccp/items/87/). The keys should be rotated every year at the end of March/beginning of April. It looks like these haven't been rotated since 2017. This is only necessary if there are network issues.