### PR TITLE
EP-2266 - Update lock icons

### DIFF
--- a/src/app/checkout/checkout.tpl.html
+++ b/src/app/checkout/checkout.tpl.html
@@ -24,8 +24,8 @@
           <div class="col-md-12">
             <div class="panel">
               <div class="panel-body">
+                <i class="fal fa-lock-alt mr--" style="font-size: 24px;"></i>
                 <h3 class="panel-name inline-block" translate>Secure Checkout</h3>
-                <i class="fal fa-lock-alt u-floatRight"></i>
 
                 <div class="steps-wrap mb_x clearfix">
                   <div class="steps-single" ng-class="{'on': $ctrl.checkoutStep === 'contact'}">

--- a/src/app/checkout/checkout.tpl.html
+++ b/src/app/checkout/checkout.tpl.html
@@ -24,7 +24,7 @@
           <div class="col-md-12">
             <div class="panel">
               <div class="panel-body">
-                <h3 class="panel-name inline-block" translate>Checkout</h3>
+                <h3 class="panel-name inline-block" translate>Secure Checkout</h3>
                 <i class="fas fa-lock u-floatRight"></i>
 
                 <div class="steps-wrap mb_x clearfix">

--- a/src/app/checkout/checkout.tpl.html
+++ b/src/app/checkout/checkout.tpl.html
@@ -25,7 +25,7 @@
             <div class="panel">
               <div class="panel-body">
                 <h3 class="panel-name inline-block" translate>Secure Checkout</h3>
-                <i class="fas fa-lock u-floatRight"></i>
+                <i class="fal fa-lock-alt u-floatRight"></i>
 
                 <div class="steps-wrap mb_x clearfix">
                   <div class="steps-single" ng-class="{'on': $ctrl.checkoutStep === 'contact'}">

--- a/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
+++ b/src/common/components/paymentMethods/bankAccountForm/bankAccountForm.tpl.html
@@ -3,7 +3,10 @@
   <div class="mb_x panel panel-default" style="padding: 11px;">
     <div class="border-bottom-small">
       <h4 class="panel-title visible" translate>{{'BANK_ACCOUNT_PAYMENT'}}</h4>
-      <i class="fas fa-lock u-floatRight" style="margin-top:-16px"></i>
+      <span class="u-floatRight" style="margin-top:-16px">
+        Secure
+        <i class="fas fa-lock ml--"></i>
+      </span>
     </div>
 
 

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.tpl.html
@@ -4,7 +4,10 @@
 
     <div class="border-bottom-small">
       <h4 class="panel-title visible" translate>{{'CREDIT_CARD_PAYMENT'}}</h4>
-      <i class="fas fa-lock u-floatRight" style="margin-top:-16px"></i>
+      <span class="u-floatRight" style="margin-top:-16px">
+        Secure
+        <i class="fas fa-lock ml--"></i>
+      </span>
     </div>
 
     <div class="row">


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2266)

There was a dip in people going through checkout when we added the original lock icons. The thought is that maybe people are thinking the form is locked vs secure. Therefore, we are adding the word Secure in a few places and changing the look a bit. Note: Having the word `Secure` on the credit card form breaks at 370px. I don't know if that's a common screen size or not making it worth adding css to hide the word on that size and lower.