### PR TITLE
EP-2353 - Do not send extra info to EP

### DIFF
--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -31,10 +31,10 @@ class BrandedCheckoutStep1Controller {
 
   initItemConfig () {
     this.itemConfig = {}
-    this.itemConfig.campaign_code = this.campaignCode
-    if (this.itemConfig.campaign_code &&
-      (this.itemConfig.campaign_code.match(/^[a-z0-9]+$/i) === null || this.itemConfig.campaign_code.length > 30)) {
-      this.itemConfig.campaign_code = ''
+    this.itemConfig.CAMPAIGN_CODE = this.campaignCode
+    if (this.itemConfig.CAMPAIGN_CODE &&
+      (this.itemConfig.CAMPAIGN_CODE.match(/^[a-z0-9]+$/i) === null || this.itemConfig.CAMPAIGN_CODE.length > 30)) {
+      this.itemConfig.CAMPAIGN_CODE = ''
     }
     this.itemConfig['campaign-page'] = this.campaignPage
     this.itemConfig.amount = this.amount

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -56,7 +56,7 @@ class BrandedCheckoutStep1Controller {
         this.defaultFrequency = 'ANNUAL'
         break
     }
-    this.itemConfig.recurring_day_of_month = this.day
+    this.itemConfig.RECURRING_DAY_OF_MONTH = this.day
     this.itemConfig.frequency = this.frequency
   }
 

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -43,7 +43,7 @@ describe('branded checkout step 1', () => {
         'campaign-page': '135',
         amount: '75',
         priceWithFees: '$76.80',
-        'recurring_day_of_month': '9'
+        'RECURRING_DAY_OF_MONTH': '9'
       })
 
       expect($ctrl.defaultFrequency).toBeUndefined()

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -39,7 +39,7 @@ describe('branded checkout step 1', () => {
       $ctrl.initItemConfig()
 
       expect($ctrl.itemConfig).toEqual({
-        campaign_code: '1234',
+        CAMPAIGN_CODE: '1234',
         'campaign-page': '135',
         amount: '75',
         priceWithFees: '$76.80',
@@ -76,13 +76,13 @@ describe('branded checkout step 1', () => {
     it('should validate campaignCode (too long)', () => {
       $ctrl.campaignCode = 'abcdefghijklmnopqrstuvwxyz0123456789'
       $ctrl.initItemConfig()
-      expect($ctrl.itemConfig.campaign_code).toEqual('')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('')
     })
 
     it('should validate campaignCode (non alpha numeric)', () => {
       $ctrl.campaignCode = '😅😳'
       $ctrl.initItemConfig()
-      expect($ctrl.itemConfig.campaign_code).toEqual('')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('')
     })
   })
 

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -102,7 +102,7 @@ class Step3Controller {
   }
 
   updateGiftStartMonth (item, month) {
-    item.config.recurring_start_month = month
+    item.config.RECURRING_START_MONTH = month
 
     this.cartData = null
     this.cartService.editItem(item.uri, item.productUri, item.config).subscribe(() => {

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -138,12 +138,12 @@ describe('checkout', () => {
           uri: '/uri',
           productUri: '/uri',
           config: {
-            'recurring_start_month': '07'
+            'RECURRING_START_MONTH': '07'
           }
         }
         self.controller.updateGiftStartMonth(item, '05')
 
-        item.config['recurring_start_month'] = '05'
+        item.config['RECURRING_START_MONTH'] = '05'
 
         expect(self.controller.cartService.editItem).toHaveBeenCalledWith(item.uri, item.productUri, item.config)
 

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -174,7 +174,7 @@
                 <span translate="FUTURE_WARNING" translate-value-days="{{i.giftStartDateDaysFromNow}}"></span>
                 <div>
                   <button class="btn btn-default" ng-click="i.giftStartDateWarning = false" translate="KEEP_DATE" translate-value-keepdate="{{i.giftStartDate.format('ll')}}"></button>
-                  <button class="btn btn-primary" ng-click="$ctrl.updateGiftStartMonth(i, $ctrl.startDate(i.config['recurring_day_of_month'], $ctrl.nextDrawDate).format('MM'))" translate="CHANGE_TO_DATE" translate-value-changedate="{{$ctrl.startDate(i.config['recurring_day_of_month'], $ctrl.nextDrawDate).format('ll')}}"></button>
+                  <button class="btn btn-primary" ng-click="$ctrl.updateGiftStartMonth(i, $ctrl.startDate(i.config['RECURRING_DAY_OF_MONTH'], $ctrl.nextDrawDate).format('MM'))" translate="CHANGE_TO_DATE" translate-value-changedate="{{$ctrl.startDate(i.config['RECURRING_DAY_OF_MONTH'], $ctrl.nextDrawDate).format('ll')}}"></button>
                 </div>
               </div>
             </td>

--- a/src/app/productConfig/productConfig.component.js
+++ b/src/app/productConfig/productConfig.component.js
@@ -24,7 +24,7 @@ class ProductConfigController {
   configModal () {
     this.productModalService
       .configureProduct(this.productCode, {
-        campaign_code: this.campaignCode,
+        CAMPAIGN_CODE: this.campaignCode,
         'campaign-page': this.campaignPage
       }, false)
   }

--- a/src/app/productConfig/productConfig.component.spec.js
+++ b/src/app/productConfig/productConfig.component.spec.js
@@ -30,7 +30,7 @@ describe('productConfig', function () {
     it('opens productConfig modal', () => {
       $ctrl.configModal()
 
-      expect(productModalService.configureProduct).toHaveBeenCalledWith('0123456', { campaign_code: 'test123', 'campaign-page': undefined }, false)
+      expect(productModalService.configureProduct).toHaveBeenCalledWith('0123456', { CAMPAIGN_CODE: 'test123', 'campaign-page': undefined }, false)
     })
   })
 })

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -306,7 +306,9 @@ class ProductConfigFormController {
     this.submittingGift = true
     this.onStateChange({ state: 'submitting' })
 
-    const data = this.productData.frequency === 'NA' ? omit(this.itemConfig, ['recurring_start_month', 'recurring_day_of_month']) : this.itemConfig
+    const data = this.productData.frequency === 'NA'
+      ? omit(this.itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title'])
+      : omit(this.itemConfig, ['jcr-title'])
 
     const savingObservable = this.isEdit
       ? this.cartService.editItem(this.uri, this.productData.uri, data)

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -113,8 +113,8 @@ class ProductConfigFormController {
     this.loading = true
     this.errorLoading = false
 
-    this.showRecipientComments = !!this.itemConfig.recipient_comments
-    this.showDSComments = !!this.itemConfig.donation_services_comments
+    this.showRecipientComments = !!this.itemConfig.RECIPIENT_COMMENTS
+    this.showDSComments = !!this.itemConfig.DONATION_SERVICES_COMMENTS
 
     const productLookupObservable = this.designationsService.productLookup(this.code)
       .do(productData => {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -5,6 +5,7 @@ import 'angular-sanitize'
 import indexOf from 'lodash/indexOf'
 import find from 'lodash/find'
 import omit from 'lodash/omit'
+import omitBy from 'lodash/omitBy'
 import map from 'lodash/map'
 import includes from 'lodash/includes'
 import isEmpty from 'lodash/isEmpty'
@@ -306,9 +307,7 @@ class ProductConfigFormController {
     this.submittingGift = true
     this.onStateChange({ state: 'submitting' })
 
-    const data = this.productData.frequency === 'NA'
-      ? omit(this.itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title'])
-      : omit(this.itemConfig, ['jcr-title'])
+    const data = this.omitIrrelevantData(this.itemConfig)
 
     const savingObservable = this.isEdit
       ? this.cartService.editItem(this.uri, this.productData.uri, data)
@@ -337,6 +336,16 @@ class ProductConfigFormController {
         this.onStateChange({ state: 'errorSubmitting' })
       }
       this.submittingGift = false
+    })
+  }
+
+  omitIrrelevantData (itemConfig) {
+    const data = this.productData.frequency === 'NA'
+      ? omit(itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title'])
+      : omit(itemConfig, ['jcr-title'])
+    // I tried using lodash.isEmpty instead of my own predicate, but for some reason it was deleting the AMOUNT value
+    return omitBy(data, (value) => {
+      return value === ''
     })
   }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -96,16 +96,16 @@ class ProductConfigFormController {
       this.itemConfig.AMOUNT = amount
     }
 
-    if (inRange(parseInt(this.itemConfig.recurring_day_of_month, 10), 1, 29)) {
-      this.itemConfig.recurring_day_of_month = padStart(this.itemConfig.recurring_day_of_month, 2, '0')
+    if (inRange(parseInt(this.itemConfig.RECURRING_DAY_OF_MONTH, 10), 1, 29)) {
+      this.itemConfig.RECURRING_DAY_OF_MONTH = padStart(this.itemConfig.RECURRING_DAY_OF_MONTH, 2, '0')
     } else {
-      delete this.itemConfig.recurring_day_of_month
+      delete this.itemConfig.RECURRING_DAY_OF_MONTH
     }
 
-    if (inRange(parseInt(this.itemConfig.recurring_start_month, 10), 1, 13)) {
-      this.itemConfig.recurring_start_month = padStart(this.itemConfig.recurring_start_month, 2, '0')
+    if (inRange(parseInt(this.itemConfig.RECURRING_START_MONTH, 10), 1, 13)) {
+      this.itemConfig.RECURRING_START_MONTH = padStart(this.itemConfig.RECURRING_START_MONTH, 2, '0')
     } else {
-      delete this.itemConfig.recurring_start_month
+      delete this.itemConfig.RECURRING_START_MONTH
     }
   }
 
@@ -126,11 +126,11 @@ class ProductConfigFormController {
     const nextDrawDateObservable = this.commonService.getNextDrawDate()
       .do(nextDrawDate => {
         this.nextDrawDate = nextDrawDate
-        if (!this.itemConfig.recurring_day_of_month && this.nextDrawDate) {
-          this.itemConfig.recurring_day_of_month = startDate(null, this.nextDrawDate).format('DD')
+        if (!this.itemConfig.RECURRING_DAY_OF_MONTH && this.nextDrawDate) {
+          this.itemConfig.RECURRING_DAY_OF_MONTH = startDate(null, this.nextDrawDate).format('DD')
         }
-        if (!this.itemConfig.recurring_start_month && this.nextDrawDate) {
-          this.itemConfig.recurring_start_month = startDate(null, this.nextDrawDate).format('MM')
+        if (!this.itemConfig.RECURRING_START_MONTH && this.nextDrawDate) {
+          this.itemConfig.RECURRING_START_MONTH = startDate(null, this.nextDrawDate).format('MM')
         }
       })
 
@@ -341,7 +341,7 @@ class ProductConfigFormController {
 
   omitIrrelevantData (itemConfig) {
     const data = this.productData.frequency === 'NA'
-      ? omit(itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title', 'AMOUNT_WITH_FEES'])
+      ? omit(itemConfig, ['RECURRING_START_MONTH', 'RECURRING_DAY_OF_MONTH', 'jcr-title', 'AMOUNT_WITH_FEES'])
       : omit(itemConfig, ['jcr-title', 'AMOUNT_WITH_FEES'])
     // I tried using lodash.isEmpty instead of my own predicate, but for some reason it was deleting the AMOUNT value
     return omitBy(data, (value) => {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -341,8 +341,8 @@ class ProductConfigFormController {
 
   omitIrrelevantData (itemConfig) {
     const data = this.productData.frequency === 'NA'
-      ? omit(itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title'])
-      : omit(itemConfig, ['jcr-title'])
+      ? omit(itemConfig, ['recurring_start_month', 'recurring_day_of_month', 'jcr-title', 'AMOUNT_WITH_FEES'])
+      : omit(itemConfig, ['jcr-title', 'AMOUNT_WITH_FEES'])
     // I tried using lodash.isEmpty instead of my own predicate, but for some reason it was deleting the AMOUNT value
     return omitBy(data, (value) => {
       return value === ''

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -98,24 +98,24 @@ describe('product config form component', function () {
 
   describe('initItemConfig', () => {
     it('should format item config values', () => {
-      $ctrl.itemConfig['recurring_day_of_month'] = '9'
-      $ctrl.itemConfig['recurring_start_month'] = '8'
+      $ctrl.itemConfig['RECURRING_DAY_OF_MONTH'] = '9'
+      $ctrl.itemConfig['RECURRING_START_MONTH'] = '8'
       $ctrl.initItemConfig()
 
       expect($ctrl.itemConfig.AMOUNT).toEqual(85)
-      expect($ctrl.itemConfig['recurring_day_of_month']).toEqual('09')
-      expect($ctrl.itemConfig['recurring_start_month']).toEqual('08')
+      expect($ctrl.itemConfig['RECURRING_DAY_OF_MONTH']).toEqual('09')
+      expect($ctrl.itemConfig['RECURRING_START_MONTH']).toEqual('08')
     })
 
     it('should handle out of range values', () => {
       $ctrl.itemConfig.AMOUNT = 'invalid'
-      $ctrl.itemConfig['recurring_day_of_month'] = '29'
-      $ctrl.itemConfig['recurring_start_month'] = '13'
+      $ctrl.itemConfig['RECURRING_DAY_OF_MONTH'] = '29'
+      $ctrl.itemConfig['RECURRING_START_MONTH'] = '13'
       $ctrl.initItemConfig()
 
       expect($ctrl.itemConfig.AMOUNT).toBeUndefined()
-      expect($ctrl.itemConfig['recurring_day_of_month']).toBeUndefined()
-      expect($ctrl.itemConfig['recurring_start_month']).toBeUndefined()
+      expect($ctrl.itemConfig['RECURRING_DAY_OF_MONTH']).toBeUndefined()
+      expect($ctrl.itemConfig['RECURRING_START_MONTH']).toBeUndefined()
     })
 
     it('should handle a whole number amount', () => {
@@ -178,8 +178,8 @@ describe('product config form component', function () {
       expect($ctrl.setDefaultFrequency).toHaveBeenCalled()
 
       expect($ctrl.nextDrawDate).toEqual('2016-10-02')
-      expect($ctrl.itemConfig['recurring_day_of_month']).toEqual('02')
-      expect($ctrl.itemConfig['recurring_start_month']).toEqual('10')
+      expect($ctrl.itemConfig['RECURRING_DAY_OF_MONTH']).toEqual('02')
+      expect($ctrl.itemConfig['RECURRING_START_MONTH']).toEqual('10')
 
       expect($ctrl.suggestedAmounts).toEqual([{ amount: 5 }, { amount: 10 }])
       expect($ctrl.useSuggestedAmounts).toEqual(true)
@@ -603,8 +603,8 @@ describe('product config form component', function () {
         $ctrl.isEdit ? expect($ctrl.analyticsFactory.cartAdd).not.toHaveBeenCalled() : expect($ctrl.analyticsFactory.cartAdd).toHaveBeenCalledWith($ctrl.itemConfig, $ctrl.productData)
       })
 
-      it('should submit a gift successfully and omit recurring_day_of_month if frequency is single', () => {
-        $ctrl.itemConfig['recurring_day_of_month'] = '01'
+      it('should submit a gift successfully and omit RECURRING_DAY_OF_MONTH if frequency is single', () => {
+        $ctrl.itemConfig['RECURRING_DAY_OF_MONTH'] = '01'
         $ctrl.itemConfigForm.$dirty = true
         $ctrl.productData.frequency = 'NA'
         $ctrl.saveGiftToCart()

--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -179,9 +179,9 @@
                 <label translate>{{'MONTH'}}</label>
                 <div class="form-group">
                   <select class="form-control form-control-subtle"
-                          ng-model="$ctrl.itemConfig['recurring_start_month']"
+                          ng-model="$ctrl.itemConfig['RECURRING_START_MONTH']"
                           ng-options="(m | date:'MM') as (m | date:'MMMM, yyyy') for m in $ctrl.possibleTransactionMonths($ctrl.nextDrawDate)"
-                          ng-change="$ctrl.changeStartDay($ctrl.itemConfig['recurring_day_of_month'], $ctrl.itemConfig['recurring_start_month'])">
+                          ng-change="$ctrl.changeStartDay($ctrl.itemConfig['RECURRING_DAY_OF_MONTH'], $ctrl.itemConfig['RECURRING_START_MONTH'])">
                   </select>
                 </div>
               </div>
@@ -191,9 +191,9 @@
                 <label translate>{{'DAY'}}</label>
                 <div class="form-group">
                   <select class="form-control form-control-subtle"
-                          ng-model="$ctrl.itemConfig['recurring_day_of_month']"
-                          ng-options="o as (o | ordinal) for o in $ctrl.possibleTransactionDays($ctrl.itemConfig['recurring_start_month'], $ctrl.nextDrawDate)"
-                          ng-change="$ctrl.changeStartDay($ctrl.itemConfig['recurring_day_of_month'], $ctrl.itemConfig['recurring_start_month'])">
+                          ng-model="$ctrl.itemConfig['RECURRING_DAY_OF_MONTH']"
+                          ng-options="o as (o | ordinal) for o in $ctrl.possibleTransactionDays($ctrl.itemConfig['RECURRING_START_MONTH'], $ctrl.nextDrawDate)"
+                          ng-change="$ctrl.changeStartDay($ctrl.itemConfig['RECURRING_DAY_OF_MONTH'], $ctrl.itemConfig['RECURRING_START_MONTH'])">
                   </select>
                 </div>
               </div>
@@ -202,7 +202,7 @@
               <div class="form-group">
                 <label translate>{{'GIFT_START_DATE'}}</label>
                 <div class="form-group">
-                  {{$ctrl.startMonth( $ctrl.itemConfig['recurring_day_of_month'], $ctrl.itemConfig['recurring_start_month'], $ctrl.nextDrawDate ).format('ll')}}
+                  {{$ctrl.startMonth( $ctrl.itemConfig['RECURRING_DAY_OF_MONTH'], $ctrl.itemConfig['RECURRING_START_MONTH'], $ctrl.nextDrawDate ).format('ll')}}
                 </div>
               </div>
             </div>

--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -229,7 +229,7 @@
                       name="recipientComments"
                       rows="3"
                       maxlength="250"
-                      ng-model="$ctrl.itemConfig.recipient_comments"
+                      ng-model="$ctrl.itemConfig.RECIPIENT_COMMENTS"
                       ng-if="$ctrl.showRecipientComments"
                       tabindex="-1"
                       style="display:block;"></textarea>
@@ -247,7 +247,7 @@
                       name="donationServicesComments"
                       rows="3"
                       maxlength="250"
-                      ng-model="$ctrl.itemConfig.donation_services_comments"
+                      ng-model="$ctrl.itemConfig.DONATION_SERVICES_COMMENTS"
                       ng-if="$ctrl.showDSComments"
                       tabindex="-1"
                       placeholder="{{'MESSAGE_EXAMPLE' | translate}}"

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.js
@@ -74,16 +74,16 @@ class ProductConfigModalController {
 
     // If CampaignCode exists in URL, use it, otherwise use default-campaign-code if set.
     if (Object.prototype.hasOwnProperty.call(params, giveGiftParams.campaignCode)) {
-      this.itemConfig.campaign_code = isArray(params[giveGiftParams.campaignCode])
+      this.itemConfig.CAMPAIGN_CODE = isArray(params[giveGiftParams.campaignCode])
         ? params[giveGiftParams.campaignCode][0]
         : params[giveGiftParams.campaignCode]
 
       // make sure campaign code is alphanumeric and less than 30 characters
-      if (this.itemConfig.campaign_code.match(/^[a-z0-9]+$/i) === null || this.itemConfig.campaign_code.length > 30) {
-        this.itemConfig.campaign_code = ''
+      if (this.itemConfig.CAMPAIGN_CODE.match(/^[a-z0-9]+$/i) === null || this.itemConfig.CAMPAIGN_CODE.length > 30) {
+        this.itemConfig.CAMPAIGN_CODE = ''
       }
     } else if (Object.prototype.hasOwnProperty.call(this.itemConfig, 'default-campaign-code')) {
-      this.itemConfig.campaign_code = this.itemConfig['default-campaign-code']
+      this.itemConfig.CAMPAIGN_CODE = this.itemConfig['default-campaign-code']
     }
 
     if (Object.prototype.hasOwnProperty.call(params, giveGiftParams.campaignPage) && params[giveGiftParams.campaignPage] !== '') {

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.js
@@ -65,11 +65,11 @@ class ProductConfigModalController {
     }
 
     if (Object.prototype.hasOwnProperty.call(params, giveGiftParams.day)) {
-      this.itemConfig.recurring_day_of_month = params[giveGiftParams.day]
+      this.itemConfig.RECURRING_DAY_OF_MONTH = params[giveGiftParams.day]
     }
 
     if (Object.prototype.hasOwnProperty.call(params, giveGiftParams.month)) {
-      this.itemConfig.recurring_start_month = params[giveGiftParams.month]
+      this.itemConfig.RECURRING_START_MONTH = params[giveGiftParams.month]
     }
 
     // If CampaignCode exists in URL, use it, otherwise use default-campaign-code if set.

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
@@ -137,7 +137,7 @@ describe('product config modal', function () {
       })
       $ctrl.initializeParams()
 
-      expect($ctrl.itemConfig.campaign_code).toEqual('LEGACY')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('LEGACY')
     })
 
     it('sets campaignCode if multiple are set in url', () => {
@@ -146,7 +146,7 @@ describe('product config modal', function () {
       })
       $ctrl.initializeParams()
 
-      expect($ctrl.itemConfig.campaign_code).toEqual('LEGACY')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('LEGACY')
     })
 
     it('sets campaignCode if default-campaign-code is set', () => {
@@ -154,7 +154,7 @@ describe('product config modal', function () {
       $ctrl.itemConfig['default-campaign-code'] = 'DEFAULT'
       $ctrl.initializeParams()
 
-      expect($ctrl.itemConfig.campaign_code).toEqual('DEFAULT')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('DEFAULT')
     })
 
     it('cleans campaignCode if containing invalid characters', () => {
@@ -163,7 +163,7 @@ describe('product config modal', function () {
       })
       $ctrl.initializeParams()
 
-      expect($ctrl.itemConfig.campaign_code).toEqual('')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('')
     })
 
     it('cleans campaignCode if longer than 30 characters', () => {
@@ -172,7 +172,7 @@ describe('product config modal', function () {
       })
       $ctrl.initializeParams()
 
-      expect($ctrl.itemConfig.campaign_code).toEqual('')
+      expect($ctrl.itemConfig.CAMPAIGN_CODE).toEqual('')
     })
   })
 

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
@@ -114,8 +114,8 @@ describe('product config modal', function () {
       expect($ctrl.$location.search).toHaveBeenCalled()
       expect($ctrl.itemConfig.amount).toEqual('150')
       expect($ctrl.defaultFrequency).toEqual('QUARTERLY')
-      expect($ctrl.itemConfig['recurring_day_of_month']).toEqual('21')
-      expect($ctrl.itemConfig['recurring_start_month']).toEqual('07')
+      expect($ctrl.itemConfig['RECURRING_DAY_OF_MONTH']).toEqual('21')
+      expect($ctrl.itemConfig['RECURRING_START_MONTH']).toEqual('07')
       expect($ctrl.itemConfig['campaign-page']).toEqual('testCampaign')
     })
 
@@ -127,7 +127,7 @@ describe('product config modal', function () {
       expect($ctrl.$location.search).toHaveBeenCalled()
       expect($ctrl.itemConfig.amount).toBeUndefined()
       expect($ctrl.defaultFrequency).toBeUndefined()
-      expect($ctrl.itemConfig['recurring_day_of_month']).toBeUndefined()
+      expect($ctrl.itemConfig['RECURRING_DAY_OF_MONTH']).toBeUndefined()
       expect($ctrl.itemConfig['campaign-page']).toBeUndefined()
     })
 

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -222,7 +222,7 @@ class DesignationsService {
           }
 
           // Copy default-campaign-code to config
-          if (data.data['jcr:content'].defaultCampaign && !itemConfig.campaign_code) {
+          if (data.data['jcr:content'].defaultCampaign && !itemConfig.CAMPAIGN_CODE) {
             itemConfig['default-campaign-code'] = data.data['jcr:content'].defaultCampaign
           }
           // Copy jcr:title


### PR DESCRIPTION
The origins of this PR was to remove things like `jcr:title` from going to EP and being stored in `tshoppingitemdata` and `torderitemdata`. However; while testing, I found more to do which was kind of related, so went ahead and fixed that too.

- Do not send AEM data to EP
- Do not send data we don't care about to EP (such as amount_with_fees)
- Do not send empty data to EP (yes, it does store it as empty string which we don't want)
- Properly capitalize some fields (EP 8.1 makes all caps) so that they repopulate correctly on editing a gift that is already in the cart

[Jira](https://jira.cru.org/browse/EP-2353)