### PR TITLE
Send processing fee to the data layer

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -530,6 +530,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               name: cartItem.designationNumber,
               id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
+              processingFee: cartItem.amountWithFees ? Number.parseFloat(cartItem.amountWithFees - cartItem.amount).toFixed(2) : undefined,
               brand: cartItem.orgId,
               category: cartItem.designationType.toLowerCase(),
               variant: cartItem.frequency.toLowerCase(),

--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -530,7 +530,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               name: cartItem.designationNumber,
               id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
-              processingFee: cartItem.amountWithFees ? Number.parseFloat(cartItem.amountWithFees - cartItem.amount).toFixed(2) : undefined,
+              processingFee: cartItem.amountWithFees ? (cartItem.amountWithFees - cartItem.amount).toFixed(2) : undefined,
               brand: cartItem.orgId,
               category: cartItem.designationType.toLowerCase(),
               variant: cartItem.frequency.toLowerCase(),

--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -512,7 +512,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
     transactionEvent: function (purchaseData) {
       try {
         // The value of whether or not user is covering credit card fees for the transaction
-        const coverFeeDecision = sessionStorage.getItem('coverFeeDecision')
+        const coverFeeDecision = JSON.parse(sessionStorage.getItem('coverFeeDecision'))
         // Parse the cart object of the last purchase
         const transactionCart = JSON.parse(localStorage.getItem('transactionCart'))
         // The purchaseId number from the last purchase
@@ -530,7 +530,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, sessionSer
               name: cartItem.designationNumber,
               id: cartItem.designationNumber,
               price: cartItem.amount.toString(),
-              processingFee: cartItem.amountWithFees ? (cartItem.amountWithFees - cartItem.amount).toFixed(2) : undefined,
+              processingFee: cartItem.amountWithFees && coverFeeDecision ? (cartItem.amountWithFees - cartItem.amount).toFixed(2) : undefined,
               brand: cartItem.orgId,
               category: cartItem.designationType.toLowerCase(),
               variant: cartItem.frequency.toLowerCase(),


### PR DESCRIPTION
The analytics team wants to track the amount of processing fees are being covered by donors, this subtracts the amount with fees by the amount without fees to come up with the fee itself, then rounds to 2 decimal points.