### PR TITLE
GTM-Update-Brand-To-OrgId

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -38,7 +38,8 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
             item = {
               productInfo: {
                 productID: cartData.items[i].designationNumber,
-                designationType: cartData.items[i].designationType
+                designationType: cartData.items[i].designationType,
+                orgId: cartData.items[i].orgId ? cartData.items[i].orgId : 'cru'
               },
               price: {
                 basePrice: cartData.items[i].amount
@@ -121,7 +122,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                   name: productData.designationNumber,
                   id: productData.designationNumber,
                   price: itemConfig.amount.toString(),
-                  brand: 'cru',
+                  brand: productData.orgId,
                   category: productData.designationType.toLowerCase(),
                   variant: frequencyObj.display.toLowerCase(),
                   quantity: '1'
@@ -165,7 +166,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                     name: item.designationNumber,
                     id: item.designationNumber,
                     price: item.amount.toString(),
-                    brand: 'cru',
+                    brand: item.orgId,
                     category: item.designationType.toLowerCase(),
                     variant: item.frequency.toLowerCase(),
                     quantity: '1'
@@ -209,7 +210,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
           name: cartItem.designationNumber,
           id: cartItem.designationNumber,
           price: cartItem.amount.toString(),
-          brand: 'cru',
+          brand: cartItem.orgId,
           category: cartItem.designationType.toLowerCase(),
           variant: cartItem.frequency.toLowerCase(),
           quantity: '1'
@@ -397,7 +398,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                 name: productData.designationNumber,
                 id: productData.designationNumber,
                 price: undefined,
-                brand: 'cru',
+                brand: productData.orgId,
                 category: productData.designationType.toLowerCase(),
                 variant: undefined,
                 quantity: '1'
@@ -474,7 +475,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                     name: product.designationNumber,
                     id: product.designationNumber,
                     price: undefined,
-                    brand: 'cru',
+                    brand: product.orgId,
                     category: product.type,
                     variant: undefined,
                     position: undefined
@@ -525,7 +526,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               name: cartItem.designationNumber,
               id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
-              brand: 'cru',
+              brand: cartItem.orgId,
               category: cartItem.designationType.toLowerCase(),
               variant: cartItem.frequency.toLowerCase(),
               quantity: '1',

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -80,15 +80,20 @@ class Cart {
       const giftStartDateDaysFromNow = giftStartDate ? giftStartDate.diff(new Date(), 'days') : 0
 
       let designationType
+      let orgId
       angular.forEach(item.itemDefinition['details'], (v, k) => {
         if (v['name'] === 'designation_type') {
           designationType = v['display-value']
+        }
+        if (v['name'] === 'org_id') {
+          orgId = v['display-value']
         }
       })
 
       return {
         uri: item.self.uri,
         code: item.itemCode.code,
+        orgId: orgId,
         displayName: item.itemDefinition['display-name'],
         designationType: designationType,
         price: item.rate.cost.display,

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -109,7 +109,8 @@ class DesignationsService {
           type: hit.designation_type || null,
           facet: hit.facet || null,
           startMonth: hit.start_date ? moment(hit.start_date).format('YYYY-MM-01') : null,
-          ministry: hit.organization_id ? ministryIds[hit.organization_id] : null
+          ministry: hit.organization_id ? ministryIds[hit.organization_id] : null,
+          orgId: hit.organization_id ? hit.organization_id : 'cru'
         }
       })
     })
@@ -151,9 +152,13 @@ class DesignationsService {
       })
 
       let designationType
+      let orgId
       angular.forEach(data.definition['details'], (v, k) => {
         if (v['name'] === 'designation_type') {
           designationType = v['display-value']
+        }
+        if (v['name'] === 'org_id') {
+          orgId = v['display-value']
         }
       })
 
@@ -164,7 +169,8 @@ class DesignationsService {
         displayName: data.definition['display-name'],
         designationType: designationType,
         code: data.code.code,
-        designationNumber: data.code['product-code']
+        designationNumber: data.code['product-code'],
+        orgId: orgId
       }
     })
   }


### PR DESCRIPTION
After discussion with Cat and Lauren, they decided to go with using the orgId for the brand value. The following events were updated:
1. add-to-cart
2. remove-from-cart
3. checkout-step
4. give-gift-modal
5. product-detail-click
6. transaction