### PR TITLE
Log any errors coming from logout during branded checkout

### DIFF
--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -47,7 +47,9 @@ class BrandedCheckoutController {
     this.sessionService.signOut().subscribe(() => {
       this.checkoutStep = 'giftContactPayment'
       this.fireAnalyticsEvents('contact', 'payment')
-    }, angular.noop)
+    }, (err) => {
+      console.error(err)
+    })
     this.$translate.use(this.language || 'en')
   }
 


### PR DESCRIPTION
This seems to fix things when using local overrides in the Chrome developer tools.

[Helpscout](https://secure.helpscout.net/conversation/1897464967/768063/)