### PR TITLE
EP-2296 - update email checkout form reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push: 
-    branches: [staging, master]
+    branches: [staging, master, ep-upgrade-stage, ep-upgrade-prod, ep-upgrade]
   pull_request:
-    branches: [staging, master]
+    branches: [staging, master, ep-upgrade-stage, ep-upgrade-prod, ep-upgrade]
 
 permissions:
   id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 .sass-cache
 stats.json
 *.iml
+
+# asdf
+.tool-versions

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -106,7 +106,7 @@ class Cart {
         frequency: frequency,
         amount: item.rate.cost[0].amount, // cost object was changed to array
         amountWithFees: item.rate.cost['amount-with-fees'],
-        designationNumber: item.item._offer[0]._code[0]['code'], // product code is fetched from offer resource
+        designationNumber: item.item._offer[0]._code[0].code, // product code is fetched from offer resource
         productUri: item.item.self.uri,
         giftStartDate: giftStartDate,
         giftStartDateDaysFromNow: giftStartDateDaysFromNow,
@@ -183,7 +183,7 @@ class Cart {
     for (const [key, value] of Object.entries(obj)) {
       res[key.toUpperCase()] = value
     }
-    delete res['QUANTITY']
+    delete res.QUANTITY
     const payLoad = {
       configuration: {
         ...res

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -173,7 +173,7 @@ class DesignationsService {
         displayName: data.definition['display-name'],
         designationType: designationType,
         code: data.code.code,
-        designationNumber: data.offer['code'],
+        designationNumber: data.offer.code,
         orgId: orgId
       }
     })

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -40,7 +40,7 @@ class Order {
       zoom: {
         donorDetails: 'order:donordetails',
         email: 'order:emailinfo:email',
-        emailForm: 'order:emailinfo:emailform'
+        emailForm: 'order:emailinfo:orderemailform'
       }
     })
       .map(data => {

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -62,7 +62,7 @@ describe('order service', () => {
       expectedDonorDetails.email = donorDetailsResponseZoomMapped.email.email
       expectedDonorDetails.emailFormUri = donorDetailsResponseZoomMapped.emailForm.links[0].uri
 
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:emailform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:orderemailform')
         .respond(200, donorDetailsResponse)
       self.orderService.getDonorDetails()
         .subscribe((data) => {
@@ -73,7 +73,7 @@ describe('order service', () => {
 
     it('should set the mailingAddress country to US if undefined', () => {
       donorDetailsResponse._order[0]._donordetails[0]['mailing-address']['country-name'] = ''
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:emailform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:orderemailform')
         .respond(200, donorDetailsResponse)
       self.orderService.getDonorDetails()
         .subscribe((data) => {
@@ -85,7 +85,7 @@ describe('order service', () => {
     })
 
     it('should handle an undefined response', () => {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:emailform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:donordetails,order:emailinfo:email,order:emailinfo:orderemailform')
         .respond(200, {})
       self.orderService.getDonorDetails()
         .subscribe((data) => {


### PR DESCRIPTION
This PR calls a new endpoint for updating emails during checkout. The new 8.1 API, in some ways, is less flexible than the current 6.15, which is why we had to make a new location for this logic.