### PR TITLE
EP-2358 - Fix phone number update

### DIFF
--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -218,7 +218,7 @@ class ProfileController {
       'phone-number': '',
       'phone-number-type': 'Mobile',
       primary: false,
-      spouse: false
+      'is-spouse': false
     })
   }
 
@@ -236,7 +236,7 @@ class ProfileController {
           'phone-number': item['phone-number'],
           'phone-number-type': item['phone-number-type'],
           primary: false,
-          spouse: item.spouse
+          'is-spouse': item['is-spouse']
         })
       }
       if (item.self && item.delete === undefined) { // update existing phone number

--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -198,7 +198,7 @@
                                    ng-disabled="$ctrl.donorDetails.staff">
                             <select name="spousePhoneNumber"
                                     class="form-control form-control-subtle"
-                                    ng-model="phone.spouse"
+                                    ng-model="phone['is-spouse']"
                                     ng-change="phone.ownerChanged = !phone.ownerChanged"
                                     ng-disabled="!$ctrl.hasSpouse || $ctrl.donorDetails.staff">
                               <option ng-value="true">{{$ctrl.donorDetails['spouse-name']['given-name']}}</option>

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -153,7 +153,7 @@ class Profile {
 
   addPhoneNumber (number) {
     return this.cortexApiService.post({
-      path: ['phonenumbers', this.cortexApiService.scope, number.spouse ? 'spouse' : ''],
+      path: ['phonenumbers', this.cortexApiService.scope, number.spouse ? 'spouse/form' : 'form'],
       data: number,
       followLocation: true
     })

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -140,11 +140,11 @@ class Profile {
       .map(data => {
         const phoneNumbers = []
         angular.forEach(data.donor, item => {
-          item.spouse = false
+          item['is-spouse'] = false
           phoneNumbers.push(item)
         })
         angular.forEach(data.spouse, item => {
-          item.spouse = true
+          item['is-spouse'] = true
           phoneNumbers.push(item)
         })
         return phoneNumbers
@@ -153,7 +153,7 @@ class Profile {
 
   addPhoneNumber (number) {
     return this.cortexApiService.post({
-      path: ['phonenumbers', this.cortexApiService.scope, number.spouse ? 'spouse/form' : 'form'],
+      path: ['phonenumbers', this.cortexApiService.scope, number['is-spouse'] ? 'spouse/form' : 'form'],
       data: number,
       followLocation: true
     })

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -598,7 +598,7 @@ describe('profile service', () => {
           'phone-number': '(343) 454-3344',
           'phone-number-type': 'Mobile',
           primary: false,
-          spouse: false
+          'is-spouse': false
         },
         {
           self: {
@@ -618,7 +618,7 @@ describe('profile service', () => {
           'phone-number': '(565) 777-5656',
           'phone-number-type': 'Mobile',
           primary: false,
-          spouse: true
+          'is-spouse': true
         }
       ]
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/phonenumbers/crugive?zoom=element,spouse')
@@ -633,18 +633,18 @@ describe('profile service', () => {
 
   describe('addPhoneNumber', () => {
     it('should add phone number', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/spouse?FollowLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/spouse/form?FollowLocation=true')
         .respond(200, 'spouse success')
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/?FollowLocation=true')
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/phonenumbers/crugive/form?FollowLocation=true')
         .respond(200, 'donor success')
       const phoneNumber = {
-        spouse: true
+        'is-spouse': true
       }
       self.profileService.addPhoneNumber(phoneNumber)
         .subscribe((data) => {
           expect(data).toEqual('spouse success')
         })
-      phoneNumber.spouse = false
+      phoneNumber['is-spouse'] = false
       self.profileService.addPhoneNumber(phoneNumber)
         .subscribe((data) => {
           expect(data).toEqual('donor success')


### PR DESCRIPTION
This is the first part of [EP-2358](https://jira.cru.org/browse/EP-2358) which updates the URLs and the property `spouse` to `is-spouse` to send data properly to the API. However, the API needs some work to handle the spouse property correctly when returning phone numbers to the client (see [EP-2360](https://jira.cru.org/browse/EP-2360)) which may require more changes associated with this Jira.