### PR TITLE
Fix asset location

### DIFF
--- a/src/assets/scss/_slider.scss
+++ b/src/assets/scss/_slider.scss
@@ -38,11 +38,11 @@
     }
 
     .prevControl {
-      background-image: url(assets/img/arrow-left-slide.png);
+      background-image: url(/assets/img/arrow-left-slide.png);
       background-position: middle left;
     }
     .nextControl {
-      background-image: url(assets/img/arrow-right-slide.png);
+      background-image: url(/assets/img/arrow-right-slide.png);
       background-position: middle-right;
     }
     .cycle-pager {


### PR DESCRIPTION
Using `assets/` instead of `/assets/` tries to get the images from `chunks/assets` first instead of `assets` and receives a 403. This came up while testing the CloudFront updates.