### PR TITLE
GTM-CheckoutStepEvent-Brand-Fix

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -209,7 +209,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
           name: cartItem.designationNumber,
           id: cartItem.designationNumber,
           price: cartItem.amount.toString(),
-          branch: 'cru',
+          brand: 'cru',
           category: cartItem.designationType.toLowerCase(),
           variant: cartItem.frequency.toLowerCase(),
           quantity: '1'


### PR DESCRIPTION
While investigating setting ```brand``` to have a value of an ```organization id```, I happened to notice this small typo. I guess this was missed in QA, and must not have been causing issues this whole time. Also went and double-checked the docs, https://developers.google.com/tag-manager/enhanced-ecommerce#checkoutstep, just to confirm the typo.