### PR TITLE
EP-2347 - Fix batch add gifts

### DIFF
--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -222,7 +222,7 @@ class Cart {
         }
         return map(response.links, (link, index) => {
           const configuredDesignation = configuredDesignations[index]
-          configuredDesignation.uri = link.uri.replace(/^\//, '')
+          configuredDesignation.uri = `carts/${link.uri.replace(/^\//, '')}/form`
           return this.addItemAndReplaceExisting(cart, configuredDesignation.uri, configuredDesignation)
         })
       })

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -287,9 +287,9 @@ describe('cart service', () => {
         },
         () => fail('Observable should not have thrown an error'),
         () => {
-          expect(self.cartService.addItemAndReplaceExisting).toHaveBeenCalledWith(expect.any(Observable), 'uri1', { designationNumber: '0123456', uri: 'uri1' })
-          expect(self.cartService.addItemAndReplaceExisting).toHaveBeenCalledWith(expect.any(Observable), 'uri2', { designationNumber: '1234567', uri: 'uri2' })
-          expect(outputValues).toEqual([{ configuredDesignation: { designationNumber: '0123456', uri: 'uri1' } }, { configuredDesignation: { designationNumber: '1234567', uri: 'uri2' } }])
+          expect(self.cartService.addItemAndReplaceExisting).toHaveBeenCalledWith(expect.any(Observable), 'carts/uri1/form', { designationNumber: '0123456', uri: 'carts/uri1/form' })
+          expect(self.cartService.addItemAndReplaceExisting).toHaveBeenCalledWith(expect.any(Observable), 'carts/uri2/form', { designationNumber: '1234567', uri: 'carts/uri2/form' })
+          expect(outputValues).toEqual([{ configuredDesignation: { designationNumber: '0123456', uri: 'carts/uri1/form' } }, { configuredDesignation: { designationNumber: '1234567', uri: 'carts/uri2/form' } }])
         })
     })
 

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -181,7 +181,7 @@ class DesignationsService {
 
   bulkLookup (designationNumbers) {
     return this.cortexApiService.post({
-      path: ['lookups', this.cortexApiService.scope, 'batches', 'items'],
+      path: ['items', this.cortexApiService.scope, 'lookups', 'batches', 'form'],
       data: {
         codes: designationNumbers
       },

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -128,7 +128,7 @@ describe('designation service', () => {
 
   describe('bulkLookup', () => {
     it('should take an array of designation numbers and return corresponding links for items', () => {
-      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/lookups/crugive/batches/items?FollowLocation=true',
+      self.$httpBackend.expectPOST('https://give-stage2.cru.org/cortex/items/crugive/lookups/batches/form?FollowLocation=true',
         { codes: ['0123456', '1234567'] })
         .respond(200, bulkLookupResponse)
       self.designationsService.bulkLookup(['0123456', '1234567'])

--- a/src/common/services/api/fixtures/product-lookup-bulk.fixture.js
+++ b/src/common/services/api/fixtures/product-lookup-bulk.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.collections.links',
-    uri: '/lookups/crugive/batches/items/sgttknrqha4deni=',
-    href: 'https://give-stage2.cru.org/cortex/lookups/crugive/batches/items/sgttknrqha4deni='
+    uri: '/lookups/crugive/batches/form/sgttknrqha4deni=',
+    href: 'https://give-stage2.cru.org/cortex/items/crugive/lookups/batches/form/sgttknrqha4deni='
   },
   links: [{
     rel: 'element',


### PR DESCRIPTION
Two URIs were wrong for the bulk add of gifts from self-service with the migration to 8.1.  This PR fixes both.