### PR TITLE
Payment method updates

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -8,7 +8,7 @@
       <label>
         <input type="radio" name="paymentMethod" ng-model="$ctrl.selectedPaymentMethod" ng-value="paymentMethod" ng-disabled="expired" required ng-change="$ctrl.switchPayment()">
         <payment-method-display payment-method="paymentMethod" expired="expired"></payment-method-display>
-        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" ng-if="paymentMethod.self.type === 'cru.creditcards.named-credit-card'" translate>edit</button>
+        <button class="btn btn-xs btn-link" ng-click="$ctrl.openPaymentMethodFormModal(paymentMethod)" ng-if="paymentMethod['card-type']" translate>edit</button>
       </label>
     </div>
 

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -70,9 +70,9 @@ class Step3Controller {
       .subscribe((data) => {
         if (!data) {
           this.$log.error('Error loading current payment info: current payment doesn\'t seem to exist')
-        } else if (data.self.type === 'elasticpath.bankaccounts.bank-account') {
+        } else if (data['account-type']) {
           this.bankAccountPaymentDetails = data
-        } else if (data.self.type === 'cru.creditcards.named-credit-card') {
+        } else if (data['card-type']) {
           this.creditCardPaymentDetails = data
         } else {
           this.$log.error('Error loading current payment info: current payment type is unknown')

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -151,7 +151,7 @@ describe('checkout', () => {
 
     describe('loadCurrentPayment', () => {
       it('should load bank account payment details', () => {
-        self.loadedPayment.self.type = 'elasticpath.bankaccounts.bank-account'
+        self.loadedPayment['account-type'] = 'Checking'
         self.controller.loadCurrentPayment()
 
         expect(self.controller.bankAccountPaymentDetails).toEqual(self.loadedPayment)
@@ -162,7 +162,7 @@ describe('checkout', () => {
       })
 
       it('should load credit card payment details', () => {
-        self.loadedPayment.self.type = 'cru.creditcards.named-credit-card'
+        self.loadedPayment['card-type'] = 'Visa'
         self.controller.loadCurrentPayment()
 
         expect(self.controller.bankAccountPaymentDetails).toBeUndefined()

--- a/src/app/profile/payment-methods/payment-method/payment-method.component.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.component.js
@@ -36,7 +36,7 @@ class PaymentMethodController {
   }
 
   isCard () {
-    return this.model.self.type === 'cru.creditcards.named-credit-card'
+    return !!this.model['card-type']
   }
 
   editPaymentMethod () {

--- a/src/app/profile/payment-methods/payment-method/payment-method.spec.js
+++ b/src/app/profile/payment-methods/payment-method/payment-method.spec.js
@@ -40,7 +40,7 @@ describe('PaymentMethodComponent', function () {
       donations: []
     },
     self: {
-      type: 'cru.creditcards.named-credit-card',
+      type: 'paymentinstruments.payment-instrument',
       uri: ''
     }
   }
@@ -53,7 +53,7 @@ describe('PaymentMethodComponent', function () {
       donations: []
     },
     self: {
-      type: 'elasticpath.bankaccounts.bank-account'
+      type: 'paymentinstruments.payment-instrument'
     }
   }
   var uibModal = { open: jest.fn(fakeModal), close: jest.fn() }

--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -140,7 +140,7 @@ class PaymentMethodsController {
   }
 
   isCard (paymentMethod) {
-    return paymentMethod.self.type === 'cru.creditcards.named-credit-card'
+    return !!paymentMethod['card-type']
   }
 
   signedOut (event) {

--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -9,6 +9,7 @@ import paymentMethodDisplay from 'common/components/paymentMethods/paymentMethod
 import sessionEnforcerService, { EnforcerCallbacks, EnforcerModes } from 'common/services/session/sessionEnforcer.service'
 import { Roles, SignOutEvent } from 'common/services/session/session.service'
 import commonModule from 'common/common.module'
+import extractPaymentAttributes from 'common/services/paymentHelpers/extractPaymentAttributes'
 import formatAddressForTemplate from 'common/services/addressHelpers/formatAddressForTemplate'
 import { scrollModalToTop } from 'common/services/modalState.service'
 import uibModal from 'angular-ui-bootstrap/src/modal'
@@ -102,7 +103,7 @@ class PaymentMethodsController {
         type: 'paymentMethodAdded'
       }
       data['_recurringgifts'] = [{ donations: [] }]
-      this.paymentMethods.push(data)
+      this.paymentMethods.push(extractPaymentAttributes(data))
       this.$timeout(() => {
         this.successMessage.show = false
       }, 60000)

--- a/src/app/profile/payment-methods/payment-methods.component.spec.js
+++ b/src/app/profile/payment-methods/payment-methods.component.spec.js
@@ -188,14 +188,16 @@ describe('PaymentMethodsComponent', function () {
     it('should return true if payment method is a card', () => {
       expect($ctrl.isCard({
         self: {
-          type: 'cru.creditcards.named-credit-card'
-        }
+          type: 'paymentinstruments.payment-instrument'
+        },
+        'card-type': 'Visa'
       })).toBe(true)
 
       expect($ctrl.isCard({
         self: {
-          type: 'elasticpath.bankaccounts.bank-account'
-        }
+          type: 'paymentinstruments.payment-instrument'
+        },
+        'account-type': 'Checking'
       })).toBe(false)
     })
   })

--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.component.spec.js
@@ -41,8 +41,9 @@ describe('edit recurring gifts modal', () => {
     it('should handle bank accounts', () => {
       const paymentMethods = [{
         self: {
-          type: 'elasticpath.bankaccounts.bank-account'
-        }
+          type: 'paymentinstruments.payment-instrument'
+        },
+        'account-type': 'Checking'
       }]
       jest.spyOn(self.controller.profileService, 'getPaymentMethods').mockReturnValue(Observable.of(paymentMethods))
       jest.spyOn(self.controller.commonService, 'getNextDrawDate').mockReturnValue(Observable.of('2015-02-04'))
@@ -63,7 +64,7 @@ describe('edit recurring gifts modal', () => {
     it('should handle active credit cards', () => {
       const paymentMethods = [{
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '01',
         'expiry-year': '2015'
@@ -87,7 +88,7 @@ describe('edit recurring gifts modal', () => {
     it('should handle inactive credit cards', () => {
       const paymentMethods = [{
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '12',
         'expiry-year': '2014'

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
@@ -54,7 +54,7 @@ describe('editRecurringGiftsModal', () => {
       beforeEach(() => {
         RecurringGiftModel.paymentMethods = [
           {
-            self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' }
+            self: { uri: '/selfservicepaymentinstruments/crugive/giydgnrxgm=' }
           }
         ]
       })

--- a/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.component.spec.js
+++ b/src/app/profile/yourGiving/stopStartRecurringGifts/restartGift/restartGift.component.spec.js
@@ -65,17 +65,18 @@ describe('your giving', () => {
           it('sets payment methods and next start date', () => {
             const paymentMethods = [{
               self: {
-                type: 'elasticpath.bankaccounts.bank-account'
-              }
+                type: 'paymentinstruments.payment-instrument'
+              },
+              'account-type': 'Checking'
             }, {
               self: {
-                type: 'cru.creditcards.named-credit-card'
+                type: 'paymentinstruments.payment-instrument'
               },
               'expiry-month': '01',
               'expiry-year': '2015'
             }, {
               self: {
-                type: 'cru.creditcards.named-credit-card'
+                type: 'paymentinstruments.payment-instrument'
               },
               'expiry-month': '12',
               'expiry-year': '2014'

--- a/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
+++ b/src/common/components/paymentMethods/paymentMethodDisplay.tpl.html
@@ -1,5 +1,5 @@
-<span ng-switch="$ctrl.paymentMethod.self.type" class="account-management">
-  <span ng-switch-when="cru.creditcards.named-credit-card">
+<span class="account-management">
+  <span ng-if="$ctrl.paymentMethod['card-type']">
     <span ng-switch="$ctrl.paymentMethod['card-type']">
       &nbsp;
       <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/american-express-curved-128px.png" ng-switch-when="American Express"/>
@@ -17,7 +17,7 @@
       {{$ctrl.paymentMethod['expiry-month']}}/<span class="hidden-xs">{{$ctrl.paymentMethod['expiry-year'] | limitTo : 2}}</span>{{$ctrl.paymentMethod['expiry-year'] | limitTo : 2 : 2}}
     </small>
   </span>
-  <span ng-switch-when="elasticpath.bankaccounts.bank-account">
+  <span ng-if="!$ctrl.paymentMethod['card-type']">
     <img class="payment-icon hidden-xs" ng-src="{{$ctrl.imgDomain}}/assets/img/cc-icons/bank-curved-128px.png" />
     <strong>
       {{$ctrl.paymentMethod['bank-name']}}

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.js
@@ -23,7 +23,7 @@ class PaymentMethodFormController {
 
   $onInit () {
     if (this.paymentMethod) {
-      this.paymentType = this.paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' ? 'bankAccount' : 'creditCard'
+      this.paymentType = this.paymentMethod['account-type'] ? 'bankAccount' : 'creditCard'
     } else if (this.defaultPaymentType === 'creditCard') {
       this.paymentType = 'creditCard'
     }

--- a/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
+++ b/src/common/components/paymentMethods/paymentMethodForm/paymentMethodForm.component.spec.js
@@ -23,11 +23,11 @@ describe('paymentMethodForm', () => {
     })
 
     it('should choose the correct payment method type from the paymentMethod if it exists', () => {
-      self.controller.paymentMethod = { self: { type: 'elasticpath.bankaccounts.bank-account' } }
+      self.controller.paymentMethod = { self: { type: 'selfservicepaymentinstruments.self-service-payment-instrument' }, 'account-type': 'Checking' }
       self.controller.$onInit()
 
       expect(self.controller.paymentType).toEqual('bankAccount')
-      self.controller.paymentMethod = { self: { type: 'cru.creditcards.named-credit-card' } }
+      self.controller.paymentMethod = { self: { type: 'selfservicepaymentinstruments.self-service-payment-instrument' }, 'card-type': 'Visa' }
       self.controller.$onInit()
 
       expect(self.controller.paymentType).toEqual('creditCard')

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -37,7 +37,7 @@ describe('recurringGift model', () => {
     RecurringGiftModel.nextDrawDate = '2015-05-20'
     RecurringGiftModel.paymentMethods = [
       {
-        self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' },
+        self: { uri: '/selfservicepaymentinstruments/crugive/giydgnrxgm=' },
         'account-type': 'Savings'
       }
     ]
@@ -221,7 +221,7 @@ describe('recurringGift model', () => {
 
     it('should lookup payment method object if it hasn\'t yet', () => {
       const paymentMethod = {
-        self: { uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=' },
+        self: { uri: '/selfservicepaymentinstruments/crugive/giydgnrxgm=' },
         'account-type': 'Savings'
       }
 

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -190,7 +190,7 @@ describe('cart service', () => {
 
     it('should add an item', () => {
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/items/crugive/<some id>?followLocation=true',
+        'https://give-stage2.cru.org/cortex/items/crugive/<some id>?FollowLocation=true',
         {
           configuration:{
             AMOUNT: 50
@@ -216,7 +216,7 @@ describe('cart service', () => {
 
         it('should add an item', () => {
           self.$httpBackend.expectPOST(
-            'https://give-stage2.cru.org/cortex/items/crugive/<some id>?followLocation=true',
+            'https://give-stage2.cru.org/cortex/items/crugive/<some id>?FollowLocation=true',
             {
               configuration: {
                   AMOUNT:50
@@ -239,7 +239,7 @@ describe('cart service', () => {
 
         it('should delete cookies and addItem to cart', () => {
           self.$httpBackend.expectPOST(
-            'https://give-stage2.cru.org/cortex/items/crugive/<some id>?followLocation=true',
+            'https://give-stage2.cru.org/cortex/items/crugive/<some id>?FollowLocation=true',
             {
               configuration:{
                 AMOUNT:50

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -93,7 +93,7 @@ describe('designation service', () => {
       designationNumber: '0354433'
     }
     it('should get product details for a designation number', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/items/crugive/lookups/form?followLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description',
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/items/crugive/lookups/form?FollowLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description',
         { code: '0354433' })
         .respond(200, lookupResponse)
       self.designationsService.productLookup('0354433')
@@ -104,7 +104,7 @@ describe('designation service', () => {
     })
 
     it('should get product details for a uri', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector?followLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector?FollowLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description')
         .respond(200, lookupResponse)
       self.designationsService.productLookup('/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector', true)
         .subscribe(data => {
@@ -114,7 +114,7 @@ describe('designation service', () => {
     })
 
     it('should handle an empty response', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector?followLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector?FollowLocation=true&zoom=code,offer:code,definition,definition:options:element:selector:choice,definition:options:element:selector:choice:description,definition:options:element:selector:choice:selectaction,definition:options:element:selector:chosen,definition:options:element:selector:chosen:description')
         .respond(200, '')
       self.designationsService.productLookup('/itemselections/crugive/a5t4fmspmhbkez6cwbnd6mrkla74hdgcupbl4xjb=/options/izzgk4lvmvxgg6i=/values/jzaq=/selector', true)
         .subscribe(() => {
@@ -128,7 +128,7 @@ describe('designation service', () => {
 
   describe('bulkLookup', () => {
     it('should take an array of designation numbers and return corresponding links for items', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/lookups/crugive/batches/items?followLocation=true',
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/lookups/crugive/batches/items?FollowLocation=true',
         { codes: ['0123456', '1234567'] })
         .respond(200, bulkLookupResponse)
       self.designationsService.bulkLookup(['0123456', '1234567'])

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -94,7 +94,7 @@ describe('donations service', () => {
         }
       }]
       $httpBackend
-        .expectPOST('https://give-stage2.cru.org/cortex/receipts/items?followLocation=true')
+        .expectPOST('https://give-stage2.cru.org/cortex/receipts/items?FollowLocation=true')
         .respond(200, receiptsResponse)
       donationsService.getReceipts({}).subscribe((receipts) => {
         expect(receipts).toEqual(response)

--- a/src/common/services/api/donations.service.spec.js
+++ b/src/common/services/api/donations.service.spec.js
@@ -131,8 +131,8 @@ describe('donations service', () => {
       paymentMethod = {
         self: {
           type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/selfservicepaymentmethods/crugive/giydcnzyga=',
-          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydcnzyga='
+          uri: '/selfservicepaymentinstruments/crugive/giydcnzyga=',
+          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydcnzyga='
         },
         'account-type': 'Savings',
         'bank-name': '2nd Bank',

--- a/src/common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js
+++ b/src/common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.carts.cart',
-    uri: '/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform',
-    href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform'
+    uri: '/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:element,order:paymentmethodinfo:element:paymentinstrumentform',
+    href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/carts/crugive/gzsggnjxmuzdoljrmrrdkljuhfrtmljymm3tillemi4gmnjwge4denjqga=?zoom=order:paymentmethodinfo:element,order:paymentmethodinfo:element:paymentinstrumentform'
   },
   links: [
     {
@@ -49,49 +49,100 @@ export default {
     {
       _paymentmethodinfo: [
         {
-          _bankaccountform: [
+          _element: [
             {
               self: {
-                type: 'training.bankaccounts.bank-account',
-                uri: '/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form',
-                href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form'
+                type: 'paymentmethods.order-payment-method',
+                uri: '/paymentmethods/orders/crugive/gy2dmnrzgq4dcljvgq2doljuga2dkllcmu2deljumeygkmrxmrrwczrsmm=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=',
+                href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentmethods/orders/crugive/gy2dmnrzgq4dcljvgq2doljuga2dkllcmu2deljumeygkmrxmrrwczrsmm=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy='
               },
-              links: [
+              messages: [],
+              links: [],
+              _paymentinstrumentform: [
                 {
-                  rel: 'createpaymentinstrumentaction',
-                  uri: '/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=',
-                  href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq='
+                  self: {
+                    type: 'paymentinstruments.order-payment-instrument-form',
+                    uri: '/paymentinstruments/paymentmethods/orders/crugive/mjswgobwmy2gkljtgazwcljumfsweljzmu2teljzmmytazrsge3wkodfmu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form',
+                    href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mjswgobwmy2gkljtgazwcljumfsweljzmu2teljzmmytazrsge3wkodfmu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+                  },
+                  messages: [],
+                  links: [
+                    {
+                      rel: 'createpaymentinstrumentaction',
+                      type: 'paymentinstruments.order-payment-instrument-form',
+                      href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mjswgobwmy2gkljtgazwcljumfsweljzmu2teljzmmytazrsge3wkodfmu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+                    }
+                  ],
+                  'default-on-profile': false,
+                  'limit-amount': 0,
+                  'payment-instrument-identification-form': {
+                    'account-type': '',
+                    'bank-name': '',
+                    'display-name': '',
+                    'encrypted-account-number': '',
+                    'routing-number': ''
+                  },
+                  'save-on-profile': false
                 }
               ],
-              'account-type': '',
-              'bank-name': '',
-              'display-account-number': '',
-              'encrypted-account-number': '',
-              'routing-number': ''
-            }
-          ],
-          _creditcardform: [
+              'display-name': 'BANKACCOUNT',
+              name: 'BANKACCOUNT'
+            },
             {
               self: {
-                type: 'cru.creditcards.named-credit-card',
-                uri: '/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form',
-                href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=/form'
+                type: 'paymentmethods.order-payment-method',
+                uri: '/paymentmethods/orders/crugive/gy2dmnrzgq4dcljvgq2doljuga2dkllcmu2deljumeygkmrxmrrwczrsmm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=',
+                href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentmethods/orders/crugive/gy2dmnrzgq4dcljvgq2doljuga2dkllcmu2deljumeygkmrxmrrwczrsmm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm='
               },
-              links: [
+              messages: [],
+              links: [],
+              _paymentinstrumentform: [
                 {
-                  rel: 'createcreditcardfororderaction',
-                  uri: '/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=',
-                  href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/creditcards/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq='
+                  self: {
+                    type: 'paymentinstruments.order-payment-instrument-form',
+                    uri: '/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form',
+                    href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+                  },
+                  messages: [],
+                  links: [
+                    {
+                      rel: 'createpaymentinstrumentaction',
+                      type: 'paymentinstruments.order-payment-instrument-form',
+                      href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+                    }
+                  ],
+                  'billing-address': {
+                    address: {
+                      'country-name': '',
+                      'extended-address': '',
+                      locality: '',
+                      'postal-code': '',
+                      region: '',
+                      'street-address': ''
+                    },
+                    name: {
+                      'family-name': '',
+                      'given-name': ''
+                    },
+                    organization: '',
+                    'phone-number': ''
+                  },
+                  'default-on-profile': false,
+                  'limit-amount': 0,
+                  'payment-instrument-identification-form': {
+                    'card-number': '',
+                    'card-type': '',
+                    'cardholder-name': '',
+                    'display-name': '',
+                    'expiry-month': '',
+                    'expiry-year': '',
+                    'last-four-digits': ''
+                  },
+                  'save-on-profile': false
                 }
               ],
-              'card-number': '',
-              'card-type': '',
-              'cardholder-name': '',
-              'expiry-month': '',
-              'expiry-year': '',
-              'issue-number': 0,
-              'start-month': '',
-              'start-year': ''
+              'display-name': 'CREDITCARD',
+              name: 'CREDITCARD'
             }
           ]
         }

--- a/src/common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js
+++ b/src/common/services/api/fixtures/cortex-cart-paymentmethodinfo-forms.fixture.js
@@ -58,7 +58,7 @@ export default {
               },
               links: [
                 {
-                  rel: 'createbankaccountfororderaction',
+                  rel: 'createpaymentinstrumentaction',
                   uri: '/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq=',
                   href: 'http://give-ep-cortex-uat.aws.cru.org/cortex/bankaccounts/orders/crugive/muytoyrymm2dallghbqtkljuhe3gmllcme4ggllcmu3tmmlcgi2weyldgq='
                 }

--- a/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
@@ -62,11 +62,11 @@ export default {
     uri: '/selfservicedonordetails/profiles/crugive/myywkmtcga2diljyme3tkljugfqtollbgzrdeljqmq2tknrtgu2tamtbga=',
     href: 'https://give-stage2.cru.org/cortex/selfservicedonordetails/profiles/crugive/myywkmtcga2diljyme3tkljugfqtollbgzrdeljqmq2tknrtgu2tamtbga='
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/fixtures/cortex-donations-recurring-gifts-active.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recurring-gifts-active.fixture.js
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -77,7 +77,7 @@ export default {
         uri: '/donations/recurring/crugive/gewuovswivbdi=',
         href: 'https://give-stage2.cru.org/cortex/donations/recurring/crugive/gewuovswivbdi='
       }, {
-        rel: 'selfservicepaymentmethods',
+        rel: 'selfservicepaymentinstruments',
         uri: '/paymentmethods/crugive',
         href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
       }, {

--- a/src/common/services/api/fixtures/cortex-donations-recurring-gifts-cancelled.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recurring-gifts-cancelled.fixture.js
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -77,7 +77,7 @@ export default {
         uri: '/donations/recurring/crugive/gewuovswivbdi=',
         href: 'https://give-stage2.cru.org/cortex/donations/recurring/crugive/gewuovswivbdi='
       }, {
-        rel: 'selfservicepaymentmethods',
+        rel: 'selfservicepaymentinstruments',
         uri: '/paymentmethods/crugive',
         href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
       }, {

--- a/src/common/services/api/fixtures/cortex-donations-recurring-gifts-multiple.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recurring-gifts-multiple.fixture.js
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -77,7 +77,7 @@ export default {
         uri: '/donations/recurring/crugive/gewuovswivbdi=',
         href: 'https://give-stage2.cru.org/cortex/donations/recurring/crugive/gewuovswivbdi='
       }, {
-        rel: 'selfservicepaymentmethods',
+        rel: 'selfservicepaymentinstruments',
         uri: '/paymentmethods/crugive',
         href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
       }, {
@@ -134,7 +134,7 @@ export default {
         uri: '/donations/recurring/crugive/gewuovswivbdi=',
         href: 'https://give-stage2.cru.org/cortex/donations/recurring/crugive/gewuovswivbdi='
       }, {
-        rel: 'selfservicepaymentmethods',
+        rel: 'selfservicepaymentinstruments',
         uri: '/paymentmethods/crugive',
         href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
       }, {

--- a/src/common/services/api/fixtures/cortex-order-paymentmethod-bankaccount.fixture.js
+++ b/src/common/services/api/fixtures/cortex-order-paymentmethod-bankaccount.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.carts.cart',
-    uri: '/carts/crugive/mi3deztfgvqtsllgmq3teljuhbsdkllbhfqwcljugvrwembume2dqndcgu=?zoom=order:paymentmethodinfo:paymentmethod',
-    href: 'https://give-stage2.cru.org/cortex/carts/crugive/mi3deztfgvqtsllgmq3teljuhbsdkllbhfqwcljugvrwembume2dqndcgu=?zoom=order:paymentmethodinfo:paymentmethod'
+    uri: '/carts/crugive/mi3deztfgvqtsllgmq3teljuhbsdkllbhfqwcljugvrwembume2dqndcgu=?zoom=order:paymentinstrumentselector:chosen:description',
+    href: 'https://give-stage2.cru.org/cortex/carts/crugive/mi3deztfgvqtsllgmq3teljuhbsdkllbhfqwcljugvrwembume2dqndcgu=?zoom=order:paymentinstrumentselector:chosen:description'
   },
   links: [{
     rel: 'lineitems',
@@ -39,24 +39,32 @@ export default {
     href: 'https://give-stage2.cru.org/cortex/totals/carts/crugive/mi3deztfgvqtsllgmq3teljuhbsdkllbhfqwcljugvrwembume2dqndcgu='
   }],
   _order: [{
-    _paymentmethodinfo: [{
-      _paymentmethod: [{
-        self: {
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/paymentmethods/orders/crugive/myywcnbqmmztgllegeydiljumfstillbmuzdqllggvrtgmlbmm3deyrsgi=',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/orders/crugive/myywcnbqmmztgllegeydiljumfstillbmuzdqllggvrtgmlbmm3deyrsgi='
-        },
-        links: [{
-          rel: 'bankaccount',
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/bankaccounts/paymentmethods/crugive/giydanzvgy=',
-          href: 'https://give-stage2.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydanzvgy='
-        }],
-        'account-type': 'checking',
-        'bank-name': 'My Bank Name',
-        'display-account-number': '3456',
-        'encrypted-account-number': '4e981aa5-993a-4771-85fa-bbcd322ce189:SHv8dEQBg8XSO5P0SFXwQg',
-        'routing-number': '000000000'
+    _paymentinstrumentselector: [{
+      _chosen: [{
+        _description: [{
+          self: {
+            type: 'paymentinstruments.payment-instrument',
+            uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gnstmzrymiytoljugbrdmljuheygellcmy2gmllcgm4dsnjygu2gmnryme=',
+            href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gnstmzrymiytoljugbrdmljuheygellcmy2gmllcgm4dsnjygu2gmnryme='
+          },
+          messages: [],
+          links: [],
+          'default-on-profile': false,
+          'limit-amount': {
+            amount: 0,
+            currency: 'USD',
+            display: '$0.00'
+          },
+          name: 'Cru Payment Instrument',
+          'payment-instrument-identification-attributes': {
+            'account-type': 'checking',
+            'bank-name': 'My Bank Name',
+            'display-account-number': '3456',
+            'encrypted-account-number': '4e981aa5-993a-4771-85fa-bbcd322ce189:SHv8dEQBg8XSO5P0SFXwQg',
+            'routing-number': '000000000'
+          },
+          'saved-on-profile': true
+        }]
       }]
     }]
   }],

--- a/src/common/services/api/fixtures/cortex-order-paymentmethod-creditcard.fixture.js
+++ b/src/common/services/api/fixtures/cortex-order-paymentmethod-creditcard.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.carts.cart',
-    uri: '/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentmethodinfo:paymentmethod',
-    href: 'https://give-stage2.cru.org/cortex/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentmethodinfo:paymentmethod'
+    uri: '/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentinstrumentselector:chosen:description',
+    href: 'https://give-stage2.cru.org/cortex/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentinstrumentselector:chosen:description'
   },
   links: [{
     rel: 'lineitems',
@@ -39,28 +39,39 @@ export default {
     href: 'https://give-stage2.cru.org/cortex/totals/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm='
   }],
   _order: [{
-    _paymentmethodinfo: [{
-      _paymentmethod: [{
-        self: {
-          type: 'cru.creditcards.named-credit-card',
-          uri: '/paymentmethods/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-        },
-        links: [],
-        address: {
-          'country-name': 'US',
-          'extended-address': '',
-          locality: 'Sacramento',
-          'postal-code': '12345',
-          region: 'CA',
-          'street-address': '1234 First Street'
-        },
-        'card-number': '1118',
-        'card-type': 'MasterCard',
-        'cardholder-name': 'Test Person',
-        description: 'MasterCard - 1118',
-        'expiry-month': '08',
-        'expiry-year': '2020'
+    _paymentinstrumentselector: [{
+      _chosen: [{
+        _description: [{
+          self: {
+            type: 'paymentinstruments.payment-instrument',
+            uri: '/paymentmethods/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
+            href: 'https://give-stage2.cru.org/cortex/paymentmethods/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+          },
+          messages: [],
+          links: [],
+          'default-on-profile': false,
+          'limit-amount': {
+            amount: 0,
+            currency: 'USD',
+            display: '$0.00'
+          },
+          name: 'Cru Payment Instrument',
+          'payment-instrument-identification-attributes': {
+            'last-four-digits': '1118',
+            'card-type': 'MasterCard',
+            'cardholder-name': 'Test Person',
+            description: 'MasterCard - 1118',
+            'expiry-month': '08',
+            'expiry-year': '2020',
+            'country-name': 'US',
+            'extended-address': '',
+            locality: 'Sacramento',
+            'postal-code': '12345',
+            region: 'CA',
+            'street-address': '1234 First Street'
+          },
+          'saved-on-profile': true
+        }]
       }]
     }]
   }],

--- a/src/common/services/api/fixtures/cortex-order-paymentmethod-selector.fixture.js
+++ b/src/common/services/api/fixtures/cortex-order-paymentmethod-selector.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.carts.cart',
-    uri: '/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description',
-    href: 'https://give-stage2.cru.org/cortex/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+    uri: '/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description',
+    href: 'https://give-stage2.cru.org/cortex/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm=?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
   },
   links: [{
     rel: 'lineitems',
@@ -39,137 +39,106 @@ export default {
     href: 'https://give-stage2.cru.org/cortex/totals/carts/crugive/my2gmmlfhaygkllbmu4deljumq3diljzgfsdellcge3wizbyhazwemtggm='
   }],
   _order: [{
-    _paymentmethodinfo: [{
-      _selector: [{
-        _choice: [{
+    _paymentinstrumentselector: [{
+      _choice: [{
+        self: {
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsim3cmy2wcmzzmmwtmylfgewtin3fgawwcnzzmiwwgndggmzgmmrqgyzwcyvknfxhg5dsovwwk3tu3esdinbwge4tonlgfu2wenbzfu2doytbfvqtimjqfu2gmnbvha2dmnrrgi2wg=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsim3cmy2wcmzzmmwtmylfgewtin3fgawwcnzzmiwwgndggmzgmmrqgyzwcyvknfxhg5dsovwwk3tu3esdinbwge4tonlgfu2wenbzfu2doytbfvqtimjqfu2gmnbvha2dmnrrgi2wg='
+        },
+        links: [{
+          rel: 'selectaction',
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsim3cmy2wcmzzmmwtmylfgewtin3fgawwcnzzmiwwgndggmzgmmrqgyzwcyvknfxhg5dsovwwk3tu3esdinbwge4tonlgfu2wenbzfu2doytbfvqtimjqfu2gmnbvha2dmnrrgi2wg='
+        }],
+        _description: [{
           self: {
-            type: 'elasticpath.collections.links',
-            uri: '/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+            type: 'paymentinstruments.payment-instrument',
+            uri: '/paymentinstruments/crugive/gnrgmnlbgm4wgljwmfstcljug5stallbg44welldgrtdgmtggiydmm3bmi=',
+            href: 'https://give-stage2.cru.org/cortex/paymentinstruments/crugive/gnrgmnlbgm4wgljwmfstcljug5stallbg44welldgrtdgmtggiydmm3bmi='
           },
-          links: [{
-            rel: 'description',
-            type: 'cru.creditcards.named-credit-card',
-            uri: '/paymentmethods/crugive/giydembug4=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4='
-          }, {
-            rel: 'selector',
-            type: 'elasticpath.controls.selector',
-            uri: '/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-          }, {
-            rel: 'selectaction',
-            uri: '/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-          }],
-          _description: [{
-            self: {
-              type: 'cru.creditcards.named-credit-card',
-              uri: '/paymentmethods/crugive/giydembug4=',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4='
-            },
-            links: [{
-              rel: 'list',
-              type: 'elasticpath.collections.links',
-              uri: '/paymentmethods/crugive',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-            }, {
-              rel: 'creditcard',
-              type: 'cru.creditcards.named-credit-card',
-              uri: '/creditcards/paymentmethods/crugive/giydembug4=',
-              href: 'https://give-stage2.cru.org/cortex/creditcards/paymentmethods/crugive/giydembug4='
-            }],
-            'card-number': '1111',
+          messages: [],
+          links: [],
+          'default-on-profile': false,
+          name: 'Cru Payment Instrument',
+          'payment-instrument-identification-attributes': {
+            'last-four-digits': '1111',
             'card-type': 'Visa',
             'cardholder-name': 'Test Card',
             'expiry-month': '11',
-            'expiry-year': '2019'
-          }]
-        }, {
+            'expiry-year': '2019',
+            'country-name': 'US',
+            'extended-address': '',
+            locality: 'Sacramento',
+            'postal-code': '12345',
+            region: 'CA',
+            'street-address': '1234 First Street'
+          }
+        }]
+      }, {
+        self: {
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsinjzgzqtcntemmwtin3egqwtintcmiwwenlfmywtmylgme2dazbtg43tmy5knfxhg5dsovwwk3tu3esdknzzg5sdizjxfu3dinlbfu2dendcfu4tiyjtfu2giyjyge3wcmbwmfsgc=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsinjzgzqtcntemmwtin3egqwtintcmiwwenlfmywtmylgme2dazbtg43tmy5knfxhg5dsovwwk3tu3esdknzzg5sdizjxfu3dinlbfu2dendcfu4tiyjtfu2giyjyge3wcmbwmfsgc='
+        },
+        links: [{
+          rel: 'selectaction',
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsinjzgzqtcntemmwtin3egqwtintcmiwwenlfmywtmylgme2dazbtg43tmy5knfxhg5dsovwwk3tu3esdknzzg5sdizjxfu3dinlbfu2dendcfu4tiyjtfu2giyjyge3wcmbwmfsgc='
+        }],
+        _description: [{
           self: {
-            type: 'elasticpath.collections.links',
-            uri: '/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+            type: 'paymentinstruments.payment-instrument',
+            uri: '/paymentinstruments/crugive/gu4tmyjrgzsggljug5sdiljugzrgellcgvswmljwmftgcnbqmqztonzwmm=',
+            href: 'https://give-stage2.cru.org/cortex/paymentinstruments/crugive/gu4tmyjrgzsggljug5sdiljugzrgellcgvswmljwmftgcnbqmqztonzwmm='
           },
-          links: [{
-            rel: 'description',
-            type: 'elasticpath.bankaccounts.bank-account',
-            uri: '/paymentmethods/crugive/giydcnzyga=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcnzyga='
-          }, {
-            rel: 'selector',
-            type: 'elasticpath.controls.selector',
-            uri: '/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-          }, {
-            rel: 'selectaction',
-            uri: '/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-          }],
-          _description: [{
-            self: {
-              type: 'elasticpath.bankaccounts.bank-account',
-              uri: '/paymentmethods/crugive/giydcnzyga=',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcnzyga='
-            },
-            links: [{
-              rel: 'list',
-              type: 'elasticpath.collections.links',
-              uri: '/paymentmethods/crugive',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-            }, {
-              rel: 'bankaccount',
-              type: 'elasticpath.bankaccounts.bank-account',
-              uri: '/bankaccounts/paymentmethods/crugive/giydcnzyga=',
-              href: 'https://give-stage2.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcnzyga='
-            }],
+          messages: [],
+          links: [],
+          'default-on-profile': false,
+          name: 'Cru Payment Instrument',
+          'payment-instrument-identification-attributes': {
             'account-type': 'Savings',
             'bank-name': '2nd Bank',
             'display-account-number': '3456',
             'encrypted-account-number': '',
             'routing-number': '021000021'
-          }]
+          }
+        }]
+      }],
+      _chosen: [{
+        self: {
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qk2wgylsoqww64temvzc22loon2he5lnmvxhjwjegazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmsvgs3ttorzhk3lfnz2nsjbrmftgmojugmzs2mrqha4s2nbqgqzs2ojwgztc2m3emvrtamrtha4tszlc=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qk2wgylsoqww64temvzc22loon2he5lnmvxhjwjegazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmsvgs3ttorzhk3lfnz2nsjbrmftgmojugmzs2mrqha4s2nbqgqzs2ojwgztc2m3emvrtamrtha4tszlc='
+        },
+        links: [{
+          rel: 'selectaction',
+          type: 'paymentinstruments.order-payment-instrument-selector-choice',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qk2wgylsoqww64temvzc22loon2he5lnmvxhjwjegazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmsvgs3ttorzhk3lfnz2nsjbrmftgmojugmzs2mrqha4s2nbqgqzs2ojwgztc2m3emvrtamrtha4tszlc='
         }],
-        _chosen: [{
+        _description: [{
           self: {
-            type: 'elasticpath.collections.links',
-            uri: '/paymentmethods/crugive/giydcmzyge=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcmzyge=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+            type: 'paymentinstruments.payment-instrument',
+            uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmq=',
+            href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmq='
           },
-          links: [{
-            rel: 'description',
-            type: 'elasticpath.bankaccounts.bank-account',
-            uri: '/paymentmethods/crugive/giydcmzyge=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcmzyge='
-          }, {
-            rel: 'selector',
-            type: 'elasticpath.controls.selector',
-            uri: '/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
-            href: 'https://give-stage2.cru.org/cortex/paymentmethods/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
-          }],
-          _description: [{
-            self: {
-              type: 'elasticpath.bankaccounts.bank-account',
-              uri: '/paymentmethods/crugive/giydcmzyge=',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcmzyge='
-            },
-            links: [{
-              rel: 'list',
-              type: 'elasticpath.collections.links',
-              uri: '/paymentmethods/crugive',
-              href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-            }, {
-              rel: 'bankaccount',
-              type: 'elasticpath.bankaccounts.bank-account',
-              uri: '/bankaccounts/paymentmethods/crugive/giydcmzyge=',
-              href: 'https://give-stage2.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcmzyge='
-            }],
+          messages: [],
+          links: [],
+          'default-on-profile': true,
+          'limit-amount': {
+            amount: 0,
+            currency: 'USD',
+            display: '$0.00'
+          },
+          name: 'Cru Payment Instrument',
+          'payment-instrument-identification-attributes': {
             'account-type': 'Checking',
             'bank-name': 'First Bank',
             'display-account-number': '6548',
-            'encrypted-account-number': 'FAecKEPeUdW6KjbHo/na/hXlAS9OjZR51dlBgKKInf2mJh4bSP9WMvsKfAAL1rW7o6P9Rmx87dp0rDz0NArbWGIdsYeoFVOaIATzQqAe4ECuy0gfHcDva26HmgriGqRWkWPDeQvEdU9jENu0XKskxAjk2sBLJOHhoTCi8+LTLUrNwu40CSdT/PGNK8/lnO27wTZDPmc221xJ6hzB/F+0sRRvJhWky2oxA491MG+SRk7lWhccqSq5KtrijfA88Ebb/EivnsSJwqZgv/WNIP2u/V3dsMF1YRtyEsEAkmgxCCYBye2TT5ehIVOChQdlUbHxF+z/izrmn+0u2IYXvyX4dw==',
+            'encrypted-account-number': '0d640924-8399-48b5-851e-808e308c2a8a:GT1pVOxr5KenKbRrvYUpnw',
             'routing-number': '121042882'
-          }]
+          },
+          'saved-on-profile': true
         }]
       }]
     }]

--- a/src/common/services/api/fixtures/cortex-profile-donordetails.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-donordetails.fixture.js
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/fixtures/cortex-profile-emails.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-emails.fixture.js
@@ -56,11 +56,11 @@ export default {
     uri: '/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge=',
     href: 'https://give-stage2.cru.org/cortex/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge='
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/fixtures/cortex-profile-giving.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-giving.fixture.js
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/fixtures/cortex-profile-mailingaddress.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-mailingaddress.fixture.js
@@ -56,11 +56,11 @@ export default {
     uri: '/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge=',
     href: 'https://give-stage2.cru.org/cortex/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge='
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethod.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethod.fixture.js
@@ -1,13 +1,13 @@
 export default {
   self: {
     type: 'paymentinstruments.payment-instrument',
-    uri: '/selfservicepaymentmethods/crugive/giydiojyg4=',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydiojyg4='
+    uri: '/selfservicepaymentinstruments/crugive/giydiojyg4=',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydiojyg4='
   },
   links: [{
     rel: 'list',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'element',
     rev: 'list',

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethod.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethod.fixture.js
@@ -1,6 +1,6 @@
 export default {
   self: {
-    type: 'cru.creditcards.named-credit-card',
+    type: 'paymentinstruments.payment-instrument',
     uri: '/selfservicepaymentmethods/crugive/giydiojyg4=',
     href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydiojyg4='
   },

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.profiles.profile',
-    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentmethods:createbankaccountform,selfservicepaymentmethods:createcreditcardform',
-    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentmethods:createbankaccountform,selfservicepaymentmethods:createcreditcardform'
+    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform',
+    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform'
   },
   links: [{
     rel: 'addresses',
@@ -46,11 +46,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -58,21 +58,21 @@ export default {
     uri: '/wishlists/crugive',
     href: 'https://give-stage2.cru.org/cortex/wishlists/crugive'
   }],
-  _selfservicepaymentmethods: [{
+  _selfservicepaymentinstruments: [{
     _createbankaccountform: [{
       self: {
         type: 'elasticpath.bankaccounts.bank-account',
-        uri: '/bankaccounts/selfservicepaymentmethods/crugive/form',
-        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentmethods/crugive/form'
+        uri: '/bankaccounts/selfservicepaymentinstruments/crugive/form',
+        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive/form'
       },
       links: [{
         rel: 'createbankaccountaction',
-        uri: '/bankaccounts/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentmethods/crugive'
+        uri: '/bankaccounts/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive'
       }, {
-        rel: 'selfservicepaymentmethods',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        rel: 'selfservicepaymentinstruments',
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }],
       'account-type': '',
       'bank-name': '',
@@ -82,17 +82,17 @@ export default {
     _createcreditcardform: [{
       self: {
         type: 'cru.creditcards.named-credit-card',
-        uri: '/creditcards/selfservicepaymentmethods/crugive/form',
-        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentmethods/crugive/form'
+        uri: '/creditcards/selfservicepaymentinstruments/crugive/form',
+        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive/form'
       },
       links: [{
         rel: 'createcreditcardaction',
-        uri: '/creditcards/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentmethods/crugive'
+        uri: '/creditcards/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive'
       }, {
-        rel: 'selfservicepaymentmethods',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        rel: 'selfservicepaymentinstruments',
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }],
       address: {
         'country-name': '',

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.profiles.profile',
-    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform',
-    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform'
+    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform',
+    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform'
   },
   links: [{
     rel: 'addresses',
@@ -58,54 +58,87 @@ export default {
     uri: '/wishlists/crugive',
     href: 'https://give-stage2.cru.org/cortex/wishlists/crugive'
   }],
-  _selfservicepaymentinstruments: [{
-    _createbankaccountform: [{
+  _paymentmethods: [{
+    _element: [{
       self: {
-        type: 'elasticpath.bankaccounts.bank-account',
-        uri: '/bankaccounts/selfservicepaymentinstruments/crugive/form',
-        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive/form'
+        type: 'paymentmethods.profile-payment-method',
+        uri: '/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=',
+        href: 'https://give-stage2.cru.org/cortex/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy='
       },
-      links: [{
-        rel: 'createbankaccountaction',
-        uri: '/bankaccounts/selfservicepaymentinstruments/crugive',
-        href: 'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive'
-      }, {
-        rel: 'selfservicepaymentinstruments',
-        uri: '/selfservicepaymentinstruments/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
+      messages: [],
+      links: [],
+      _paymentinstrumentform: [{
+        self: {
+          type: 'paymentinstruments.profile-payment-instrument-form',
+          uri: '/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form',
+          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+        },
+        messages: [],
+        links: [{
+          rel: 'createpaymentinstrumentaction',
+          type: 'paymentinstruments.profile-payment-instrument-form',
+          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+        }],
+        'default-on-profile': false,
+        'payment-instrument-identification-form': {
+          'account-type': '',
+          'bank-name': '',
+          'encrypted-account-number': '',
+          'routing-number': ''
+        }
       }],
-      'account-type': '',
-      'bank-name': '',
-      'encrypted-account-number': '',
-      'routing-number': ''
-    }],
-    _createcreditcardform: [{
+      'display-name': 'BANKACCOUNT',
+      name: 'BANKACCOUNT'
+    },
+    {
       self: {
-        type: 'cru.creditcards.named-credit-card',
-        uri: '/creditcards/selfservicepaymentinstruments/crugive/form',
-        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive/form'
+        type: 'paymentmethods.profile-payment-method',
+        uri: '/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=',
+        href: 'https://give-stage2.cru.org/cortex/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm='
       },
-      links: [{
-        rel: 'createcreditcardaction',
-        uri: '/creditcards/selfservicepaymentinstruments/crugive',
-        href: 'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive'
-      }, {
-        rel: 'selfservicepaymentinstruments',
-        uri: '/selfservicepaymentinstruments/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
+      messages: [],
+      links: [],
+      _paymentinstrumentform: [{
+        self: {
+          type: 'paymentinstruments.profile-payment-instrument-form',
+          uri: '/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form',
+          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+        },
+        messages: [],
+        links: [{
+          rel: 'createpaymentinstrumentaction',
+          type: 'paymentinstruments.profile-payment-instrument-form',
+          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+        }],
+        'billing-address': {
+          address: {
+            'country-name': '',
+            'extended-address': '',
+            locality: '',
+            'postal-code': '',
+            region: '',
+            'street-address': ''
+          },
+          name: {
+            'family-name': '',
+            'given-name': ''
+          },
+          organization: '',
+          'phone-number': ''
+        },
+        'default-on-profile': false,
+        'payment-instrument-identification-form': {
+          'card-number': '',
+          'card-type': '',
+          'cardholder-name': '',
+          'display-name': '',
+          'expiry-month': '',
+          'expiry-year': '',
+          'last-four-digits': ''
+        }
       }],
-      address: {
-        'country-name': '',
-        'extended-address': '',
-        locality: '',
-        'postal-code': '',
-        region: '',
-        'street-address': ''
-      },
-      'card-number': '',
-      'cardholder-name': '',
-      'expiry-month': '',
-      'expiry-year': ''
+      'display-name': 'CREDITCARD',
+      name: 'CREDITCARD'
     }]
   }],
   'family-name': 'Lname',

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods-with-donations.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods-with-donations.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.profiles.profile',
-    uri: '/profiles/crugive/mi4tozbwgm4tqljwgjqtmljugmzgcljyg4ydiljtge2tkmdfgiztkzldgy=?zoom=selfservicepaymentmethods:element,selfservicepaymentmethods:element:recurringgifts',
-    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/mi4tozbwgm4tqljwgjqtmljugmzgcljyg4ydiljtge2tkmdfgiztkzldgy=?zoom=selfservicepaymentmethods:element,selfservicepaymentmethods:element:recurringgifts'
+    uri: '/profiles/crugive/mi4tozbwgm4tqljwgjqtmljugmzgcljyg4ydiljtge2tkmdfgiztkzldgy=?zoom=selfservicepaymentinstruments:element,selfservicepaymentinstruments:element:recurringgifts',
+    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/mi4tozbwgm4tqljwgjqtmljugmzgcljyg4ydiljtge2tkmdfgiztkzldgy=?zoom=selfservicepaymentinstruments:element,selfservicepaymentinstruments:element:recurringgifts'
   },
   links: [{
     rel: 'addresses',
@@ -51,11 +51,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -63,17 +63,17 @@ export default {
     uri: '/wishlists/crugive',
     href: 'https://give-stage2.cru.org/cortex/wishlists/crugive'
   }],
-  _selfservicepaymentmethods: [{
+  _selfservicepaymentinstruments: [{
     _element: [{
       self: {
         type: 'elasticpath.bankaccounts.bank-account',
-        uri: '/selfservicepaymentmethods/crugive/giydgobwgq=',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydgobwgq='
+        uri: '/selfservicepaymentinstruments/crugive/giydgobwgq=',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydgobwgq='
       },
       links: [{
         rel: 'list',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }, {
         rel: 'recurringgifts',
         uri: '/donations/recurring/crugive/paymentmethods/giydgobwgq=',
@@ -90,9 +90,9 @@ export default {
           uri: '/giving/crugive',
           href: 'https://give-stage2.cru.org/cortex/giving/crugive'
         }, {
-          rel: 'selfservicepaymentmethods',
-          uri: '/selfservicepaymentmethods/crugive/giydgobwgq=',
-          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydgobwgq='
+          rel: 'selfservicepaymentinstruments',
+          uri: '/selfservicepaymentinstruments/crugive/giydgobwgq=',
+          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydgobwgq='
         }],
         donations: []
       }],
@@ -105,13 +105,13 @@ export default {
     }, {
       self: {
         type: 'elasticpath.bankaccounts.bank-account',
-        uri: '/selfservicepaymentmethods/crugive/giydimjtgq=',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydimjtgq='
+        uri: '/selfservicepaymentinstruments/crugive/giydimjtgq=',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydimjtgq='
       },
       links: [{
         rel: 'list',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }, {
         rel: 'element',
         rev: 'list',
@@ -152,9 +152,9 @@ export default {
           uri: '/giving/crugive',
           href: 'https://give-stage2.cru.org/cortex/giving/crugive'
         }, {
-          rel: 'selfservicepaymentmethods',
-          uri: '/selfservicepaymentmethods/crugive/giydimjtgq=',
-          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydimjtgq='
+          rel: 'selfservicepaymentinstruments',
+          uri: '/selfservicepaymentinstruments/crugive/giydimjtgq=',
+          href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydimjtgq='
         }],
         donations: [{
           'donation-lines': [{

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.profiles.profile',
-    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentmethods:element',
-    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentmethods:element'
+    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:element',
+    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=selfservicepaymentinstruments:element'
   },
   links: [{
     rel: 'addresses',
@@ -46,11 +46,11 @@ export default {
     uri: '/purchases/crugive',
     href: 'https://give-stage2.cru.org/cortex/purchases/crugive'
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',
@@ -58,17 +58,17 @@ export default {
     uri: '/wishlists/crugive',
     href: 'https://give-stage2.cru.org/cortex/wishlists/crugive'
   }],
-  _selfservicepaymentmethods: [{
+  _selfservicepaymentinstruments: [{
     _element: [{
       self: {
         type: 'paymentinstruments.payment-instrument',
-        uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydgnrxgm='
+        uri: '/selfservicepaymentinstruments/crugive/giydgnrxgm=',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydgnrxgm='
       },
       links: [{
         rel: 'list',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }, {
         rel: 'recurringgifts',
         uri: '/donations/recurring/crugive/paymentmethods/giydgnrxgm=',
@@ -91,13 +91,13 @@ export default {
     }, {
       self: {
         type: 'paymentinstruments.payment-instrument',
-        uri: '/selfservicepaymentmethods/crugive/giydcnzyga=',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydcnzyga='
+        uri: '/selfservicepaymentinstruments/crugive/giydcnzyga=',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydcnzyga='
       },
       links: [{
         rel: 'list',
-        uri: '/selfservicepaymentmethods/crugive',
-        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+        uri: '/selfservicepaymentinstruments/crugive',
+        href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
       }, {
         rel: 'recurringgifts',
         uri: '/donations/recurring/crugive/paymentmethods/giydcnzyga=',

--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods.fixture.js
@@ -61,7 +61,7 @@ export default {
   _selfservicepaymentmethods: [{
     _element: [{
       self: {
-        type: 'cru.creditcards.named-credit-card',
+        type: 'paymentinstruments.payment-instrument',
         uri: '/selfservicepaymentmethods/crugive/giydgnrxgm=',
         href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydgnrxgm='
       },
@@ -90,7 +90,7 @@ export default {
       'expiry-year': '2019'
     }, {
       self: {
-        type: 'elasticpath.bankaccounts.bank-account',
+        type: 'paymentinstruments.payment-instrument',
         uri: '/selfservicepaymentmethods/crugive/giydcnzyga=',
         href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydcnzyga='
       },

--- a/src/common/services/api/fixtures/cortex-profile-selfservicedonordetails.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-selfservicedonordetails.fixture.js
@@ -56,11 +56,11 @@ export default {
     uri: '/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge=',
     href: 'https://give-stage2.cru.org/cortex/selfservicedonordetails/profiles/crugive/gzsdkojsmvsdcljsmu2geljumqzgmljyg5qtillemy4ggnryhbrwezbzge='
   }, {
-    rel: 'selfservicepaymentmethods',
+    rel: 'selfservicepaymentinstruments',
     rev: 'profile',
     type: 'elasticpath.collections.links',
-    uri: '/selfservicepaymentmethods/crugive',
-    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive'
+    uri: '/selfservicepaymentinstruments/crugive',
+    href: 'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive'
   }, {
     rel: 'wishlists',
     rev: 'profile',

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -96,7 +96,7 @@ class Order {
         .do((data) => {
           this.paymentMethodForms = data
 
-          if (!this.hateoasHelperService.getLink(data.bankAccount, 'createbankaccountfororderaction') || !this.hateoasHelperService.getLink(data.creditCard, 'createcreditcardfororderaction')) {
+          if (!this.hateoasHelperService.getLink(data.bankAccount, 'createpaymentinstrumentaction') || !this.hateoasHelperService.getLink(data.creditCard, 'createcreditcardfororderaction')) {
             this.$log.warn('Payment form request contains empty link', data)
           }
         })
@@ -107,7 +107,7 @@ class Order {
     return this.getPaymentMethodForms()
       .mergeMap((data) => {
         return this.cortexApiService.post({
-          path: this.hateoasHelperService.getLink(data.bankAccount, 'createbankaccountfororderaction'),
+          path: this.hateoasHelperService.getLink(data.bankAccount, 'createpaymentinstrumentaction'),
           data: paymentInfo,
           followLocation: true
         })

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -457,80 +457,79 @@ describe('order service', () => {
       clonedPaymentMethodSelectorResponse = angular.copy(paymentMethodSelectorResponse)
       expectedResponse = [{
         self: {
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/paymentmethods/crugive/giydcmzyge=',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcmzyge='
+          type: 'paymentinstruments.payment-instrument',
+          uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmq=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmq='
         },
-        links: [{
-          rel: 'list',
-          type: 'elasticpath.collections.links',
-          uri: '/paymentmethods/crugive',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-        }, {
-          rel: 'bankaccount',
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/bankaccounts/paymentmethods/crugive/giydcmzyge=',
-          href: 'https://give-stage2.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcmzyge='
-        }],
+        messages: [],
+        links: [],
+        'default-on-profile': true,
+        'limit-amount': {
+          amount: 0,
+          currency: 'USD',
+          display: '$0.00'
+        },
+        name: 'Cru Payment Instrument',
         'account-type': 'Checking',
         'bank-name': 'First Bank',
         'display-account-number': '6548',
-        'encrypted-account-number': 'FAecKEPeUdW6KjbHo/na/hXlAS9OjZR51dlBgKKInf2mJh4bSP9WMvsKfAAL1rW7o6P9Rmx87dp0rDz0NArbWGIdsYeoFVOaIATzQqAe4ECuy0gfHcDva26HmgriGqRWkWPDeQvEdU9jENu0XKskxAjk2sBLJOHhoTCi8+LTLUrNwu40CSdT/PGNK8/lnO27wTZDPmc221xJ6hzB/F+0sRRvJhWky2oxA491MG+SRk7lWhccqSq5KtrijfA88Ebb/EivnsSJwqZgv/WNIP2u/V3dsMF1YRtyEsEAkmgxCCYBye2TT5ehIVOChQdlUbHxF+z/izrmn+0u2IYXvyX4dw==',
+        'encrypted-account-number': '0d640924-8399-48b5-851e-808e308c2a8a:GT1pVOxr5KenKbRrvYUpnw',
         'routing-number': '121042882',
+        'saved-on-profile': true,
         chosen: true,
-        selectAction: '/paymentmethods/crugive/giydcmzyge=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+        selectAction: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qk2wgylsoqww64temvzc22loon2he5lnmvxhjwjegazdgmlgha3gmllbha4wmljugi3dmljzguygmllemrsgimtegrqwmnlfmsvgs3ttorzhk3lfnz2nsjbrmftgmojugmzs2mrqha4s2nbqgqzs2ojwgztc2m3emvrtamrtha4tszlc='
       }, {
         self: {
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/paymentmethods/crugive/giydcnzyga=',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydcnzyga='
+          type: 'paymentinstruments.payment-instrument',
+          uri: '/paymentinstruments/crugive/gu4tmyjrgzsggljug5sdiljugzrgellcgvswmljwmftgcnbqmqztonzwmm=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/crugive/gu4tmyjrgzsggljug5sdiljugzrgellcgvswmljwmftgcnbqmqztonzwmm='
         },
-        links: [{
-          rel: 'list',
-          type: 'elasticpath.collections.links',
-          uri: '/paymentmethods/crugive',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-        }, {
-          rel: 'bankaccount',
-          type: 'elasticpath.bankaccounts.bank-account',
-          uri: '/bankaccounts/paymentmethods/crugive/giydcnzyga=',
-          href: 'https://give-stage2.cru.org/cortex/bankaccounts/paymentmethods/crugive/giydcnzyga='
-        }],
+        messages: [],
+        links: [],
+        'default-on-profile': false,
+        name: 'Cru Payment Instrument',
         'account-type': 'Savings',
         'bank-name': '2nd Bank',
         'display-account-number': '3456',
         'encrypted-account-number': '',
         'routing-number': '021000021',
-        selectAction: '/paymentmethods/crugive/giydcnzyga=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+        selectAction: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsinjzgzqtcntemmwtin3egqwtintcmiwwenlfmywtmylgme2dazbtg43tmy5knfxhg5dsovwwk3tu3esdknzzg5sdizjxfu3dinlbfu2dendcfu4tiyjtfu2giyjyge3wcmbwmfsgc='
       }, {
         self: {
-          type: 'cru.creditcards.named-credit-card',
-          uri: '/paymentmethods/crugive/giydembug4=',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4='
+          type: 'paymentinstruments.payment-instrument',
+          uri: '/paymentinstruments/crugive/gnrgmnlbgm4wgljwmfstcljug5stallbg44welldgrtdgmtggiydmm3bmi=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/crugive/gnrgmnlbgm4wgljwmfstcljug5stallbg44welldgrtdgmtggiydmm3bmi='
         },
-        links: [{
-          rel: 'list',
-          type: 'elasticpath.collections.links',
-          uri: '/paymentmethods/crugive',
-          href: 'https://give-stage2.cru.org/cortex/paymentmethods/crugive'
-        }, {
-          rel: 'creditcard',
-          type: 'cru.creditcards.named-credit-card',
-          uri: '/creditcards/paymentmethods/crugive/giydembug4=',
-          href: 'https://give-stage2.cru.org/cortex/creditcards/paymentmethods/crugive/giydembug4='
-        }],
-        'card-number': '1111',
+        messages: [],
+        links: [],
+        'default-on-profile': false,
+        name: 'Cru Payment Instrument',
+        'last-four-digits': '1111',
         'card-type': 'Visa',
         'cardholder-name': 'Test Card',
         'expiry-month': '11',
         'expiry-year': '2019',
-        selectAction: '/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq='
+        'country-name': 'US',
+        'extended-address': '',
+        locality: 'Sacramento',
+        'postal-code': '12345',
+        region: 'CA',
+        'street-address': '1234 First Street',
+        address: {
+          country: 'US',
+          extendedAddress: '',
+          locality: 'Sacramento',
+          postalCode: '12345',
+          region: 'CA',
+          streetAddress: '1234 First Street'
+        },
+        selectAction: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/paymentinstrumentselector/qkzwg5ltorxw2zlsfvuw443uoj2w2zlootmsim3cmy2wcmzzmmwtmylfgewtin3fgawwcnzzmiwwgndggmzgmmrqgyzwcyvknfxhg5dsovwwk3tu3esdinbwge4tonlgfu2wenbzfu2doytbfvqtimjqfu2gmnbvha2dmnrrgi2wg='
       }]
     })
 
     it('should load a user\'s existing payment methods', (done) => {
       self.$httpBackend.expectGET(
-        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
       ).respond(200, clonedPaymentMethodSelectorResponse)
 
       self.orderService.getExistingPaymentMethods()
@@ -544,11 +543,11 @@ describe('order service', () => {
 
     it('should load a user\'s existing payment methods even if there is no chosen one', (done) => {
       // Move the payment method in chosen to be one of the choices for this test
-      clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice.push(clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0])
-      delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen
+      clonedPaymentMethodSelectorResponse._order[0]._paymentinstrumentselector[0]._choice.push(clonedPaymentMethodSelectorResponse._order[0]._paymentinstrumentselector[0]._chosen[0])
+      delete clonedPaymentMethodSelectorResponse._order[0]._paymentinstrumentselector[0]._chosen
 
       self.$httpBackend.expectGET(
-        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
       ).respond(200, clonedPaymentMethodSelectorResponse)
 
       // Since there is no chosen element, this payment method should not be marked as chosen
@@ -565,10 +564,10 @@ describe('order service', () => {
 
     it('should load a user\'s existing payment methods even if there is no choice element and only a chosen one', (done) => {
       // Delete all the choices so there is only a chosen element for this test
-      delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice
+      delete clonedPaymentMethodSelectorResponse._order[0]._paymentinstrumentselector[0]._choice
 
       self.$httpBackend.expectGET(
-        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
       ).respond(200, clonedPaymentMethodSelectorResponse)
 
       // Since there are no choices, there should only be one the one chosen paymentMethod
@@ -584,11 +583,12 @@ describe('order service', () => {
     })
 
     it('should format payment addresses while loading existing payment methods', (done) => {
-      clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0]._description[0].address = { 'country-name': 'US' }
-      expectedResponse[0].address = { country: 'US', streetAddress: undefined, extendedAddress: undefined, locality: undefined, region: undefined, postalCode: undefined }
+      clonedPaymentMethodSelectorResponse._order[0]._paymentinstrumentselector[0]._choice[0]._description[0]['payment-instrument-identification-attributes']['extended-address'] = 'Apt B'
+      expectedResponse[2].address = { country: 'US', streetAddress: '1234 First Street', extendedAddress: 'Apt B', locality: 'Sacramento', region: 'CA', postalCode: '12345' }
+      expectedResponse[2]['extended-address'] = 'Apt B'
 
       self.$httpBackend.expectGET(
-        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
+        'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
       ).respond(200, clonedPaymentMethodSelectorResponse)
 
       self.orderService.getExistingPaymentMethods()
@@ -620,12 +620,35 @@ describe('order service', () => {
 
   describe('getCurrentPayment', () => {
     it('should retrieve the current payment details', (done) => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:paymentmethod')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:chosen:description')
         .respond(200, paymentMethodBankAccountResponse)
+
+      const expectedResponse = {
+        self: {
+          type: 'paymentinstruments.payment-instrument',
+          uri: '/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gnstmzrymiytoljugbrdmljuheygellcmy2gmllcgm4dsnjygu2gmnryme=',
+          href: 'https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/orderpaymentinstrument/gnstmzrymiytoljugbrdmljuheygellcmy2gmllcgm4dsnjygu2gmnryme='
+        },
+        messages: [],
+        links: [],
+        'default-on-profile': false,
+        'limit-amount': {
+          amount: 0,
+          currency: 'USD',
+          display: '$0.00'
+        },
+        name: 'Cru Payment Instrument',
+        'account-type': 'checking',
+        'bank-name': 'My Bank Name',
+        'display-account-number': '3456',
+        'encrypted-account-number': '4e981aa5-993a-4771-85fa-bbcd322ce189:SHv8dEQBg8XSO5P0SFXwQg',
+        'routing-number': '000000000',
+        'saved-on-profile': true
+      }
 
       self.orderService.getCurrentPayment()
         .subscribe((data) => {
-          expect(data).toEqual(paymentMethodBankAccountResponse._order[0]._paymentmethodinfo[0]._paymentmethod[0])
+          expect(data).toEqual(expectedResponse)
           done()
         })
 
@@ -633,10 +656,10 @@ describe('order service', () => {
     })
 
     it('should retrieve the current payment details with a billing address', (done) => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:paymentmethod')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:chosen:description')
         .respond(200, paymentMethodCreditCardResponse)
 
-      const expectedPaymentInfo = angular.copy(paymentMethodCreditCardResponse._order[0]._paymentmethodinfo[0]._paymentmethod[0])
+      const expectedPaymentInfo = angular.copy(paymentMethodCreditCardResponse._order[0]._paymentinstrumentselector[0]._chosen[0]._description[0])
       expectedPaymentInfo.address = {
         country: 'US',
         extendedAddress: '',
@@ -645,6 +668,20 @@ describe('order service', () => {
         region: 'CA',
         streetAddress: '1234 First Street'
       }
+      expectedPaymentInfo['payment-instrument-identification-attributes'] = undefined
+      expectedPaymentInfo['last-four-digits'] = '1118'
+      expectedPaymentInfo['card-type'] = 'MasterCard'
+      expectedPaymentInfo['cardholder-name'] = 'Test Person'
+      expectedPaymentInfo.description = 'MasterCard - 1118'
+      expectedPaymentInfo['expiry-month'] = '08'
+      expectedPaymentInfo['expiry-year'] = '2020'
+      expectedPaymentInfo['country-name'] = 'US'
+      expectedPaymentInfo['extended-address'] = ''
+      expectedPaymentInfo.locality = 'Sacramento'
+      expectedPaymentInfo['postal-code'] = '12345'
+      expectedPaymentInfo.region = 'CA'
+      expectedPaymentInfo['street-address'] = '1234 First Street'
+
       self.orderService.getCurrentPayment()
         .subscribe((data) => {
           expect(data).toEqual(expectedPaymentInfo)

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -219,7 +219,7 @@ describe('order service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mjswgobwmy2gkljtgazwcljumfsweljzmu2teljzmmytazrsge3wkodfmu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mjswgobwmy2gkljtgazwcljumfsweljzmu2teljzmmytazrsge3wkodfmu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -262,7 +262,7 @@ describe('order service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, { self: { uri: 'new cc uri' } })
 
@@ -317,7 +317,7 @@ describe('order service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/orders/crugive/mnrwmntdmjrgkljvgi4gmljugrstcllbmjqtsllegq2winbvgbrdamrzgm=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, { self: { uri: 'new cc uri' } })
 
@@ -737,7 +737,7 @@ describe('order service', () => {
 
     it('should send a request to finalize the purchase', (done) => {
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
         { 'cover-cc-fees': false }
       ).respond(200, purchaseResponse)
 
@@ -752,7 +752,7 @@ describe('order service', () => {
 
     it('should send a request to finalize the purchase and with a CVV', (done) => {
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
         { 'security-code': '123', 'cover-cc-fees': false }
       ).respond(200, purchaseResponse)
 
@@ -769,7 +769,7 @@ describe('order service', () => {
       self.$window.localStorage.setItem('coverFees', 'true')
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
         { 'cover-cc-fees': true }
       ).respond(200, purchaseResponse)
 
@@ -786,7 +786,7 @@ describe('order service', () => {
       self.$window.localStorage.setItem('coverFees', 'false')
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
         { 'cover-cc-fees': false }
       ).respond(200, purchaseResponse)
 
@@ -803,7 +803,7 @@ describe('order service', () => {
       expect(self.$window.localStorage.getItem('coverFees')).toEqual(null)
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
         { 'cover-cc-fees': false }
       ).respond(200, purchaseResponse)
 

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -48,7 +48,7 @@ describe('order service', () => {
   }
 
   describe('getDonorDetails', () => {
-    it('should load the donorDetails', () => {
+    it('should load the donorDetails', (done) => {
       const donorDetailsResponseZoomMapped = {
         donorDetails: donorDetailsResponse._order[0]._donordetails[0],
         email: donorDetailsResponse._order[0]._emailinfo[0]._email[0],
@@ -67,11 +67,12 @@ describe('order service', () => {
       self.orderService.getDonorDetails()
         .subscribe((data) => {
           expect(data).toEqual(expectedDonorDetails)
+          done()
         })
       self.$httpBackend.flush()
     })
 
-    it('should set the mailingAddress country to US if undefined', () => {
+    it('should set the mailingAddress country to US if undefined', (done) => {
       donorDetailsResponse._order[0]._donordetails[0]['mailing-address']['country-name'] = ''
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:emailform')
         .respond(200, donorDetailsResponse)
@@ -80,11 +81,12 @@ describe('order service', () => {
           expect(data).toEqual(expect.objectContaining({
             mailingAddress: expect.objectContaining({ country: 'US' })
           }))
+          done()
         })
       self.$httpBackend.flush()
     })
 
-    it('should handle an undefined response', () => {
+    it('should handle an undefined response', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:emailform')
         .respond(200, {})
       self.orderService.getDonorDetails()
@@ -95,13 +97,14 @@ describe('order service', () => {
             email: undefined,
             emailFormUri: undefined
           })
+          done()
         })
       self.$httpBackend.flush()
     })
   })
 
   describe('updateDonorDetails', () => {
-    it('should send a request to save the donor details', () => {
+    it('should send a request to save the donor details', (done) => {
       self.$httpBackend.expectPUT(
         'https://give-stage2.cru.org/cortex/donordetails/orders/crugive/mjstoztgmqydaljrmeytqljumm3dmljymnrdallbhfsdqnbrmq2wimrqgu=',
         {
@@ -139,13 +142,14 @@ describe('order service', () => {
       })
         .subscribe((data) => {
           expect(data).toEqual('somedata')
+          done()
         })
       self.$httpBackend.flush()
     })
   })
 
   describe('addEmail', () => {
-    it('should send a request to save the email', () => {
+    it('should send a request to save the email', (done) => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/emails/crugive',
         { email: 'someemail@somedomain.com' }
@@ -153,6 +157,7 @@ describe('order service', () => {
       self.orderService.addEmail('someemail@somedomain.com', '/emails/crugive')
         .subscribe((data) => {
           expect(data).toEqual('somedata')
+          done()
         })
       self.$httpBackend.flush()
     })
@@ -164,29 +169,30 @@ describe('order service', () => {
         .respond(200, cartResponse)
     }
 
-    function initiateRequest () {
+    function initiateRequest (done) {
       self.orderService.getPaymentMethodForms()
         .subscribe((data) => {
           expect(data).toEqual(cartResponseZoomMapped)
+          done()
         })
     }
 
-    it('should send a request to get the payment form links', () => {
+    it('should send a request to get the payment form links', (done) => {
       setupRequest()
-      initiateRequest()
+      initiateRequest(done)
       self.$httpBackend.flush()
     })
 
-    it('should use the cached response if called a second time', () => {
+    it('should use the cached response if called a second time', (done) => {
       setupRequest()
-      initiateRequest()
+      initiateRequest(done)
       self.$httpBackend.flush()
-      initiateRequest()
+      initiateRequest(done)
     })
   })
 
   describe('addBankAccountPayment', () => {
-    it('should send a request to save the bank account payment info', () => {
+    it('should send a request to save the bank account payment info', (done) => {
       const paymentInfo = {
         'account-type': 'checking',
         'bank-name': 'First Bank',
@@ -206,6 +212,7 @@ describe('order service', () => {
       self.orderService.addBankAccountPayment(paymentInfo)
         .subscribe((data) => {
           expect(data).toEqual('success')
+          done()
         })
 
       self.$httpBackend.flush()
@@ -217,7 +224,7 @@ describe('order service', () => {
       jest.spyOn(self.orderService, 'storeCardSecurityCode').mockImplementation(() => {})
     })
 
-    it('should send a request to save the credit card payment info with no billing address', () => {
+    it('should send a request to save the credit card payment info with no billing address', (done) => {
       const paymentInfo = {
         'card-number': '**fake*encrypted**1234567890123456**',
         'card-type': 'VISA',
@@ -241,6 +248,7 @@ describe('order service', () => {
       self.orderService.addCreditCardPayment(paymentInfo)
         .subscribe((data) => {
           expect(data).toEqual({ self: { uri: 'new cc uri' } })
+          done()
         })
 
       self.$httpBackend.flush()
@@ -248,7 +256,7 @@ describe('order service', () => {
       expect(self.orderService.storeCardSecurityCode).toHaveBeenCalledWith('456', 'new cc uri')
     })
 
-    it('should send a request to save the credit card payment info with a billing address', () => {
+    it('should send a request to save the credit card payment info with a billing address', (done) => {
       const paymentInfo = {
         address: {
           country: 'US',
@@ -288,6 +296,7 @@ describe('order service', () => {
       self.orderService.addCreditCardPayment(paymentInfo)
         .subscribe((data) => {
           expect(data).toEqual({ self: { uri: 'new cc uri' } })
+          done()
         })
 
       self.$httpBackend.flush()
@@ -297,7 +306,7 @@ describe('order service', () => {
   })
 
   describe('addPaymentMethod', () => {
-    it('should save a new bank account payment method', () => {
+    it('should save a new bank account payment method', (done) => {
       jest.spyOn(self.orderService, 'addBankAccountPayment').mockReturnValue(Observable.of('success'))
       const paymentInfo = {
         'account-type': 'checking',
@@ -310,12 +319,13 @@ describe('order service', () => {
         bankAccount: paymentInfo
       }).subscribe((data) => {
         expect(data).toEqual('success')
+        done()
       })
 
       expect(self.orderService.addBankAccountPayment).toHaveBeenCalledWith(paymentInfo)
     })
 
-    it('should save a new credit card payment method', () => {
+    it('should save a new credit card payment method', (done) => {
       jest.spyOn(self.orderService, 'addCreditCardPayment').mockReturnValue(Observable.of({ self: { uri: 'new payment method uri' } }))
       const paymentInfo = {
         address: {
@@ -337,6 +347,7 @@ describe('order service', () => {
         creditCard: paymentInfo
       }).subscribe((data) => {
         expect(data).toEqual({ self: { uri: 'new payment method uri' } })
+        done()
       })
 
       expect(self.orderService.addCreditCardPayment).toHaveBeenCalledWith(paymentInfo)
@@ -486,7 +497,7 @@ describe('order service', () => {
       }]
     })
 
-    it('should load a user\'s existing payment methods', () => {
+    it('should load a user\'s existing payment methods', (done) => {
       self.$httpBackend.expectGET(
         'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:selector:choice,order:paymentmethodinfo:selector:choice:description,order:paymentmethodinfo:selector:chosen,order:paymentmethodinfo:selector:chosen:description'
       ).respond(200, clonedPaymentMethodSelectorResponse)
@@ -494,12 +505,13 @@ describe('order service', () => {
       self.orderService.getExistingPaymentMethods()
         .subscribe(data => {
           expect(data).toEqual(expectedResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should load a user\'s existing payment methods even if there is no chosen one', () => {
+    it('should load a user\'s existing payment methods even if there is no chosen one', (done) => {
       // Move the payment method in chosen to be one of the choices for this test
       clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice.push(clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0])
       delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen
@@ -514,12 +526,13 @@ describe('order service', () => {
       self.orderService.getExistingPaymentMethods()
         .subscribe(data => {
           expect(data).toEqual(expectedResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should load a user\'s existing payment methods even if there is no choice element and only a chosen one', () => {
+    it('should load a user\'s existing payment methods even if there is no choice element and only a chosen one', (done) => {
       // Delete all the choices so there is only a chosen element for this test
       delete clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._choice
 
@@ -533,12 +546,13 @@ describe('order service', () => {
       self.orderService.getExistingPaymentMethods()
         .subscribe(data => {
           expect(data).toEqual(expectedResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should format payment addresses while loading existing payment methods', () => {
+    it('should format payment addresses while loading existing payment methods', (done) => {
       clonedPaymentMethodSelectorResponse._order[0]._paymentmethodinfo[0]._selector[0]._chosen[0]._description[0].address = { 'country-name': 'US' }
       expectedResponse[0].address = { country: 'US', streetAddress: undefined, extendedAddress: undefined, locality: undefined, region: undefined, postalCode: undefined }
 
@@ -549,6 +563,7 @@ describe('order service', () => {
       self.orderService.getExistingPaymentMethods()
         .subscribe(data => {
           expect(data).toEqual(expectedResponse)
+          done()
         })
 
       self.$httpBackend.flush()
@@ -556,7 +571,7 @@ describe('order service', () => {
   })
 
   describe('selectPaymentMethod', () => {
-    it('should post the URI of the selected payment method for cortex to select it', () => {
+    it('should post the URI of the selected payment method for cortex to select it', (done) => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=',
         {}
@@ -565,6 +580,7 @@ describe('order service', () => {
       self.orderService.selectPaymentMethod('/paymentmethods/crugive/giydembug4=/selector/orders/crugive/mm2tsnrrg5qtqljshfsteljuhe2dellcgrrweljugftdgndcg4zweztbmq=')
         .subscribe((data) => {
           expect(data).toEqual('success')
+          done()
         })
 
       self.$httpBackend.flush()
@@ -572,19 +588,20 @@ describe('order service', () => {
   })
 
   describe('getCurrentPayment', () => {
-    it('should retrieve the current payment details', () => {
+    it('should retrieve the current payment details', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:paymentmethod')
         .respond(200, paymentMethodBankAccountResponse)
 
       self.orderService.getCurrentPayment()
         .subscribe((data) => {
           expect(data).toEqual(paymentMethodBankAccountResponse._order[0]._paymentmethodinfo[0]._paymentmethod[0])
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should retrieve the current payment details with a billing address', () => {
+    it('should retrieve the current payment details with a billing address', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:paymentmethod')
         .respond(200, paymentMethodCreditCardResponse)
 
@@ -600,6 +617,7 @@ describe('order service', () => {
       self.orderService.getCurrentPayment()
         .subscribe((data) => {
           expect(data).toEqual(expectedPaymentInfo)
+          done()
         })
 
       self.$httpBackend.flush()
@@ -607,33 +625,36 @@ describe('order service', () => {
   })
 
   describe('getPurchaseForms', () => {
-    it('should send a request to get the payment form links', () => {
+    it('should send a request to get the payment form links', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:enhancedpurchaseform').respond(200, purchaseFormResponse)
       self.orderService.getPurchaseForm()
         .subscribe((data) => {
           expect(data).toEqual(purchaseFormResponseZoomMapped)
+          done()
         })
       self.$httpBackend.flush()
     })
   })
 
   describe('checkErrors', () => {
-    it('should send a request to get the payment form links', () => {
+    it('should send a request to get the payment form links', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:needinfo').respond(200, needInfoResponse)
       self.orderService.checkErrors()
         .subscribe((data) => {
           expect(data).toEqual(['email-info', 'billing-address-info', 'payment-method-info'])
+          done()
         })
       self.$httpBackend.flush()
 
       expect(self.$log.error.logs[0]).toEqual(['The user was presented with these `needinfo` errors. They should have been caught earlier in the checkout process.', ['email-info', 'billing-address-info', 'payment-method-info']])
     })
 
-    it('should return undefined and not log anything if there are no errors', () => {
+    it('should return undefined and not log anything if there are no errors', (done) => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:needinfo').respond(200, undefined)
       self.orderService.checkErrors()
         .subscribe((data) => {
           expect(data).toBeUndefined()
+          done()
         })
       self.$httpBackend.flush()
       self.$log.assertEmpty()
@@ -646,7 +667,7 @@ describe('order service', () => {
       jest.spyOn(self.orderService, 'getPurchaseForm').mockReturnValue(Observable.of(purchaseFormResponseZoomMapped))
     })
 
-    it('should send a request to finalize the purchase', () => {
+    it('should send a request to finalize the purchase', (done) => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
         { 'cover-cc-fees': false }
@@ -655,12 +676,13 @@ describe('order service', () => {
       self.orderService.submit()
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should send a request to finalize the purchase and with a CVV', () => {
+    it('should send a request to finalize the purchase and with a CVV', (done) => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
         { 'security-code': '123', 'cover-cc-fees': false }
@@ -669,12 +691,13 @@ describe('order service', () => {
       self.orderService.submit('123')
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should send the (true) cover fees flag to the server', () => {
+    it('should send the (true) cover fees flag to the server', (done) => {
       self.$window.localStorage.setItem('coverFees', 'true')
 
       self.$httpBackend.expectPOST(
@@ -685,12 +708,13 @@ describe('order service', () => {
       self.orderService.submit()
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should send the (false) cover fees flag to the server', () => {
+    it('should send the (false) cover fees flag to the server', (done) => {
       self.$window.localStorage.setItem('coverFees', 'false')
 
       self.$httpBackend.expectPOST(
@@ -701,12 +725,13 @@ describe('order service', () => {
       self.orderService.submit()
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
+          done()
         })
 
       self.$httpBackend.flush()
     })
 
-    it('should send the (false) cover fees flag to the server if the flag is not set in local storage', () => {
+    it('should send the (false) cover fees flag to the server if the flag is not set in local storage', (done) => {
       expect(self.$window.localStorage.getItem('coverFees')).toEqual(null)
 
       self.$httpBackend.expectPOST(
@@ -717,6 +742,7 @@ describe('order service', () => {
       self.orderService.submit()
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
+          done()
         })
 
       self.$httpBackend.flush()

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -195,7 +195,7 @@ class Profile {
     return this.cortexApiService.get({
       path: ['profiles', this.cortexApiService.scope, 'default'],
       zoom: {
-        paymentMethods: 'selfservicepaymentmethods:element[]'
+        paymentMethods: 'selfservicepaymentinstruments:element[]'
       },
       cache: !!cache
     })
@@ -230,7 +230,7 @@ class Profile {
     return this.cortexApiService.get({
       path: ['profiles', this.cortexApiService.scope, 'default'],
       zoom: {
-        paymentMethods: 'selfservicepaymentmethods:element[],selfservicepaymentmethods:element:recurringgifts'
+        paymentMethods: 'selfservicepaymentinstruments:element[],selfservicepaymentinstruments:element:recurringgifts'
       }
     })
       .pluck('paymentMethods')
@@ -258,8 +258,8 @@ class Profile {
       return this.cortexApiService.get({
         path: ['profiles', this.cortexApiService.scope, 'default'],
         zoom: {
-          bankAccount: 'selfservicepaymentmethods:createbankaccountform',
-          creditCard: 'selfservicepaymentmethods:createcreditcardform'
+          bankAccount: 'selfservicepaymentinstruments:createbankaccountform',
+          creditCard: 'selfservicepaymentinstruments:createcreditcardform'
         }
       })
         .do((data) => {

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -3,7 +3,7 @@ import pick from 'lodash/pick'
 import find from 'lodash/find'
 import omit from 'lodash/omit'
 import map from 'lodash/map'
-import flatMap from 'lodash/flatMap'
+// import flatMap from 'lodash/flatMap'
 import assign from 'lodash/assign'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
@@ -13,7 +13,7 @@ import 'rxjs/add/operator/map'
 import 'rxjs/add/operator/mergeMap'
 
 import sortPaymentMethods from 'common/services/paymentHelpers/paymentMethodSort'
-import RecurringGiftModel from 'common/models/recurringGift.model'
+// import RecurringGiftModel from 'common/models/recurringGift.model'
 
 import cortexApiService from '../cortexApi.service'
 import hateoasHelperService from 'common/services/hateoasHelper.service'
@@ -239,12 +239,13 @@ class Profile {
           if (paymentMethod.address) {
             paymentMethod.address = formatAddressForTemplate(paymentMethod.address)
           }
-          paymentMethod.recurringGifts = flatMap(paymentMethod.recurringgifts.donations, donation => {
-            return map(donation['donation-lines'], donationLine => {
-              return new RecurringGiftModel(donationLine, donation)
-            })
-          })
-          delete paymentMethod.recurringgifts
+          // TODO: Implement when this is on the server
+          // paymentMethod.recurringGifts = flatMap(paymentMethod.recurringgifts.donations, donation => {
+          //   return map(donation['donation-lines'], donationLine => {
+          //     return new RecurringGiftModel(donationLine, donation)
+          //   })
+          // })
+          // delete paymentMethod.recurringgifts
           return paymentMethod
         })
         return sortPaymentMethods(paymentMethods)

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -21,10 +21,16 @@ import phoneNumbersResponse from 'common/services/api/fixtures/cortex-profile-ph
 import selfserviceDonorDetailsResponse from 'common/services/api/fixtures/cortex-profile-selfservicedonordetails.fixture.js'
 import mailingAddressResponse from 'common/services/api/fixtures/cortex-profile-mailingaddress.fixture.js'
 import RecurringGiftModel from 'common/models/recurringGift.model'
+import cartResponse from './fixtures/cortex-cart-paymentmethodinfo-forms.fixture'
+
+const paymentMethodForms = cloneDeep(paymentmethodsFormsResponse._paymentmethods[0]._element)
+angular.forEach(paymentMethodForms, form => {
+  form.paymentinstrumentform = form._paymentinstrumentform[0]
+  delete form._paymentinstrumentform
+})
 
 const paymentmethodsFormsResponseZoomMapped = {
-  bankAccount: paymentmethodsFormsResponse._selfservicepaymentinstruments[0]._createbankaccountform[0],
-  creditCard: paymentmethodsFormsResponse._selfservicepaymentinstruments[0]._createcreditcardform[0],
+  paymentMethodForms: paymentMethodForms,
   rawData: paymentmethodsFormsResponse
 }
 
@@ -129,7 +135,7 @@ describe('profile service', () => {
 
   describe('getPaymentMethodForms', () => {
     function setupRequest () {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform')
         .respond(200, paymentmethodsFormsResponse)
     }
 
@@ -164,9 +170,13 @@ describe('profile service', () => {
         'routing-number': '123456789'
       }
 
+      const expectedPostData = {
+        'payment-instrument-identification-form': paymentInfo
+      }
+
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive?followLocation=true',
-        paymentInfo
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?followLocation=true',
+        expectedPostData
       ).respond(200, 'success')
 
       // cache getPaymentForms response to avoid another http request while testing
@@ -192,12 +202,14 @@ describe('profile service', () => {
         cvv: 'someEncryptedCVV...'
       }
 
-      const paymentInfoWithoutCVV = angular.copy(paymentInfo)
-      delete paymentInfoWithoutCVV.cvv
+      const expectedPostData = {
+        'payment-instrument-identification-form': paymentInfo
+      }
+      delete expectedPostData['payment-instrument-identification-form'].cvv
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive?followLocation=true',
-        paymentInfoWithoutCVV
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        expectedPostData
       ).respond(200, 'success')
 
       // cache getPaymentForms response to avoid another http request while testing
@@ -229,20 +241,27 @@ describe('profile service', () => {
         cvv: 'someEncryptedCVV...'
       }
 
-      const paymentInfoWithoutCVV = angular.copy(paymentInfo)
-      delete paymentInfoWithoutCVV.cvv
-      paymentInfoWithoutCVV.address = {
-        'country-name': 'US',
-        'street-address': '123 First St',
-        'extended-address': 'Apt 123',
-        locality: 'Sacramento',
-        'postal-code': '12345',
-        region: 'CA'
+      const expectedPostData = {
+        address: {
+          'country-name': 'US',
+          'street-address': '123 First St',
+          'extended-address': 'Apt 123',
+          locality: 'Sacramento',
+          'postal-code': '12345',
+          region: 'CA'
+        },
+        'payment-instrument-identification-form': {
+          'card-number': '**fake*encrypted**1234567890123456**',
+          'card-type': 'VISA',
+          'cardholder-name': 'Test Name',
+          'expiry-month': '06',
+          'expiry-year': '12'
+        }
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive?followLocation=true',
-        paymentInfoWithoutCVV
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        expectedPostData
       ).respond(200, 'success')
 
       // cache getPaymentForms response to avoid another http request while testing

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -175,7 +175,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -208,7 +208,7 @@ describe('profile service', () => {
       delete expectedPostData['payment-instrument-identification-form'].cvv
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -260,7 +260,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?followLocation=true',
+        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -548,9 +548,9 @@ describe('profile service', () => {
 
   describe('updateEmail', () => {
     it('should add spouse\'s details', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/emails/crugive/spouse?followLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/emails/crugive/spouse?FollowLocation=true')
         .respond(200, 'spouse success')
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/emails/crugive/?followLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/emails/crugive/?FollowLocation=true')
         .respond(200, 'donor success')
 
       self.profileService.updateEmail({}, true)
@@ -621,9 +621,9 @@ describe('profile service', () => {
 
   describe('addPhoneNumber', () => {
     it('should add phone number', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/spouse?followLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/spouse?FollowLocation=true')
         .respond(200, 'spouse success')
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/?followLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/?FollowLocation=true')
         .respond(200, 'donor success')
       const phoneNumber = {
         spouse: true

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -23,8 +23,8 @@ import mailingAddressResponse from 'common/services/api/fixtures/cortex-profile-
 import RecurringGiftModel from 'common/models/recurringGift.model'
 
 const paymentmethodsFormsResponseZoomMapped = {
-  bankAccount: paymentmethodsFormsResponse._selfservicepaymentmethods[0]._createbankaccountform[0],
-  creditCard: paymentmethodsFormsResponse._selfservicepaymentmethods[0]._createcreditcardform[0],
+  bankAccount: paymentmethodsFormsResponse._selfservicepaymentinstruments[0]._createbankaccountform[0],
+  creditCard: paymentmethodsFormsResponse._selfservicepaymentinstruments[0]._createcreditcardform[0],
   rawData: paymentmethodsFormsResponse
 }
 
@@ -57,10 +57,10 @@ describe('profile service', () => {
 
   describe('getPaymentMethods', () => {
     it('should load the user\'s saved payment methods', () => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentmethods:element')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:element')
         .respond(200, paymentmethodsResponse)
 
-      const expectedPaymentMethods = angular.copy(paymentmethodsResponse._selfservicepaymentmethods[0]._element)
+      const expectedPaymentMethods = angular.copy(paymentmethodsResponse._selfservicepaymentinstruments[0]._element)
       expectedPaymentMethods[0].id = expectedPaymentMethods[0].self.uri.split('/').pop()
       expectedPaymentMethods[1].id = expectedPaymentMethods[1].self.uri.split('/').pop()
       expectedPaymentMethods[0].address = {
@@ -84,7 +84,7 @@ describe('profile service', () => {
 
   describe('getPaymentMethod', () => {
     it('should load a user\'s payment method', () => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/selfservicepaymentmethods/crugive/giydiojyg4=')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydiojyg4=')
         .respond(200, paymentmethodResponse)
 
       const expectedPaymentMethod = angular.copy(paymentmethodResponse)
@@ -97,7 +97,7 @@ describe('profile service', () => {
         region: 'IN',
         'street-address': '198 W King St'
       }
-      self.profileService.getPaymentMethod('/selfservicepaymentmethods/crugive/giydiojyg4=')
+      self.profileService.getPaymentMethod('/selfservicepaymentinstruments/crugive/giydiojyg4=')
         .subscribe((data) => {
           expect(data.id).toEqual(expectedPaymentMethod.id)
           expect(data.address['card-number']).toEqual(expectedPaymentMethod.address['card-number'])
@@ -109,10 +109,10 @@ describe('profile service', () => {
 
   describe('getPaymentMethodsWithDonations', () => {
     it('should load the user\'s saved payment methods with donations', () => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentmethods:element,selfservicepaymentmethods:element:recurringgifts')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:element,selfservicepaymentinstruments:element:recurringgifts')
         .respond(200, paymentmethodsWithDonationsResponse)
 
-      const expectedData = cloneDeep(paymentmethodsWithDonationsResponse._selfservicepaymentmethods[0]._element)
+      const expectedData = cloneDeep(paymentmethodsWithDonationsResponse._selfservicepaymentinstruments[0]._element)
         .map(paymentMethod => {
           paymentMethod.recurringGifts = []
           delete paymentMethod._recurringgifts
@@ -129,7 +129,7 @@ describe('profile service', () => {
 
   describe('getPaymentMethodForms', () => {
     function setupRequest () {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentmethods:createbankaccountform,selfservicepaymentmethods:createcreditcardform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:createbankaccountform,selfservicepaymentinstruments:createcreditcardform')
         .respond(200, paymentmethodsFormsResponse)
     }
 
@@ -165,7 +165,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentmethods/crugive?followLocation=true',
+        'https://give-stage2.cru.org/cortex/bankaccounts/selfservicepaymentinstruments/crugive?followLocation=true',
         paymentInfo
       ).respond(200, 'success')
 
@@ -196,7 +196,7 @@ describe('profile service', () => {
       delete paymentInfoWithoutCVV.cvv
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentmethods/crugive?followLocation=true',
+        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive?followLocation=true',
         paymentInfoWithoutCVV
       ).respond(200, 'success')
 
@@ -241,7 +241,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentmethods/crugive?followLocation=true',
+        'https://give-stage2.cru.org/cortex/creditcards/selfservicepaymentinstruments/crugive?followLocation=true',
         paymentInfoWithoutCVV
       ).respond(200, 'success')
 

--- a/src/common/services/api/verification.service.spec.js
+++ b/src/common/services/api/verification.service.spec.js
@@ -61,7 +61,7 @@ describe('verification service', () => {
     const answers = [{ key: 'a', answer: '1' }, { key: 'b', answer: '2' }]
     it('submits donor verification answers', () => {
       $httpBackend
-        .expectPOST('https://give-stage2.cru.org/cortex/verifyregistrations/crugive?followLocation=true', {
+        .expectPOST('https://give-stage2.cru.org/cortex/verifyregistrations/crugive?FollowLocation=true', {
           'verification-questions': answers,
           'that-is-not-me': 'false'
         })
@@ -74,7 +74,7 @@ describe('verification service', () => {
   describe('thatIsNotMe()', () => {
     it('submits \'that-is-not-me\' donor verification', () => {
       $httpBackend
-        .expectPOST('https://give-stage2.cru.org/cortex/verifyregistrations/crugive?followLocation=true', {
+        .expectPOST('https://give-stage2.cru.org/cortex/verifyregistrations/crugive?FollowLocation=true', {
           'that-is-not-me': 'true'
         })
         .respond(201, {})

--- a/src/common/services/cortexApi.service.js
+++ b/src/common/services/cortexApi.service.js
@@ -35,7 +35,7 @@ class CortexApi {
       config.params.zoom = this.hateoasHelperService.serializeZoom(config.zoom)
     }
     if (config.followLocation) {
-      config.params.followLocation = true
+      config.params.FollowLocation = true
     }
     if (!config.cache && this.envService.read('isBrandedCheckout')) {
       config.params.nocache = new Date().getTime()

--- a/src/common/services/cortexApi.spec.js
+++ b/src/common/services/cortexApi.spec.js
@@ -44,7 +44,7 @@ describe('cortex api service', () => {
     })
 
     it('should set the followLocation param if it is set in the config', () => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/test?followLocation=true').respond(200, 'success')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/test?FollowLocation=true').respond(200, 'success')
       self.cortexApiService.http({
         method: 'GET',
         path: 'test',

--- a/src/common/services/hateoasHelper.service.js
+++ b/src/common/services/hateoasHelper.service.js
@@ -18,9 +18,12 @@ class HateoasHelper {
 
   getLink (response, relationshipName) {
     const linkObj = find(response && response.links, { rel: relationshipName })
-    return linkObj
-      ? linkObj.uri.replace(/^\//, '') // remove initial slash
-      : undefined
+    if (linkObj) {
+      return linkObj.uri ? linkObj.uri.replace(/^\//, '') // remove initial slash
+        : linkObj.href ? linkObj.href.replace(/^https?:\/{2}:?[0-9]{0,4}[a-z].*\/cortex(.*)/, '$1')
+          : undefined
+    }
+    return undefined
   }
 
   getElement (response, path, zoomIsArray) {

--- a/src/common/services/hateoasHelper.spec.js
+++ b/src/common/services/hateoasHelper.spec.js
@@ -12,8 +12,7 @@ describe('HATEOAS helper service', function () {
     self.hateoasHelperService = hateoasHelperService
 
     self.zoom = {
-      bankaccountform: 'order:paymentmethodinfo:bankaccountform',
-      creditcardform: 'order:paymentmethodinfo:creditcardform'
+      paymentMethodForms: 'order:paymentmethodinfo'
     }
   }))
 
@@ -45,7 +44,7 @@ describe('HATEOAS helper service', function () {
 
   describe('getElement', () => {
     it('should get the object specified by a path array', () => {
-      expect(self.hateoasHelperService.getElement(cartResponse, ['order', 'paymentmethodinfo', 'bankaccountform'])).toEqual(cartResponse._order[0]._paymentmethodinfo[0]._bankaccountform[0])
+      expect(self.hateoasHelperService.getElement(cartResponse, ['order', 'paymentmethodinfo', 'element'])).toEqual(cartResponse._order[0]._paymentmethodinfo[0]._element[0])
     })
 
     it('should get the object specified by a path string', () => {
@@ -69,22 +68,20 @@ describe('HATEOAS helper service', function () {
 
   describe('serializeZoom', () => {
     it('should join all zoom strings with a comma', () => {
-      expect(self.hateoasHelperService.serializeZoom(self.zoom)).toEqual('order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform')
+      expect(self.hateoasHelperService.serializeZoom(self.zoom)).toEqual('order:paymentmethodinfo')
     })
 
     it('should join all zoom strings with a comma and remove array indicators', () => {
-      self.zoom.bankaccountform += '[]'
-      self.zoom.creditcardform += '[]'
+      self.zoom.paymentMethodForms += '[]'
 
-      expect(self.hateoasHelperService.serializeZoom(self.zoom)).toEqual('order:paymentmethodinfo:bankaccountform,order:paymentmethodinfo:creditcardform')
+      expect(self.hateoasHelperService.serializeZoom(self.zoom)).toEqual('order:paymentmethodinfo')
     })
   })
 
   describe('mapZoomElements', () => {
     it('should use the zoom keys as keys and find the corresponding objects', () => {
       expect(self.hateoasHelperService.mapZoomElements(cartResponse, self.zoom)).toEqual({
-        bankaccountform: cartResponse._order[0]._paymentmethodinfo[0]._bankaccountform[0],
-        creditcardform: cartResponse._order[0]._paymentmethodinfo[0]._creditcardform[0],
+        paymentMethodForms: cartResponse._order[0]._paymentmethodinfo[0],
         rawData: cartResponse
       })
     })
@@ -138,11 +135,10 @@ describe('HATEOAS helper service', function () {
     })
 
     it('should return undefined if the zoom isn\'t found', () => {
-      self.zoom.creditcardform += '[]'
+      self.zoom.paymentMethodForms += '[]'
 
       expect(self.hateoasHelperService.mapZoomElements({}, self.zoom)).toEqual({
-        bankaccountform: undefined,
-        creditcardform: undefined,
+        paymentMethodForms: undefined,
         rawData: {}
       })
     })

--- a/src/common/services/paymentHelpers/extractPaymentAttributes.js
+++ b/src/common/services/paymentHelpers/extractPaymentAttributes.js
@@ -1,0 +1,15 @@
+function flattenObject (obj) {
+  const flattened = {}
+
+  Object.keys(obj).forEach(key => {
+    if (key === 'payment-instrument-identification-attributes') {
+      Object.assign(flattened, flattenObject(obj[key]))
+    } else {
+      flattened[key] = obj[key]
+    }
+  })
+
+  return flattened
+}
+
+export default flattenObject

--- a/src/common/services/paymentHelpers/paymentMethodSort.js
+++ b/src/common/services/paymentHelpers/paymentMethodSort.js
@@ -4,9 +4,11 @@ import orderBy from 'lodash/orderBy'
 
 // Sort payment methods so checking accounts are first, then savings accounts, then credit cards ordered by expiration date (longest expiration first)
 function sortPaymentMethods (paymentMethods) {
-  const [bankAccounts, creditCards] = partition(paymentMethods, { self: { type: 'elasticpath.bankaccounts.bank-account' } })
+  const [bankAccounts, creditCards] = partition(paymentMethods, (paymentMethod) => {
+    return paymentMethod['account-type']
+  })
   return concat( // Display bank accounts first
-    orderBy(bankAccounts, 'account-type'), // Display checking accounts first
+    orderBy(bankAccounts, (bankAccount) => bankAccount['account-type']), // Display checking accounts first
     orderBy(creditCards, (card) => card['expiry-year'] + card['expiry-month'], 'desc') // Display newer expiration dates first
   )
 }

--- a/src/common/services/paymentHelpers/paymentMethodSort.spec.js
+++ b/src/common/services/paymentHelpers/paymentMethodSort.spec.js
@@ -3,35 +3,35 @@ import sortPaymentMethods from 'common/services/paymentHelpers/paymentMethodSort
 describe('paymentMethodSort', () => {
   const checkingAccount1 = {
     self: {
-      type: 'elasticpath.bankaccounts.bank-account'
+      type: 'paymentinstruments.payment-instrument'
     },
     'account-type': 'Checking',
     'bank-name': 'First Bank'
   }
   const checkingAccount2 = {
     self: {
-      type: 'elasticpath.bankaccounts.bank-account'
+      type: 'paymentinstruments.payment-instrument'
     },
     'account-type': 'Checking',
     'bank-name': 'Second Bank'
   }
   const savingsAccount1 = {
     self: {
-      type: 'elasticpath.bankaccounts.bank-account'
+      type: 'paymentinstruments.payment-instrument'
     },
     'account-type': 'Savings',
     'bank-name': 'Third Bank'
   }
   const savingsAccount2 = {
     self: {
-      type: 'elasticpath.bankaccounts.bank-account'
+      type: 'paymentinstruments.payment-instrument'
     },
     'account-type': 'Savings',
     'bank-name': 'Third Bank'
   }
   const creditCard1 = {
     self: {
-      type: 'cru.creditcards.named-credit-card'
+      type: 'paymentinstruments.payment-instrument'
     },
     'card-type': 'Visa',
     'expiry-month': '11',
@@ -39,7 +39,7 @@ describe('paymentMethodSort', () => {
   }
   const creditCard2 = {
     self: {
-      type: 'cru.creditcards.named-credit-card'
+      type: 'paymentinstruments.payment-instrument'
     },
     'card-type': 'Visa',
     'expiry-month': '12',
@@ -47,7 +47,7 @@ describe('paymentMethodSort', () => {
   }
   const creditCard3 = {
     self: {
-      type: 'cru.creditcards.named-credit-card'
+      type: 'paymentinstruments.payment-instrument'
     },
     'card-type': 'Visa',
     'expiry-month': '12',

--- a/src/common/services/paymentHelpers/validPaymentMethods.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.js
@@ -7,5 +7,5 @@ export function validPaymentMethods (paymentMethods) {
 }
 
 export function validPaymentMethod (paymentMethod) {
-  return paymentMethod.self.type === 'elasticpath.bankaccounts.bank-account' || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1 }).isSameOrAfter(moment(), 'month')
+  return paymentMethod['account-type'] || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1 }).isSameOrAfter(moment(), 'month')
 }

--- a/src/common/services/paymentHelpers/validPaymentMethods.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.js
@@ -7,5 +7,6 @@ export function validPaymentMethods (paymentMethods) {
 }
 
 export function validPaymentMethod (paymentMethod) {
-  return paymentMethod['account-type'] || moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1 }).isSameOrAfter(moment(), 'month')
+  return paymentMethod['account-type'] ||
+    moment({ year: paymentMethod['expiry-year'], month: parseInt(paymentMethod['expiry-month']) - 1 }).isSameOrAfter(moment(), 'month')
 }

--- a/src/common/services/paymentHelpers/validPaymentMethods.spec.js
+++ b/src/common/services/paymentHelpers/validPaymentMethods.spec.js
@@ -11,8 +11,9 @@ describe('validPaymentMethods', () => {
   it('should return bank accounts', () => {
     const paymentMethods = [{
       self: {
-        type: 'elasticpath.bankaccounts.bank-account'
-      }
+        type: 'paymentinstruments.payment-instrument'
+      },
+      'account-type': 'Checking'
     }]
 
     expect(validPaymentMethods(paymentMethods)).toEqual(paymentMethods)
@@ -21,7 +22,7 @@ describe('validPaymentMethods', () => {
   it('should return active credit cards', () => {
     const paymentMethods = [{
       self: {
-        type: 'cru.creditcards.named-credit-card'
+        type: 'paymentinstruments.payment-instrument'
       },
       'expiry-month': '01',
       'expiry-year': '2015'
@@ -33,7 +34,7 @@ describe('validPaymentMethods', () => {
   it('should filter out inactive credit cards', () => {
     const paymentMethods = [{
       self: {
-        type: 'cru.creditcards.named-credit-card'
+        type: 'paymentinstruments.payment-instrument'
       },
       'expiry-month': '12',
       'expiry-year': '2014'
@@ -52,45 +53,47 @@ describe('validPaymentMethods', () => {
     const paymentMethods = [
       {
         self: {
-          type: 'elasticpath.bankaccounts.bank-account'
-        }
+          type: 'paymentinstruments.payment-instrument'
+        },
+        'account-type': 'Checking'
       },
       {
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '01',
         'expiry-year': '2015'
       },
       {
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '12',
         'expiry-year': '2014'
       },
       {
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '02',
         'expiry-year': '2015'
       },
       {
         self: {
-          type: 'elasticpath.bankaccounts.bank-account'
-        }
+          type: 'paymentinstruments.payment-instrument'
+        },
+        'account-type': 'Checking'
       },
       {
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '01',
         'expiry-year': '2014'
       },
       {
         self: {
-          type: 'cru.creditcards.named-credit-card'
+          type: 'paymentinstruments.payment-instrument'
         },
         'expiry-month': '01',
         'expiry-year': '2016'
@@ -115,17 +118,18 @@ describe('validPaymentMethod', () => {
   it('should consider bank accounts valid', () => {
     const paymentMethod = {
       self: {
-        type: 'elasticpath.bankaccounts.bank-account'
-      }
+        type: 'paymentinstruments.payment-instrument'
+      },
+      'account-type': 'Checking'
     }
 
-    expect(validPaymentMethod(paymentMethod)).toEqual(true)
+    expect(validPaymentMethod(paymentMethod)).toBeTruthy()
   })
 
   it('should consider unexpired credit cards valid', () => {
     const paymentMethod = {
       self: {
-        type: 'cru.creditcards.named-credit-card'
+        type: 'paymentinstruments.payment-instrument'
       },
       'expiry-month': '01',
       'expiry-year': '2015'
@@ -137,7 +141,7 @@ describe('validPaymentMethod', () => {
   it('should consider expired credit cards invalid', () => {
     const paymentMethod = {
       self: {
-        type: 'cru.creditcards.named-credit-card'
+        type: 'paymentinstruments.payment-instrument'
       },
       'expiry-month': '12',
       'expiry-year': '2014'


### PR DESCRIPTION
This PR is the first round of fixing payment methods to work with the new 8.1 API. Some notable changes:

- The `type` of payment methods has changed, and can no longer be relied upon for logic between credit cards and bank accounts
- The JSON structure changed, moving the properties we care about into a new `payment-instrument-identification-form` object (besides billing address, which is still outside)
- The location of payment methods has changed

This does not
 - Handle the recurring gifts link on payment methods
 - Handle billing address properly

This PR also taught me there could probably be a good chunk of refactoring done to re-use code between `order.service.js` and `profile.service.js`.