### PR TITLE
EP-2278 - Update CC in checkout

### DIFF
--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -178,23 +178,36 @@ class Order {
       paymentInfo.address = formatAddressForCortex(paymentInfo.address)
     }
 
+    let dataToSubmit = { ...paymentInfo, ...paymentInfo.address }
+    dataToSubmit = omit(dataToSubmit, ['cvv', 'address'])
+    dataToSubmit = { 'payment-instrument-identification-attributes': dataToSubmit }
+
+    if (paymentMethod.self.type === 'paymentinstruments.order-payment-instrument') {
+      return this.updatePaymentMethodInCortex(paymentMethod.self.uri, dataToSubmit, paymentInfo.cvv, paymentMethod)
+    }
+
     return this.selectPaymentMethod(paymentMethod.selectAction)
       .mergeMap(() => {
         return this.cortexApiService.get({
           path: ['carts', this.cortexApiService.scope, 'default'],
           zoom: {
-            updateForm: 'order:paymentmethodinfo:creditcardupdateform'
+            chosen: 'order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description'
           }
         })
       })
       .mergeMap(data => {
-        return this.cortexApiService.post({
-          path: this.hateoasHelperService.getLink(data.updateForm, 'updatecreditcardfororderaction'),
-          data: omit(paymentInfo, 'cvv')
-        })
-          .do(() => {
-            this.storeCardSecurityCode(paymentInfo.cvv, paymentMethod.self.uri)
-          })
+        const uri = data.chosen ? data.chosen.description.self.uri : paymentMethod.self.uri
+        return this.updatePaymentMethodInCortex(uri, dataToSubmit, paymentInfo.cvv, paymentMethod)
+      })
+  }
+
+  updatePaymentMethodInCortex (uri, dataToSubmit, cvv, paymentMethod) {
+    return this.cortexApiService.put({
+      path: uri,
+      data: dataToSubmit
+    })
+      .do(() => {
+        this.storeCardSecurityCode(cvv, paymentMethod.self.uri)
       })
   }
 

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -126,7 +126,13 @@ class Order {
     const dataToSend = {}
 
     if (paymentInfo.address) {
-      dataToSend.address = formatAddressForCortex(paymentInfo.address)
+      dataToSend['billing-address'] = {
+        name: {
+          'family-name': 'na',
+          'given-name': 'na'
+        },
+        address: formatAddressForCortex(paymentInfo.address)
+      }
       paymentInfo.address = undefined
     }
     dataToSend['payment-instrument-identification-form'] = paymentInfo

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -303,13 +303,19 @@ describe('order service', () => {
       }
 
       const expectedPostData = {
-        address: {
-          'country-name': 'US',
-          'street-address': '123 First St',
-          'extended-address': 'Apt 123',
-          locality: 'Sacramento',
-          'postal-code': '12345',
-          region: 'CA'
+        'billing-address': {
+          name: {
+            'family-name': 'na',
+            'given-name': 'na'
+          },
+          address: {
+            'country-name': 'US',
+            'street-address': '123 First St',
+            'extended-address': 'Apt 123',
+            locality: 'Sacramento',
+            'postal-code': '12345',
+            region: 'CA'
+          }
         },
         'payment-instrument-identification-form': {
           'card-number': '**fake*encrypted**1234567890123456**',

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -437,23 +437,25 @@ describe('order service', () => {
       runTestWith = (paymentInfo, expectedRequestData, expectedCvv) => {
         jest.spyOn(self.orderService, 'storeCardSecurityCode').mockImplementation(() => {})
         jest.spyOn(self.orderService, 'selectPaymentMethod').mockReturnValue(Observable.of('placeholder'))
-        self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentmethodinfo:creditcardupdateform')
+        self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description')
           .respond(200, {
             _order: [{
-              _paymentmethodinfo: [{
-                _creditcardupdateform: [{
-                  links: [
-                    {
-                      rel: 'updatecreditcardfororderaction',
-                      uri: '/creditcards/orders/crugive/default=/update/<payment id>='
+              _paymentinstrumentselector: [{
+                _chosen: [{
+                  _description: [{
+                    self: {
+                      uri: '/paymentinstruments/orders/crugive/<order id>=/orderpaymentinstrument/<payment id>='
                     }
-                  ]
+                  }],
+                  self: {
+                    uri: '/paymentinstruments/orders/crugive/<order id>=/paymentinstrumentselector/<selector id>='
+                  }
                 }]
               }]
             }]
           })
 
-        self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/creditcards/orders/crugive/default=/update/<payment id>=',
+        self.$httpBackend.expectPUT('https://give-stage2.cru.org/cortex/paymentinstruments/orders/crugive/<order id>=/orderpaymentinstrument/<payment id>=',
           expectedRequestData)
           .respond(200, {})
 
@@ -470,18 +472,36 @@ describe('order service', () => {
     })
 
     it('should update the given payment method', () => {
-      runTestWith({ 'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa', cvv: '963' },
-        { 'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa' }, '963')
+      runTestWith(
+        { 'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa', cvv: '963' },
+        {
+          'payment-instrument-identification-attributes': {
+            'cardholder-name': 'New name', 'last-four-digits': '8888', 'card-type': 'Visa'
+          }
+        },
+        '963')
     })
 
     it('should update the given payment method with an address', () => {
-      runTestWith({ 'cardholder-name': 'New name', cvv: '789', address: { country: 'US' } },
-        { 'cardholder-name': 'New name', address: { 'country-name': 'US' } }, '789')
+      runTestWith(
+        { 'cardholder-name': 'New name', cvv: '789', address: { country: 'US' } },
+        {
+          'payment-instrument-identification-attributes': {
+            'cardholder-name': 'New name', 'country-name': 'US'
+          }
+        },
+        '789')
     })
 
     it('should call storeCardSecurityCode with undefined when the cvv wasn\'t changed', () => {
-      runTestWith({ 'cardholder-name': 'New name', 'card-number': '0000' },
-        { 'cardholder-name': 'New name', 'card-number': '0000' }, undefined)
+      runTestWith(
+        { 'cardholder-name': 'New name', 'card-number': '0000' },
+        {
+          'payment-instrument-identification-attributes': {
+            'cardholder-name': 'New name', 'card-number': '0000'
+          }
+        },
+        undefined)
     })
   })
 


### PR DESCRIPTION
[EP-2278](https://jira.cru.org/browse/EP-2278)
[EP-2299](https://jira.cru.org/browse/EP-2299)

I added EP-2299 because it was such a small thing, and labeled it in the commit message so it is easy to find in the commit history.

This PR fixes some issues with updating credit cards during checkout.