### PR TITLE
[EP-2314] Require uploaded files to be images

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "angular-translate": "^2.19.0",
     "angular-ui-bootstrap": "^2.5.6",
     "angular-ui-router": "^1.0.30",
-    "angular-upload": "^1.0.13",
     "bootstrap-sass": "^3.4.1",
     "change-case-object": "^2.0.0",
     "cru-payments": "^1.2.2",

--- a/src/app/designationEditor/carouselModal/carouselModal.tpl.html
+++ b/src/app/designationEditor/carouselModal/carouselModal.tpl.html
@@ -73,12 +73,11 @@
     <div class="form-group text-center">
       <div ng-if="!$ctrl.uploading">
         <label translate>Select a Photo to Upload</label>
-        <upload-button
+        <image-upload
           class="form-control"
           url="/bin/crugive/image?designationNumber={{$ctrl.designationNumber}}"
-          accept="image/*"
           on-upload="$ctrl.uploading = true"
-          on-success="$ctrl.uploadComplete(response)"
+          on-success="$ctrl.uploadComplete()"
           on-error="$ctrl.uploading = false"/>
       </div>
 

--- a/src/app/designationEditor/carouselModal/carouselModal.tpl.html
+++ b/src/app/designationEditor/carouselModal/carouselModal.tpl.html
@@ -72,11 +72,14 @@
   <div class="upload-drag-target p mb">
     <div class="form-group text-center">
       <div ng-if="!$ctrl.uploading">
-        <label translate>Select a Photo to Upload</label>
+        <div><label translate>Select a Photo to Upload</label></div>
+        <div><label ng-if="$ctrl.invalidFileType" translate>Uploaded image must be a JPEG or a PNG file</label></div>
         <image-upload
           class="form-control"
           url="/bin/crugive/image?designationNumber={{$ctrl.designationNumber}}"
+          on-invalid-file-type="$ctrl.invalidFileType = true"
           on-upload="$ctrl.uploading = true"
+          on-complete="$ctrl.invalidFileType = false"
           on-success="$ctrl.uploadComplete()"
           on-error="$ctrl.uploading = false"/>
       </div>

--- a/src/app/designationEditor/photoModal/photo.modal.js
+++ b/src/app/designationEditor/photoModal/photo.modal.js
@@ -1,6 +1,6 @@
 import angular from 'angular'
-import 'angular-upload'
 
+import imageUploadDirective from 'common/directives/imageUpload.directive'
 import designationEditorService from 'common/services/api/designationEditor.service'
 
 const controllerName = 'photoCtrl'
@@ -49,7 +49,7 @@ class ModalInstanceCtrl {
 
 export default angular
   .module(controllerName, [
-    'lr.upload',
+    imageUploadDirective.name,
     designationEditorService.name
   ])
   .controller(controllerName, ModalInstanceCtrl)

--- a/src/app/designationEditor/photoModal/photoModal.tpl.html
+++ b/src/app/designationEditor/photoModal/photoModal.tpl.html
@@ -10,11 +10,13 @@
   <div class="upload-drag-target p mb">
     <div class="form-group text-center">
       <div ng-if="!$ctrl.uploading">
-        <label translate>Select a Photo to Upload</label>
-
+        <div><label translate>Select a Photo to Upload</label></div>
+        <div><label ng-if="$ctrl.invalidFileType" translate>Uploaded image must be a JPEG or a PNG file</label></div>
         <image-upload
           class="form-control"
           url="/bin/crugive/image?designationNumber={{$ctrl.designationNumber}}"
+          on-invalid-file-type="$ctrl.invalidFileType = true"
+          on-complete="$ctrl.invalidFileType = false"
           on-upload="$ctrl.uploading = true"
           on-success="$ctrl.uploadComplete()"
           on-error="$ctrl.uploading = false"

--- a/src/app/designationEditor/photoModal/photoModal.tpl.html
+++ b/src/app/designationEditor/photoModal/photoModal.tpl.html
@@ -12,14 +12,13 @@
       <div ng-if="!$ctrl.uploading">
         <label translate>Select a Photo to Upload</label>
 
-        <upload-button
+        <image-upload
           class="form-control"
           url="/bin/crugive/image?designationNumber={{$ctrl.designationNumber}}"
-          accept="image/*"
           on-upload="$ctrl.uploading = true"
-          on-success="$ctrl.uploadComplete(response)"
+          on-success="$ctrl.uploadComplete()"
           on-error="$ctrl.uploading = false"
-        ></upload-button>
+        >
       </div>
 
       <label ng-if="$ctrl.uploading" translate>Uploading...</label>

--- a/src/common/directives/imageUpload.directive.js
+++ b/src/common/directives/imageUpload.directive.js
@@ -1,0 +1,64 @@
+import angular from 'angular'
+
+const directiveName = 'imageUpload'
+
+// Based on https://github.com/leon/angular-upload
+// Fixes bug where even if accept is "image/*", you could still drag-and-drop non-image files onto the upload button
+const imageUpload = /* @ngInject */ ($http) => ({
+  restrict: 'EA',
+  scope: {
+    url: '@',
+    onUpload: '&',
+    onSuccess: '&',
+    onError: '&',
+    onComplete: '&'
+  },
+  link: (scope, element) => {
+    const validMimeTypes = ['image/jpeg', 'image/png']
+
+    const el = angular.element(element)
+    const fileInput = angular.element(`<input type="file" accept="${validMimeTypes.join(',')}" />`)
+    el.append(fileInput)
+
+    fileInput.on('change', (event) => {
+      const files = event.target.files
+      const file = files[0]
+      if (!file) {
+        return
+      }
+
+      if (!validMimeTypes.includes(file.type)) {
+        // Clear the selected file because it's not a valid image
+        event.target.value = null
+        return
+      }
+
+      scope.$apply(() => {
+        scope.onUpload({ files })
+      })
+
+      const formData = new FormData()
+      formData.append('file', file)
+      $http({
+        url: scope.url,
+        method: 'POST',
+        headers: {
+          // Allow the browser to automatically determine the content type
+          'Content-Type': undefined
+        },
+        data: formData
+      }).then((response) => {
+        scope.onSuccess({ response })
+        scope.onComplete({ response })
+      }).catch((response) => {
+        scope.onError({ response })
+        scope.onComplete({ response })
+      }
+      )
+    })
+  }
+})
+
+export default angular
+  .module(directiveName, [])
+  .directive(directiveName, imageUpload)

--- a/src/common/directives/imageUpload.directive.js
+++ b/src/common/directives/imageUpload.directive.js
@@ -8,6 +8,7 @@ const imageUpload = /* @ngInject */ ($http) => ({
   restrict: 'EA',
   scope: {
     url: '@',
+    onInvalidFileType: '&',
     onUpload: '&',
     onSuccess: '&',
     onError: '&',
@@ -30,6 +31,9 @@ const imageUpload = /* @ngInject */ ($http) => ({
       if (!validMimeTypes.includes(file.type)) {
         // Clear the selected file because it's not a valid image
         event.target.value = null
+        scope.$apply(() => {
+          scope.onInvalidFileType()
+        })
         return
       }
 

--- a/src/common/directives/imageUpload.directive.spec.js
+++ b/src/common/directives/imageUpload.directive.spec.js
@@ -1,0 +1,27 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './imageUpload.directive'
+
+describe('imageUpload', () => {
+  beforeEach(angular.mock.module(module.name))
+  let $compile, $rootScope;
+
+  beforeEach(() => {
+    inject( ($injector) =>{
+      $compile = $injector.get('$compile');
+      $rootScope = $injector.get('$rootScope');
+    });
+  });
+
+  it('should display input', () => {
+    const element = $compile('<div class="btn btn-primary btn-upload" image-upload><button>Upload</button></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.html()).toContain('type="file"');
+  });
+
+  it('should set accept', () => {
+    const element = $compile('<div class="btn btn-primary btn-upload" image-upload><button>Upload</button></div>')($rootScope);
+    $rootScope.$digest();
+    expect(element.find('input').attr('accept')).toEqual('image/jpeg,image/png');
+  });
+});

--- a/src/common/directives/imageUpload.directive.spec.js
+++ b/src/common/directives/imageUpload.directive.spec.js
@@ -2,26 +2,111 @@ import angular from 'angular'
 import 'angular-mocks'
 import module from './imageUpload.directive'
 
+const uploadFile = (input, file) => {
+  // jsdom doesn't yet support changing an inputs' files because it doesn't let you instantiate a
+  // FileList and it doesn't yet support DataTransfer. The easiest way around this to send a change
+  // event with `target.files` manually mocked.
+  // Reference: https://github.com/jsdom/jsdom/issues/1272
+  const event = new Event('change')
+  // Use defineProperty because `target` is a getter and can't be set normally
+  Object.defineProperty(event, 'target', {
+    get: () => ({ files: file ? [file] : [] })
+  })
+  input.dispatchEvent(event)
+}
+
 describe('imageUpload', () => {
   beforeEach(angular.mock.module(module.name))
-  let $compile, $rootScope;
 
+  let $httpBackend, $scope, element
   beforeEach(() => {
-    inject( ($injector) =>{
-      $compile = $injector.get('$compile');
-      $rootScope = $injector.get('$rootScope');
-    });
-  });
+    inject(($compile, $injector, $rootScope) => {
+      $httpBackend = $injector.get('$httpBackend')
+      $httpBackend.whenPOST(/^\/upload$/).respond(() => [200, 'Success', {}])
+
+      $scope = $rootScope.$new()
+      $scope.onInvalidFileType = jest.fn()
+      $scope.onUpload = jest.fn()
+      $scope.onSuccess = jest.fn()
+      $scope.onError = jest.fn()
+      $scope.onComplete = jest.fn()
+
+      element = $compile('<div class="btn btn-primary btn-upload" image-upload url="/upload" on-invalid-file-type="onInvalidFileType()" on-upload="onUpload()" on-success="onSuccess()" on-error="onError()" on-complete="onComplete()"><button>Upload</button></div>')($scope)
+    })
+  })
 
   it('should display input', () => {
-    const element = $compile('<div class="btn btn-primary btn-upload" image-upload><button>Upload</button></div>')($rootScope);
-    $rootScope.$digest();
-    expect(element.html()).toContain('type="file"');
-  });
+    $scope.$digest()
+    expect(element.html()).toContain('type="file"')
+  })
 
   it('should set accept', () => {
-    const element = $compile('<div class="btn btn-primary btn-upload" image-upload><button>Upload</button></div>')($rootScope);
-    $rootScope.$digest();
-    expect(element.find('input').attr('accept')).toEqual('image/jpeg,image/png');
-  });
-});
+    $scope.$digest()
+    expect(element.find('input').attr('accept')).toEqual('image/jpeg,image/png')
+  })
+
+  it('should accept file uploads for JPEG', () => {
+    const file = new File(['contents'], 'file.jpg', { type: 'image/jpeg' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+
+    expect($scope.onUpload).toHaveBeenCalled()
+  })
+
+  it('should accept file uploads for PNG', () => {
+    const file = new File(['contents'], 'file.png', { type: 'image/png' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+
+    expect($scope.onUpload).toHaveBeenCalled()
+  })
+
+  it('should ignore null file', () => {
+    uploadFile(element.find('input')[0], null)
+    $scope.$digest()
+
+    expect($scope.onUpload).not.toHaveBeenCalled()
+  })
+
+  it('should reject non-image files', () => {
+    const file = new File(['contents'], 'file.txt', { type: 'text/plain' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+
+    expect($scope.onInvalidFileType).toHaveBeenCalled()
+    expect($scope.onUpload).not.toHaveBeenCalled()
+  })
+
+  it('should reject HEIC files', () => {
+    const file = new File(['contents'], 'file.heic', { type: 'image/heic' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+
+    expect($scope.onInvalidFileType).toHaveBeenCalled()
+    expect($scope.onUpload).not.toHaveBeenCalled()
+  })
+
+  it('should call onSuccess and onComplete', () => {
+    const file = new File(['contents'], 'file.png', { type: 'image/png' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+    $httpBackend.flush()
+
+    expect($scope.onSuccess).toHaveBeenCalled()
+    expect($scope.onComplete).toHaveBeenCalled()
+  })
+
+  it('should call onError and onComplete', () => {
+    $httpBackend.matchLatestDefinitionEnabled(true)
+    $httpBackend.whenPOST(/^\/upload$/).respond(() => [500, 'Error', {}])
+
+    const file = new File(['contents'], 'file.png', { type: 'image/png' })
+    uploadFile(element.find('input')[0], file)
+    $scope.$digest()
+    $httpBackend.flush()
+
+    expect($scope.onSuccess).not.toHaveBeenCalled()
+    expect($scope.onError).toHaveBeenCalled()
+    expect($scope.onComplete).toHaveBeenCalled()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,14 +2134,7 @@ angular-ui-router@^1.0.30:
   dependencies:
     "@uirouter/core" "6.0.8"
 
-angular-upload@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/angular-upload/-/angular-upload-1.0.13.tgz#f622bde164e5ed96ba062409e659a3021921c407"
-  integrity sha1-9iK94WTl7Za6BiQJ5lmjAhkhxAc=
-  dependencies:
-    angular ">=1.2.0"
-
-angular@*, angular@>=1.2.0:
+angular@*:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
   integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==


### PR DESCRIPTION
One source of the designation editor photo upload errors is lack of proper file validation. Even with `accept="image/*"` browsers don't validate the MIME type when dragging and dropping files, so a user could upload non-image files that way. Also, Safari allows users to upload HEIC files, which causes a server-side exception when attempting to rotate it ([Rollbar example](https://rollbar.com/Cru/give-aem/items/53/)). Other image formats like SVG or WEBP would likely cause similar issues.

This PR reimplements the dead `angular-upload` package to add that additional validation, allowing only PNG and JPEG files to be uploaded.

https://jira.cru.org/browse/EP-2314