### PR TITLE
Pass Tsys Device Id on Order Submission

### DIFF
--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -12,6 +12,7 @@ import sortPaymentMethods from 'common/services/paymentHelpers/paymentMethodSort
 
 import cortexApiService from '../cortexApi.service'
 import cartService from './cart.service'
+import tsysService from './tsys.service'
 import hateoasHelperService from 'common/services/hateoasHelper.service'
 
 import formatAddressForCortex from '../addressHelpers/formatAddressForCortex'
@@ -23,10 +24,11 @@ const serviceName = 'orderService'
 
 class Order {
   /* @ngInject */
-  constructor (cortexApiService, cartService, hateoasHelperService, analyticsFactory, $window, $log, $filter) {
+  constructor (cortexApiService, cartService, hateoasHelperService, tsysService, analyticsFactory, $window, $log, $filter) {
     this.cortexApiService = cortexApiService
     this.cartService = cartService
     this.hateoasHelperService = hateoasHelperService
+    this.tsysService = tsysService
     this.analyticsFactory = analyticsFactory
     this.sessionStorage = $window.sessionStorage
     this.localStorage = $window.localStorage
@@ -253,6 +255,7 @@ class Order {
         const postData = cvv ? { 'security-code': cvv } : {}
         postData['cover-cc-fees'] = !!this.retrieveCoverFeeDecision()
         postData['radio-call-letters'] = this.retrieveRadioStationCallLetters()
+        postData['tsys-device'] = this.tsysService.getDevice()
         return this.cortexApiService.post({
           path: this.hateoasHelperService.getLink(data.enhancedpurchaseform, 'createenhancedpurchaseaction'),
           data: postData,
@@ -351,6 +354,7 @@ export default angular
     cortexApiService.name,
     cartService.name,
     hateoasHelperService.name,
+    tsysService.name,
     analyticsFactory.name
   ])
   .service(serviceName, Order)

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -20,9 +20,10 @@ describe('order service', () => {
   beforeEach(angular.mock.module(module.name))
   var self = {}
 
-  beforeEach(inject((orderService, cartService, $httpBackend, $window, $log) => {
+  beforeEach(inject((orderService, cartService, tsysService, $httpBackend, $window, $log) => {
     self.orderService = orderService
     self.cartService = cartService
+    self.tsysService = tsysService
     self.$httpBackend = $httpBackend
     self.$window = $window
     self.$log = $log
@@ -649,7 +650,7 @@ describe('order service', () => {
     it('should send a request to finalize the purchase', () => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
-        { 'cover-cc-fees': false, 'radio-call-letters': null }
+        { 'cover-cc-fees': false, 'radio-call-letters': null, 'tsys-device': '' }
       ).respond(200, purchaseResponse)
 
       self.orderService.submit()
@@ -663,7 +664,7 @@ describe('order service', () => {
     it('should send a request to finalize the purchase and with a CVV', () => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
-        { 'security-code': '123', 'cover-cc-fees': false, 'radio-call-letters': null }
+        { 'security-code': '123', 'cover-cc-fees': false, 'radio-call-letters': null, 'tsys-device': '' }
       ).respond(200, purchaseResponse)
 
       self.orderService.submit('123')
@@ -679,7 +680,7 @@ describe('order service', () => {
 
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
-        { 'cover-cc-fees': true, 'radio-call-letters': null }
+        { 'cover-cc-fees': true, 'radio-call-letters': null, 'tsys-device': '' }
       ).respond(200, purchaseResponse)
 
       self.orderService.submit()
@@ -695,7 +696,24 @@ describe('order service', () => {
 
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
-        { 'cover-cc-fees': false, 'radio-call-letters': 'WXYZ' }
+        { 'cover-cc-fees': false, 'radio-call-letters': 'WXYZ', 'tsys-device': '' }
+      ).respond(200, purchaseResponse)
+
+      self.orderService.submit()
+        .subscribe((data) => {
+          expect(data).toEqual(purchaseResponse)
+          done()
+        })
+
+      self.$httpBackend.flush()
+    })
+
+    it('should send the tsys device id to the server', (done) => {
+      self.tsysService.device = 'test-env'
+
+      self.$httpBackend.expectPOST(
+        'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?followLocation=true',
+        { 'cover-cc-fees': false, 'radio-call-letters': null, 'tsys-device': 'test-env' }
       ).respond(200, purchaseResponse)
 
       self.orderService.submit()

--- a/src/common/services/api/tsys.service.js
+++ b/src/common/services/api/tsys.service.js
@@ -15,6 +15,10 @@ class Tsys {
     this.device = device
   }
 
+  getDevice () {
+    return this.device
+  }
+
   getManifest () {
     return this.cortexApiService.get({
       path: this.device ? ['tsys', 'manifest', this.device] : ['tsys', 'manifest']

--- a/src/common/services/api/tsys.service.spec.js
+++ b/src/common/services/api/tsys.service.spec.js
@@ -26,6 +26,15 @@ describe('order service', () => {
     })
   })
 
+  describe('getDevice', () => {
+    it('should get the branded checkout TSYS device', () => {
+      self.tsysService.device = 'test-env'
+      const device = self.tsysService.getDevice()
+
+      expect(device).toEqual('test-env')
+    })
+  })
+
   describe('getManifest', () => {
     it('should load the device id and manifest for TSYS tokenization', () => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/tsys/manifest')


### PR DESCRIPTION
Get Tsys Id from branded checkout configuration and pass it as postData in  order submission.

Client-side follow-up to https://github.com/CruGlobal/give-ep-extensions/pull/692.