### PR TITLE
EP-2379 Fill in Recent Designation Numbers by Adapting to 8.1 payload

### DIFF
--- a/src/common/services/api/donations.service.js
+++ b/src/common/services/api/donations.service.js
@@ -159,7 +159,7 @@ const DonationsService = /* @ngInject */ function (cortexApiService, profileServ
         return map(response.recipients, (recipient) => {
           return {
             'designation-name': recipient.definition['display-name'],
-            'designation-number': recipient.code['product-code']
+            'designation-number': recipient.code.code
           }
         })
       })


### PR DESCRIPTION
https://jira.cru.org/browse/EP-2379 
This has been tested in 8.1 staging, and fixes the problem it is intended to.  I clicked around a little bit, but did not notice any additional bugs that have arisen as a result of this solution.  However, I did not _**exhaustively**_ test to ensure this is completely without side-effects.