### PR TITLE
Fix issues with updating payment methods in profile

### DIFF
--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -338,13 +338,15 @@ class Profile {
       paymentInfo = paymentInfo.creditCard
       if (paymentInfo.address) {
         paymentInfo.address = formatAddressForCortex(paymentInfo.address)
+        paymentInfo = { ...paymentInfo, ...paymentInfo.address }
+        delete paymentInfo.address
       }
     } else {
       return Observable.throw('Error updating payment method. The data passed to profileService.updatePaymentMethod did not contain bankAccount or creditCard data.')
     }
     return this.cortexApiService.put({
       path: originalPaymentInfo.self.uri,
-      data: paymentInfo
+      data: { 'payment-instrument-identification-attributes': paymentInfo }
     })
   }
 

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -391,7 +391,7 @@ describe('profile service', () => {
   describe('updatePaymentMethod', () => {
     it('should update a bank account', () => {
       self.$httpBackend.expectPUT('https://give-stage2.cru.org/cortex/paymentUri',
-        { 'bank-name': 'Some Bank' }
+        { 'payment-instrument-identification-attributes': { 'bank-name': 'Some Bank' } }
       ).respond(200, null)
       self.profileService.updatePaymentMethod({ self: { uri: 'paymentUri' } }, { bankAccount: { 'bank-name': 'Some Bank' } })
         .subscribe(null, () => fail())
@@ -400,7 +400,16 @@ describe('profile service', () => {
 
     it('should update a credit card', () => {
       self.$httpBackend.expectPUT('https://give-stage2.cru.org/cortex/paymentUri',
-        { 'cardholder-name': 'Some Person', address: { 'street-address': 'Some Address||||||', 'extended-address': '', locality: '', 'postal-code': '', region: '' } }
+        {
+          'payment-instrument-identification-attributes': {
+            'cardholder-name': 'Some Person',
+            'street-address': 'Some Address||||||',
+            'extended-address': '',
+            locality: '',
+            'postal-code': '',
+            region: ''
+          }
+        }
       ).respond(200, null)
       self.profileService.updatePaymentMethod({ self: { uri: 'paymentUri' } }, { creditCard: { 'cardholder-name': 'Some Person', address: { streetAddress: 'Some Address' } } })
         .subscribe(null, () => fail())
@@ -409,7 +418,7 @@ describe('profile service', () => {
 
     it('should update a credit card with no billing address (api will use mailing address)', () => {
       self.$httpBackend.expectPUT('https://give-stage2.cru.org/cortex/paymentUri',
-        { 'cardholder-name': 'Some Person' }
+        { 'payment-instrument-identification-attributes': { 'cardholder-name': 'Some Person' } }
       ).respond(200, null)
       self.profileService.updatePaymentMethod({ self: { uri: 'paymentUri' } }, { creditCard: { 'cardholder-name': 'Some Person', address: undefined } })
         .subscribe(null, () => fail())


### PR DESCRIPTION
The PUT request should be in the format
```
{
  'payment-instrument-identification-attributes': {
    payment method attributes,
    if (credit card) => billing address attributes
  }
}
```

Instead of the old format
```
{
  payment method attributes,
  if (credit card) => address: {
    billing address attributes
  }
}
```