### PR TITLE
GTM-Add-Credit-Card-Cover-Fee-Event

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -509,6 +509,8 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
     },
     transactionEvent: function (purchaseData) {
       try {
+        // The value of whether or not user is covering credit card fees for the transaction
+        const coverFees = localStorage.getItem('coverFees')
         // Parse the cart object of the last purchase
         const transactionCart = JSON.parse(localStorage.getItem('transactionCart'))
         // The purchaseId number from the last purchase
@@ -561,6 +563,12 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
                 }
               }
             })
+            // Send cover fees event if value is true
+            if (coverFees) {
+              $window.dataLayer.push({
+                event: 'ga-cover-fees-checkbox'
+              })
+            }
           }
         }
         // Remove the transactionCart from localStorage since it is no longer needed

--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -489,13 +489,15 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         // Error caught in analyticsFactory.productViewDetailsEvent
       }
     },
-    purchase: function (donorDetails, cartData) {
+    purchase: function (donorDetails, cartData, coverFeeDecision) {
       try {
         // Build cart data layer
         this.setDonorDetails(donorDetails)
         this.buildProductVar(cartData)
         // Stringify the cartObject and store in localStorage for the transactionEvent
         localStorage.setItem('transactionCart', JSON.stringify(cartData))
+        // Store value of coverFeeDecision in sessionStorage for the transactionEvent
+        sessionStorage.setItem('coverFeeDecision', coverFeeDecision)
       } catch (e) {
         // Error caught in analyticsFactory.purchase
       }
@@ -510,7 +512,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
     transactionEvent: function (purchaseData) {
       try {
         // The value of whether or not user is covering credit card fees for the transaction
-        const coverFees = localStorage.getItem('coverFees')
+        const coverFeeDecision = sessionStorage.getItem('coverFeeDecision')
         // Parse the cart object of the last purchase
         const transactionCart = JSON.parse(localStorage.getItem('transactionCart'))
         // The purchaseId number from the last purchase
@@ -564,7 +566,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               }
             })
             // Send cover fees event if value is true
-            if (coverFees) {
+            if (coverFeeDecision) {
               $window.dataLayer.push({
                 event: 'ga-cover-fees-checkbox'
               })
@@ -573,6 +575,8 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
         }
         // Remove the transactionCart from localStorage since it is no longer needed
         localStorage.removeItem('transactionCart')
+        // Remove the coverFeeDecision from sessionStorage since it is no longer needed
+        sessionStorage.removeItem('coverFeeDecision')
       } catch (e) {
         // Error in analyticsFactory.transactionEvent
       }

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -139,7 +139,7 @@ class Step3Controller {
       submitRequest = Observable.throw({ data: 'Current payment type is unknown' })
     }
     submitRequest.subscribe(() => {
-      this.analyticsFactory.purchase(this.donorDetails, this.cartData)
+      this.analyticsFactory.purchase(this.donorDetails, this.cartData, this.orderService.retrieveCoverFeeDecision())
       this.submittingOrder = false
       this.onSubmittingOrder({ value: false })
       this.orderService.clearCardSecurityCodes()


### PR DESCRIPTION
This adds a new GTM event for cover fees, but only when the user has actually covered credit card fees for that transaction. This event still needs to be created in GTM, then QA can begin.