### PR TITLE
Remove-Remaining-Adobe-Analytics-Events

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -130,11 +130,6 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
             }
           })
         }
-
-        // Call DTM direct call rule
-        if (typeof $window._satellite !== 'undefined') {
-          $window._satellite.track('aa-add-to-cart')
-        }
       } catch (e) {
         // Error caught in analyticsFactory.cartAdd
       }
@@ -159,9 +154,6 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               }
             }
           }]
-          if (typeof $window._satellite !== 'undefined') {
-            $window._satellite.track('aa-cart-remove')
-          }
           // Send GTM Advance Ecommerce event
           if (typeof $window.dataLayer !== 'undefined') {
             $window.dataLayer.push({
@@ -769,13 +761,6 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         }
       } catch (e) {
         // Error caught in analyticsFactory.setSiteSections
-      }
-    },
-    track: function (event) {
-      try {
-        $window._satellite.track(event)
-      } catch (e) {
-        // Error caught in analyticsFactory.track
       }
     },
     trackGTM: function (eventName) {

--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -763,13 +763,13 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         // Error caught in analyticsFactory.setSiteSections
       }
     },
-    trackGTM: function (eventName) {
+    track: function (eventName) {
       try {
         $window.dataLayer.push({
           event: eventName
         })
       } catch (e) {
-        // Error caught in analyticsFactory.trackGTM
+        // Error caught in analyticsFactory.track
       }
     }
   }

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -98,7 +98,6 @@ class BrandedCheckoutController {
   fireAnalyticsEvents (...checkoutSteps) {
     checkoutSteps.forEach(checkoutStep => {
       this.analyticsFactory.setEvent('checkout step ' + checkoutStep)
-      this.analyticsFactory.track('aa-checkout-step-' + checkoutStep)
     })
   }
 }

--- a/src/app/checkout/checkout.component.js
+++ b/src/app/checkout/checkout.component.js
@@ -68,7 +68,6 @@ class CheckoutController {
     this.$locationChangeSuccessListener = this.$rootScope.$on('$locationChangeSuccess', () => {
       this.initStepParam(this.$location.search().step || 'contact')
       this.analyticsFactory.setEvent('checkout step ' + this.checkoutStep)
-      this.analyticsFactory.track('aa-checkout-step-' + this.checkoutStep)
       this.cartService.get().subscribe((cartData) => {
         this.analyticsFactory.checkoutStepEvent(this.$location.search().step, cartData)
       })

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -61,7 +61,7 @@
     payment-methods="$ctrl.paymentMethods"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(paymentMethod)"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-select-payment-method'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-select-payment-method')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-select-payment-method')">
   </step-0-payment-method-list>
 
   <step-0-add-update-payment-method
@@ -71,9 +71,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(paymentMethod)"
-    ng-init="$ctrl.analyticsFactory.track($ctrl.paymentMethod ?
-      'aa-edit-recurring-edit-payment-method' : 'aa-edit-recurring-add-payment-method'); $ctrl.analyticsFactory.trackGTM($ctrl.paymentMethod ?
-      'ga-edit-recurring-edit-payment-method' : 'ga-edit-recurring-add-payment-method')">
+    ng-init="$ctrl.analyticsFactory.trackGTM($ctrl.paymentMethod ? 'ga-edit-recurring-edit-payment-method' : 'ga-edit-recurring-add-payment-method')">
   </step-0-add-update-payment-method>
 
   <step-1-edit-recurring-gifts
@@ -81,7 +79,7 @@
     recurring-gifts="$ctrl.recurringGifts"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(null, recurringGifts)"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-configure'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure')">
   </step-1-edit-recurring-gifts>
 
   <step-2-add-recent-recipients
@@ -93,7 +91,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-add-recent'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-add-recent')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-add-recent')">
   </step-2-add-recent-recipients>
 
   <step-2-search-recipients
@@ -101,7 +99,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-search'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-search')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-search')">
   </step-2-search-recipients>
 
   <step-3-configure-recent-recipients
@@ -110,7 +108,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-configure-new-gifts'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure-new-gifts')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure-new-gifts')">
   </step-3-configure-recent-recipients>
 
   <step-4-confirm
@@ -120,6 +118,6 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next()"
-    ng-init="$ctrl.analyticsFactory.track('aa-edit-recurring-review'); $ctrl.analyticsFactory.trackGTM('ga-edit-recurring-review')">
+    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-review')">
   </step-4-confirm>
 </div>

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -61,7 +61,7 @@
     payment-methods="$ctrl.paymentMethods"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(paymentMethod)"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-select-payment-method')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-select-payment-method')">
   </step-0-payment-method-list>
 
   <step-0-add-update-payment-method
@@ -71,7 +71,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(paymentMethod)"
-    ng-init="$ctrl.analyticsFactory.trackGTM($ctrl.paymentMethod ? 'ga-edit-recurring-edit-payment-method' : 'ga-edit-recurring-add-payment-method')">
+    ng-init="$ctrl.analyticsFactory.track($ctrl.paymentMethod ? 'ga-edit-recurring-edit-payment-method' : 'ga-edit-recurring-add-payment-method')">
   </step-0-add-update-payment-method>
 
   <step-1-edit-recurring-gifts
@@ -79,7 +79,7 @@
     recurring-gifts="$ctrl.recurringGifts"
     dismiss="$ctrl.dismiss()"
     next="$ctrl.next(null, recurringGifts)"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-configure')">
   </step-1-edit-recurring-gifts>
 
   <step-2-add-recent-recipients
@@ -91,7 +91,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-add-recent')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-add-recent')">
   </step-2-add-recent-recipients>
 
   <step-2-search-recipients
@@ -99,7 +99,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-search')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-search')">
   </step-2-search-recipients>
 
   <step-3-configure-recent-recipients
@@ -108,7 +108,7 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-configure-new-gifts')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-configure-new-gifts')">
   </step-3-configure-recent-recipients>
 
   <step-4-confirm
@@ -118,6 +118,6 @@
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next()"
-    ng-init="$ctrl.analyticsFactory.trackGTM('ga-edit-recurring-review')">
+    ng-init="$ctrl.analyticsFactory.track('ga-edit-recurring-review')">
   </step-4-confirm>
 </div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
@@ -31,7 +31,6 @@ class ConfirmRecurringGiftsController {
   }
 
   saveChanges () {
-    this.analyticsFactory.track('aa-edit-recurring-submit')
     this.analyticsFactory.trackGTM('ga-edit-recurring-submit')
     this.saving = true
     this.savingError = ''

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.js
@@ -31,7 +31,7 @@ class ConfirmRecurringGiftsController {
   }
 
   saveChanges () {
-    this.analyticsFactory.trackGTM('ga-edit-recurring-submit')
+    this.analyticsFactory.track('ga-edit-recurring-submit')
     this.saving = true
     this.savingError = ''
     const requests = []

--- a/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step4/confirmRecurringGifts.component.spec.js
@@ -53,7 +53,7 @@ describe('editRecurringGiftsModal', () => {
           addedGifts = clone(gifts)
           return Observable.of('add gifts response')
         })
-        jest.spyOn(self.controller.analyticsFactory, 'trackGTM').mockImplementation(() => {})
+        jest.spyOn(self.controller.analyticsFactory, 'track').mockImplementation(() => {})
         self.controller.saveChanges()
 
         expect(self.controller.donationsService.updateRecurringGifts).toHaveBeenCalledWith(expect.anything())
@@ -66,7 +66,7 @@ describe('editRecurringGiftsModal', () => {
         expect(self.controller.additions).toEqual([])
         expect(self.controller.next).toHaveBeenCalled()
         expect(self.controller.savingError).toEqual('')
-        expect(self.controller.analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-edit-recurring-submit')
+        expect(self.controller.analyticsFactory.track).toHaveBeenCalledWith('ga-edit-recurring-submit')
       })
 
       it('should handle an error updating recurring gifts', () => {

--- a/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.tpl.html
+++ b/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.tpl.html
@@ -57,16 +57,14 @@
     ng-switch-when="step1SelectRecentRecipients"
     recent-recipients="$ctrl.recentRecipients"
     dismiss="$ctrl.dismiss()"
-    next="$ctrl.next(selectedRecipients, search)"
-    ng-init="$ctrl.analyticsFactory.track('aa-give-extra-1-time-your-favorites')">
+    next="$ctrl.next(selectedRecipients, search)">
   </step-1-select-recent-recipients>
 
   <step-1-search-recipients
     ng-switch-when="step1SearchRecipients"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
-    next="$ctrl.next(null, null, additionalRecipients)"
-    ng-init="$ctrl.analyticsFactory.track('aa-give-extra-1-time-search')">
+    next="$ctrl.next(null, null, additionalRecipients)">
   </step-1-search-recipients>
 
   <step-2-enter-amounts
@@ -76,7 +74,6 @@
     errors="$ctrl.errors"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
-    next="$ctrl.next(selectedRecipients)"
-    ng-init="$ctrl.analyticsFactory.track('aa-give-extra-1-time-configure')">
+    next="$ctrl.next(selectedRecipients)">
   </step-2-enter-amounts>
 </div>

--- a/src/app/profile/yourGiving/giveOneTimeGift/step2/enterAmounts.component.js
+++ b/src/app/profile/yourGiving/giveOneTimeGift/step2/enterAmounts.component.js
@@ -28,7 +28,6 @@ class EnterAmountsController {
   addToCart () {
     this.addingToCart = true
     this.next({ selectedRecipients: this.selectedRecipients })
-    this.analyticsFactory.track('aa-give-extra-1-time-add-to-cart')
   }
 }
 

--- a/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.js
+++ b/src/app/profile/yourGiving/historicalView/historicalGift/historicalGift.component.js
@@ -14,7 +14,6 @@ class HistoricalGift {
   }
 
   giveNewGift () {
-    this.analyticsFactory.track('aa-your-giving-give-new-gift')
     this.productModalService.configureProduct(this.gift['historical-donation-line']['designation-number'])
   }
 

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
@@ -72,7 +72,6 @@ class RecipientGift {
   }
 
   giveNewGift () {
-    this.analyticsFactory.track('aa-your-giving-give-new-gift')
     this.productModalService.configureProduct(this.recipient['designation-number'])
   }
 

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/redirectGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/redirectGift.tpl.html
@@ -12,14 +12,12 @@
                         gifts="$ctrl.gifts"
                         on-select-gift="$ctrl.selectGift(gift)"
                         cancel="$ctrl.cancel()"
-                        previous="$ctrl.previous()"
-                        ng-init="$ctrl.analyticsFactory.track('aa-redirect-select-recipient')">
+                        previous="$ctrl.previous()">
   </redirect-gift-step-1>
   <redirect-gift-step-2 ng-switch-when="step-2"
                         on-select-result="$ctrl.selectResult(selected)"
                         cancel="$ctrl.cancel()"
-                        previous="$ctrl.previous()"
-                        ng-init="$ctrl.analyticsFactory.track('aa-redirect-search')">
+                        previous="$ctrl.previous()">
   </redirect-gift-step-2>
   <redirect-gift-step-3 ng-switch-when="step-3"
                         stop-gift="$ctrl.selectedGift"
@@ -27,7 +25,6 @@
                         on-complete="$ctrl.complete()"
                         on-cancel="$ctrl.cancel()"
                         on-previous="$ctrl.previous()"
-                        set-loading="$ctrl.setLoading({loading: loading})"
-                        ng-init="$ctrl.analyticsFactory.track('aa-redirect-search')">
+                        set-loading="$ctrl.setLoading({loading: loading})">
   </redirect-gift-step-3>
 </div>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.component.js
@@ -22,7 +22,6 @@ class RedirectGiftStep3Controller {
   }
 
   submitGift () {
-    this.analyticsFactory.track('aa-redirect-submit')
     this.hasError = false
     this.setLoading({ loading: true })
     this.donationsService.updateRecurringGifts(this.gift).subscribe(() => {

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/redirectGift/step3/redirectGiftStep3.tpl.html
@@ -20,12 +20,12 @@
 <div class="modal-body">
   <div class="alert alert-danger" role="alert" ng-if="$ctrl.hasError" translate>An error occurred saving changes. You may try again by clicking "Confirm Changes."</div>
   <form name="$ctrl.redirectForm" ng-switch="$ctrl.state">
-    <div class="repeating-row" ng-switch-when="update" ng-init="$ctrl.analyticsFactory.track('aa-redirect-configure')">
+    <div class="repeating-row" ng-switch-when="update">
       <gift-list-item gift="$ctrl.gift">
         <gift-update-view gift="$ctrl.gift" />
       </gift-list-item>
     </div>
-    <div class="repeating-row" ng-switch-when="confirm" ng-init="$ctrl.analyticsFactory.track('aa-redirect-review')">
+    <div class="repeating-row" ng-switch-when="confirm">
       <div class="col-xs-12">
         <p class="text-danger">The recurring gift to this recipient will be stopped:</p>
       </div>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.tpl.html
@@ -28,15 +28,13 @@
                         gifts="$ctrl.suggestedRecipients"
                         cancel="$ctrl.cancel()"
                         previous="$ctrl.previous()"
-                        next="$ctrl.next(selected)"
-                        ng-init="$ctrl.analyticsFactory.track('aa-restart-select-recipients')">
+                        next="$ctrl.next(selected)">
   </suggested-recipients>
 
   <redirect-gift-step-2 ng-switch-when="search"
                         on-select-result="$ctrl.next(selected)"
                         cancel="$ctrl.cancel()"
-                        previous="$ctrl.previous()"
-                        ng-init="$ctrl.analyticsFactory.track('aa-restart-search')">
+                        previous="$ctrl.previous()">
   </redirect-gift-step-2>
 
   <!-- Step 2 -->
@@ -44,8 +42,7 @@
                    gifts="$ctrl.gifts"
                    cancel="$ctrl.cancel()"
                    previous="$ctrl.previous()"
-                   next="$ctrl.next(null, configured)"
-                   ng-init="$ctrl.analyticsFactory.track('aa-restart-configure')">
+                   next="$ctrl.next(null, configured)">
   </configure-gifts>
 
   <!-- Step 3 -->
@@ -54,8 +51,7 @@
                  cancel="$ctrl.cancel()"
                  previous="$ctrl.previous()"
                  next="$ctrl.next()"
-                 set-loading="$ctrl.setLoading({loading: loading})"
-                 ng-init="$ctrl.analyticsFactory.track('aa-restart-review')">
+                 set-loading="$ctrl.setLoading({loading: loading})">
   </confirm-gifts>
 
   <!-- Loading -->

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/step3/confirmGifts/confirmGifts.component.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/step3/confirmGifts/confirmGifts.component.js
@@ -33,7 +33,6 @@ class ConfirmGiftsController {
   }
 
   processRestarts () {
-    this.analyticsFactory.track('aa-restart-submit')
     const requests = []
     this.setLoading({ loading: true })
     if (!isEmpty(this.adds)) {

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.component.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.component.js
@@ -65,7 +65,6 @@ class StopGiftController {
   }
 
   confirmChanges () {
-    this.analyticsFactory.track('aa-stop-submit')
     this.setLoading({ loading: true })
     this.donationsService.updateRecurringGifts(map(this.selectedGifts, (gift) => {
       gift.donationLineStatus = 'Cancelled'

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/stopGift/stopGift.tpl.html
@@ -13,14 +13,12 @@
                     gifts="$ctrl.gifts"
                     on-select-gifts="$ctrl.selectGifts(selectedGifts)"
                     cancel="$ctrl.cancel()"
-                    previous="$ctrl.previous()"
-                    ng-init="$ctrl.analyticsFactory.track('aa-stop-select-recipients')">
+                    previous="$ctrl.previous()">
   </stop-gift-step-1>
   <stop-gift-step-2 ng-switch-when="step-2"
                     gifts="$ctrl.selectedGifts"
                     on-confirm="$ctrl.confirmChanges()"
                     cancel="$ctrl.cancel()"
-                    previous="$ctrl.previous()"
-                    ng-init="$ctrl.analyticsFactory.track('aa-stop-review')">
+                    previous="$ctrl.previous()">
   </stop-gift-step-2>
 </div>

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/stopStartRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/stopStartRecurringGifts.modal.tpl.html
@@ -2,8 +2,7 @@
   <stop-start-step-0 ng-switch-when="step-0"
                      gift-action="$ctrl.giftAction"
                      change-state="$ctrl.changeState(state)"
-                     cancel="$ctrl.dismiss()"
-                     ng-init="$ctrl.analyticsFactory.track('aa-stop-restart-choice')">
+                     cancel="$ctrl.dismiss()">
   </stop-start-step-0>
   <stop-gift ng-switch-when="stop"
              change-state="$ctrl.changeState(state)"

--- a/src/app/profile/yourGiving/yourGiving.component.js
+++ b/src/app/profile/yourGiving/yourGiving.component.js
@@ -138,7 +138,7 @@ class YourGivingController {
         this.recurringGiftsUpdateSuccess = true
         this.reload = true
       }, () => {
-        this.analyticsFactory.trackGTM('ga-edit-recurring-exit')
+        this.analyticsFactory.track('ga-edit-recurring-exit')
       })
   }
 

--- a/src/app/profile/yourGiving/yourGiving.component.js
+++ b/src/app/profile/yourGiving/yourGiving.component.js
@@ -118,8 +118,6 @@ class YourGivingController {
       this.view = givingViews[0]
     }
     this.$location.search(queryParams.view, this.view)
-
-    this.analyticsFactory.track(this.view === 'historical' ? 'aa-your-giving-historical-view' : 'aa-your-giving-recipient-view')
   }
 
   setViewLoading (loading) {
@@ -140,7 +138,6 @@ class YourGivingController {
         this.recurringGiftsUpdateSuccess = true
         this.reload = true
       }, () => {
-        this.analyticsFactory.track('aa-edit-recurring-exit')
         this.analyticsFactory.trackGTM('ga-edit-recurring-exit')
       })
   }
@@ -150,8 +147,6 @@ class YourGivingController {
       component: 'giveOneTimeGiftModal',
       backdrop: 'static', // Disables closing on click
       windowTemplateUrl: giveModalWindowTemplate
-    }).result.then(angular.noop, () => {
-      this.analyticsFactory.track('aa-give-extra-1-time-exit')
     })
   }
 
@@ -165,8 +160,6 @@ class YourGivingController {
       .result.then(() => {
         this.stopStartGiftsSuccess = true
         this.reload = true
-      }, () => {
-        this.analyticsFactory.track('aa-stop-restart-exit')
       })
   }
 }

--- a/src/app/profile/yourGiving/yourGiving.component.spec.js
+++ b/src/app/profile/yourGiving/yourGiving.component.spec.js
@@ -205,12 +205,10 @@ describe('your giving', function () {
     it('should call analytics event on dismiss', () => {
       const thenSpy = jest.fn()
       jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: { then: thenSpy } })
-      jest.spyOn($ctrl.analyticsFactory, 'track').mockReturnValue(null)
       jest.spyOn($ctrl.analyticsFactory, 'trackGTM').mockReturnValue(null)
       $ctrl.openEditRecurringGiftsModal()
       thenSpy.mock.calls[0][1]()
 
-      expect($ctrl.analyticsFactory.track).toHaveBeenCalledWith('aa-edit-recurring-exit')
       expect($ctrl.analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-edit-recurring-exit')
     });
   })
@@ -224,15 +222,6 @@ describe('your giving', function () {
       expect($ctrl.$uibModal.open).toHaveBeenCalledWith(expect.objectContaining({ component: 'giveOneTimeGiftModal' }))
     });
 
-    it('should call analytics event on dismiss', () => {
-      const thenSpy = jest.fn()
-      jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: { then: thenSpy } })
-      jest.spyOn($ctrl.analyticsFactory, 'track').mockReturnValue(null)
-      $ctrl.openGiveOneTimeGiftModal()
-      thenSpy.mock.calls[0][1]()
-
-      expect($ctrl.analyticsFactory.track).toHaveBeenCalledWith('aa-give-extra-1-time-exit')
-    });
   })
 
   describe('openStopStartRecurringGiftsModal', () => {
@@ -247,16 +236,6 @@ describe('your giving', function () {
 
       expect($ctrl.stopStartGiftsSuccess).toEqual(true)
       expect($ctrl.reload).toEqual(true)
-    });
-
-    it('should call analytics event on dismiss', () => {
-      const thenSpy = jest.fn()
-      jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: { then: thenSpy } })
-      jest.spyOn($ctrl.analyticsFactory, 'track').mockReturnValue(null)
-      $ctrl.openStopStartRecurringGiftsModal()
-      thenSpy.mock.calls[0][1]()
-
-      expect($ctrl.analyticsFactory.track).toHaveBeenCalledWith('aa-stop-restart-exit')
     });
   })
 

--- a/src/app/profile/yourGiving/yourGiving.component.spec.js
+++ b/src/app/profile/yourGiving/yourGiving.component.spec.js
@@ -205,11 +205,11 @@ describe('your giving', function () {
     it('should call analytics event on dismiss', () => {
       const thenSpy = jest.fn()
       jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: { then: thenSpy } })
-      jest.spyOn($ctrl.analyticsFactory, 'trackGTM').mockReturnValue(null)
+      jest.spyOn($ctrl.analyticsFactory, 'track').mockReturnValue(null)
       $ctrl.openEditRecurringGiftsModal()
       thenSpy.mock.calls[0][1]()
 
-      expect($ctrl.analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-edit-recurring-exit')
+      expect($ctrl.analyticsFactory.track).toHaveBeenCalledWith('ga-edit-recurring-exit')
     });
   })
 

--- a/src/common/components/contactInfoModal/contactInfoModal.component.js
+++ b/src/common/components/contactInfoModal/contactInfoModal.component.js
@@ -20,7 +20,7 @@ class contactInfoModalController {
 
   $onInit () {
     this.modalTitle = this.gettext('Your Contact Information')
-    this.analyticsFactory.trackGTM('ga-registration-contact-information')
+    this.analyticsFactory.track('ga-registration-contact-information')
   }
 
   onSubmit (success) {

--- a/src/common/components/contactInfoModal/contactInfoModal.component.js
+++ b/src/common/components/contactInfoModal/contactInfoModal.component.js
@@ -20,7 +20,6 @@ class contactInfoModalController {
 
   $onInit () {
     this.modalTitle = this.gettext('Your Contact Information')
-    this.analyticsFactory.track('aa-registration-contact-information')
     this.analyticsFactory.trackGTM('ga-registration-contact-information')
   }
 

--- a/src/common/components/contactInfoModal/contactInfoModal.component.spec.js
+++ b/src/common/components/contactInfoModal/contactInfoModal.component.spec.js
@@ -15,11 +15,11 @@ describe('contactInfoModal', function () {
 
   describe('$onInit', () => {
     it('should set the modal title', () => {
-      jest.spyOn(self.controller.analyticsFactory, 'trackGTM').mockImplementation(() => {})
+      jest.spyOn(self.controller.analyticsFactory, 'track').mockImplementation(() => {})
       self.controller.$onInit()
 
       expect(self.controller.modalTitle).toEqual('Your Contact Information')
-      expect(self.controller.analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-registration-contact-information')
+      expect(self.controller.analyticsFactory.track).toHaveBeenCalledWith('ga-registration-contact-information')
     })
   })
 

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -21,17 +21,17 @@
     </p>
   </div>
   <user-match-question ng-switch-when="question"
-                       ng-init="$ctrl.analyticsFactory.track('aa-registration-match-security-question'+$ctrl.questionCount); $ctrl.analyticsFactory.trackGTM('ga-registration-match-security-question'+$ctrl.questionCount)"
+                       ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-security-question'+$ctrl.questionCount)"
                        question="$ctrl.question"
                        question-index="$ctrl.questionIndex"
                        question-count="$ctrl.questionCount"
                        on-question-answer="$ctrl.onQuestionAnswer(key, answer)">
   </user-match-question>
   <div ng-switch-when="success">
-    <p ng-if="!$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.track('aa-registration-match-linked-account-success'); $ctrl.analyticsFactory.trackGTM('ga-registration-match-linked-account-success')">
+    <p ng-if="!$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-linked-account-success')">
       Thank you for taking the time to answer our security questions. Your account is now activated.
     </p>
-    <p ng-if="$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.track('aa-registration-no-match-new-account-success'); $ctrl.analyticsFactory.trackGTM('ga-registration-no-match-new-account-success')">
+    <p ng-if="$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-no-match-new-account-success')">
       Thank you for completing account registration. Your account has been activated.
     </p>
     <p>
@@ -39,7 +39,7 @@
     </p>
   </div>
   <failed-verification-modal ng-switch-when="failure"
-                             ng-init="$ctrl.analyticsFactory.track('aa-registration-match-failed-questions'); $ctrl.analyticsFactory.trackGTM('ga-registration-match-failed-questions')"
+                             ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-failed-questions')"
                              modal-title="$ctrl.modalTitle"
                              on-ok="$ctrl.onFailure()">
   </failed-verification-modal>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -21,17 +21,17 @@
     </p>
   </div>
   <user-match-question ng-switch-when="question"
-                       ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-security-question'+$ctrl.questionCount)"
+                       ng-init="$ctrl.analyticsFactory.track('ga-registration-match-security-question'+$ctrl.questionCount)"
                        question="$ctrl.question"
                        question-index="$ctrl.questionIndex"
                        question-count="$ctrl.questionCount"
                        on-question-answer="$ctrl.onQuestionAnswer(key, answer)">
   </user-match-question>
   <div ng-switch-when="success">
-    <p ng-if="!$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-linked-account-success')">
+    <p ng-if="!$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.track('ga-registration-match-linked-account-success')">
       Thank you for taking the time to answer our security questions. Your account is now activated.
     </p>
-    <p ng-if="$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-no-match-new-account-success')">
+    <p ng-if="$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.track('ga-registration-no-match-new-account-success')">
       Thank you for completing account registration. Your account has been activated.
     </p>
     <p>
@@ -39,7 +39,7 @@
     </p>
   </div>
   <failed-verification-modal ng-switch-when="failure"
-                             ng-init="$ctrl.analyticsFactory.trackGTM('ga-registration-match-failed-questions')"
+                             ng-init="$ctrl.analyticsFactory.track('ga-registration-match-failed-questions')"
                              modal-title="$ctrl.modalTitle"
                              on-ok="$ctrl.onFailure()">
   </failed-verification-modal>

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -300,10 +300,10 @@ class Profile {
 
   addPaymentMethod (paymentInfo) {
     if (paymentInfo.bankAccount) {
-      this.analyticsFactory.trackGTM('add-payment-method')
+      this.analyticsFactory.track('add-payment-method')
       return this.addBankAccountPayment(paymentInfo.bankAccount)
     } else if (paymentInfo.creditCard) {
-      this.analyticsFactory.trackGTM('add-payment-method')
+      this.analyticsFactory.track('add-payment-method')
       return this.addCreditCardPayment(paymentInfo.creditCard)
     } else {
       return Observable.throw('Error adding payment method. The data passed to profileService.addPaymentMethod did not contain bankAccount or creditCard data')
@@ -328,7 +328,7 @@ class Profile {
   }
 
   deletePaymentMethod (uri) {
-    this.analyticsFactory.trackGTM('delete-payment-method')
+    this.analyticsFactory.track('delete-payment-method')
     return this.cortexApiService.delete({
       path: uri
     })

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -307,7 +307,7 @@ describe('profile service', () => {
   describe('addPaymentMethod', () => {
     it('should save a new bank account payment method', () => {
       jest.spyOn(self.profileService, 'addBankAccountPayment').mockReturnValue(Observable.of('success'))
-      jest.spyOn(self.analyticsFactory, 'trackGTM').mockReturnValue(() => {})
+      jest.spyOn(self.analyticsFactory, 'track').mockReturnValue(() => {})
       const paymentInfo = {
         'account-type': 'checking',
         'bank-name': 'First Bank',
@@ -322,12 +322,12 @@ describe('profile service', () => {
       })
 
       expect(self.profileService.addBankAccountPayment).toHaveBeenCalledWith(paymentInfo)
-      expect(self.analyticsFactory.trackGTM).toHaveBeenCalledWith('add-payment-method')
+      expect(self.analyticsFactory.track).toHaveBeenCalledWith('add-payment-method')
     })
 
     it('should save a new credit card payment method', () => {
       jest.spyOn(self.profileService, 'addCreditCardPayment').mockReturnValue(Observable.of('credit card success'))
-      jest.spyOn(self.analyticsFactory, 'trackGTM').mockReturnValue(() => {})
+      jest.spyOn(self.analyticsFactory, 'track').mockReturnValue(() => {})
 
       const paymentInfo = {
         address: {
@@ -353,7 +353,7 @@ describe('profile service', () => {
       })
 
       expect(self.profileService.addCreditCardPayment).toHaveBeenCalledWith(paymentInfo)
-      expect(self.analyticsFactory.trackGTM).toHaveBeenCalledWith('add-payment-method')
+      expect(self.analyticsFactory.track).toHaveBeenCalledWith('add-payment-method')
     })
 
     it('should throw an error if the payment info doesn\'t contain a bank account or credit card', () => {
@@ -407,7 +407,7 @@ describe('profile service', () => {
 
   describe('deletePaymentMethod', () => {
     it('should delete payment method', () => {
-      jest.spyOn(self.analyticsFactory, 'trackGTM').mockReturnValue(() => {})
+      jest.spyOn(self.analyticsFactory, 'track').mockReturnValue(() => {})
       const uri = '/uri'
       self.$httpBackend.expectDELETE('https://give-stage2.cru.org/cortex' + uri)
         .respond(200, 'success')
@@ -416,7 +416,7 @@ describe('profile service', () => {
           expect(data).toEqual('success')
         })
       self.$httpBackend.flush()
-      expect(self.analyticsFactory.trackGTM).toHaveBeenCalledWith('delete-payment-method')
+      expect(self.analyticsFactory.track).toHaveBeenCalledWith('delete-payment-method')
     })
   })
 

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -40,7 +40,6 @@ class SessionModalController {
   }
 
   onSignUpSuccess () {
-    this.analyticsFactory.track('aa-sign-in-create-login')
     this.analyticsFactory.trackGTM('ga-sign-in-create-login')
     this.close()
   }

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -40,7 +40,7 @@ class SessionModalController {
   }
 
   onSignUpSuccess () {
-    this.analyticsFactory.trackGTM('ga-sign-in-create-login')
+    this.analyticsFactory.track('ga-sign-in-create-login')
     this.close()
   }
 

--- a/src/common/services/session/sessionModal.component.spec.js
+++ b/src/common/services/session/sessionModal.component.spec.js
@@ -54,11 +54,11 @@ describe('sessionModalController', function () {
 
   describe('$ctrl.onSignUpSuccess', () => {
     it('should close modal', () => {
-      jest.spyOn($ctrl.analyticsFactory, 'trackGTM').mockImplementation(() => {})
+      jest.spyOn($ctrl.analyticsFactory, 'track').mockImplementation(() => {})
       $ctrl.onSignUpSuccess()
 
       expect($ctrl.close).toHaveBeenCalled()
-      expect($ctrl.analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in-create-login')
+      expect($ctrl.analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in-create-login')
     })
   })
 

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -45,13 +45,13 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
     if (options.dismissAnalyticsEvent) {
       currentModal.result
         .then(angular.noop, () => {
-          analyticsFactory.trackGTM(options.dismissAnalyticsEvent)
+          analyticsFactory.track(options.dismissAnalyticsEvent)
         })
     }
 
     if (options.openAnalyticsEvent) {
       currentModal.opened.then(() => {
-        analyticsFactory.trackGTM(options.openAnalyticsEvent)
+        analyticsFactory.track(options.openAnalyticsEvent)
       }, angular.noop)
     }
 

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -45,35 +45,13 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
     if (options.dismissAnalyticsEvent) {
       currentModal.result
         .then(angular.noop, () => {
-          analyticsFactory.track(options.dismissAnalyticsEvent)
-          switch (type) {
-            case 'sign-in':
-            case 'sign-up':
-              analyticsFactory.trackGTM('ga-sign-in-exit')
-              break
-            case 'user-match':
-              analyticsFactory.trackGTM('ga-registration-exit')
-              break
-            default:
-              break
-          }
+          analyticsFactory.trackGTM(options.dismissAnalyticsEvent)
         })
     }
 
     if (options.openAnalyticsEvent) {
       currentModal.opened.then(() => {
-        analyticsFactory.track(options.openAnalyticsEvent)
-        switch (type) {
-          case 'sign-in':
-          case 'sign-up':
-            analyticsFactory.trackGTM('ga-sign-in')
-            break
-          case 'user-match':
-            analyticsFactory.trackGTM('ga-registration-match-is-this-you')
-            break
-          default:
-            break
-        }
+        analyticsFactory.trackGTM(options.openAnalyticsEvent)
       }, angular.noop)
     }
 
@@ -85,16 +63,16 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
     currentModal: () => currentModal,
     signIn: (lastPurchaseId) => openModal('sign-in', {
       resolve: { lastPurchaseId: () => lastPurchaseId },
-      openAnalyticsEvent: 'aa-sign-in',
-      dismissAnalyticsEvent: 'aa-sign-in-exit'
+      openAnalyticsEvent: 'ga-sign-in',
+      dismissAnalyticsEvent: 'ga-sign-in-exit'
     }).result,
     signUp: () => openModal('sign-up').result,
     forgotPassword: () => openModal('forgot-password').result,
     resetPassword: () => openModal('reset-password', { backdrop: 'static' }).result,
     userMatch: () => openModal('user-match', {
       backdrop: 'static',
-      openAnalyticsEvent: 'aa-registration-match-is-this-you',
-      dismissAnalyticsEvent: 'aa-registration-exit'
+      openAnalyticsEvent: 'ga-registration-match-is-this-you',
+      dismissAnalyticsEvent: 'ga-registration-exit'
     }).result,
     contactInfo: () => openModal('contact-info', { size: '', backdrop: 'static' }).result,
     accountBenefits: (lastPurchaseId) => openModal('account-benefits', { resolve: { lastPurchaseId: () => lastPurchaseId } }).result,

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -52,53 +52,38 @@ describe('sessionModalService', function () {
         $rootScope = _$rootScope_
         deferred = _$q_.defer()
         analyticsFactory = _analyticsFactory_
-        jest.spyOn(analyticsFactory, 'track').mockImplementation(() => {})
         jest.spyOn(analyticsFactory, 'trackGTM').mockImplementation(() => {})
         $uibModal.open.mockReturnValue({ result: { finally: angular.noop, then: angular.noop }, opened: deferred.promise })
       }))
 
       it('sends analytics event for sign-up', () => {
         sessionModalService.open('sign-up', {
-          openAnalyticsEvent: 'eventA'
+          openAnalyticsEvent: 'ga-sign-in'
         })
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in')
       })
 
       it('send analytics event for sign-in', () => {
         sessionModalService.open('sign-in', {
-          openAnalyticsEvent: 'eventA'
+          openAnalyticsEvent: 'ga-sign-in'
         })
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in')
       })
 
       it('send analytics event for user-match', () => {
         sessionModalService.open('user-match', {
-          openAnalyticsEvent: 'eventA'
+          openAnalyticsEvent: 'ga-registration-match-is-this-you'
         })
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-registration-match-is-this-you')
-      })
-
-      it('does not send gtm analytics event when case does not exist', () => {
-        sessionModalService.open('some-random-type', {
-          openAnalyticsEvent: 'eventA'
-        })
-        deferred.resolve()
-        $rootScope.$digest()
-
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
-        expect(analyticsFactory.trackGTM).not.toHaveBeenCalled()
       })
     })
 
@@ -110,7 +95,6 @@ describe('sessionModalService', function () {
         deferred = _$q_.defer()
         analyticsFactory = _analyticsFactory_
         jest.spyOn(modalStateService, 'name').mockImplementation(() => {})
-        jest.spyOn(analyticsFactory, 'track').mockImplementation(() => {})
         jest.spyOn(analyticsFactory, 'trackGTM').mockImplementation(() => {})
         $uibModal.open.mockReturnValue({ result: deferred.promise })
       }))
@@ -121,52 +105,37 @@ describe('sessionModalService', function () {
         $rootScope.$digest()
 
         expect(modalStateService.name).toHaveBeenCalledWith(null)
-        expect(analyticsFactory.track).not.toHaveBeenCalled()
         expect(analyticsFactory.trackGTM).not.toHaveBeenCalled()
       })
 
       it('sends analytics event for sign-up', () => {
         sessionModalService.open('sign-up', {
-          dismissAnalyticsEvent: 'eventA'
+          dismissAnalyticsEvent: 'ga-sign-in-exit'
         })
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in-exit')
       })
 
       it('sends analytics event for sign-in', () => {
         sessionModalService.open('sign-in', {
-          dismissAnalyticsEvent: 'eventA'
+          dismissAnalyticsEvent: 'ga-sign-in-exit'
         })
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in-exit')
       })
 
       it('sends analytics event for user-match', () => {
         sessionModalService.open('user-match', {
-          dismissAnalyticsEvent: 'eventA'
+          dismissAnalyticsEvent: 'ga-registration-exit'
         })
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
         expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-registration-exit')
-      })
-
-      it('does not send gtm analytics event when case does not exist', () => {
-        sessionModalService.open('some-random-type', {
-          dismissAnalyticsEvent: 'eventA'
-        })
-        deferred.reject()
-        $rootScope.$digest()
-
-        expect(analyticsFactory.track).toHaveBeenCalledWith('eventA')
-        expect(analyticsFactory.trackGTM).not.toHaveBeenCalled()
       })
     })
 

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -52,7 +52,7 @@ describe('sessionModalService', function () {
         $rootScope = _$rootScope_
         deferred = _$q_.defer()
         analyticsFactory = _analyticsFactory_
-        jest.spyOn(analyticsFactory, 'trackGTM').mockImplementation(() => {})
+        jest.spyOn(analyticsFactory, 'track').mockImplementation(() => {})
         $uibModal.open.mockReturnValue({ result: { finally: angular.noop, then: angular.noop }, opened: deferred.promise })
       }))
 
@@ -63,7 +63,7 @@ describe('sessionModalService', function () {
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in')
       })
 
       it('send analytics event for sign-in', () => {
@@ -73,7 +73,7 @@ describe('sessionModalService', function () {
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in')
       })
 
       it('send analytics event for user-match', () => {
@@ -83,7 +83,7 @@ describe('sessionModalService', function () {
         deferred.resolve()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-registration-match-is-this-you')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-registration-match-is-this-you')
       })
     })
 
@@ -95,7 +95,7 @@ describe('sessionModalService', function () {
         deferred = _$q_.defer()
         analyticsFactory = _analyticsFactory_
         jest.spyOn(modalStateService, 'name').mockImplementation(() => {})
-        jest.spyOn(analyticsFactory, 'trackGTM').mockImplementation(() => {})
+        jest.spyOn(analyticsFactory, 'track').mockImplementation(() => {})
         $uibModal.open.mockReturnValue({ result: deferred.promise })
       }))
 
@@ -105,7 +105,7 @@ describe('sessionModalService', function () {
         $rootScope.$digest()
 
         expect(modalStateService.name).toHaveBeenCalledWith(null)
-        expect(analyticsFactory.trackGTM).not.toHaveBeenCalled()
+        expect(analyticsFactory.track).not.toHaveBeenCalled()
       })
 
       it('sends analytics event for sign-up', () => {
@@ -115,7 +115,7 @@ describe('sessionModalService', function () {
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in-exit')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in-exit')
       })
 
       it('sends analytics event for sign-in', () => {
@@ -125,7 +125,7 @@ describe('sessionModalService', function () {
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-sign-in-exit')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in-exit')
       })
 
       it('sends analytics event for user-match', () => {
@@ -135,7 +135,7 @@ describe('sessionModalService', function () {
         deferred.reject()
         $rootScope.$digest()
 
-        expect(analyticsFactory.trackGTM).toHaveBeenCalledWith('ga-registration-exit')
+        expect(analyticsFactory.track).toHaveBeenCalledWith('ga-registration-exit')
       })
     })
 


### PR DESCRIPTION
I broke this up into two commits:
1.  Removing remaining adobe events that have been migrated to google analytics.
2. Removing the remaining adobe events that were not migrated.

I confirmed with Lauren and Clark, but all events of importance were migrated over during the initial migration phase. These events that were removed in the second commit are no longer of importance. However, I split this into two commits in case they become important again in the future. That way, we'll have a way to identify what remaining events need to be added to google analytics.