### PR TITLE
[EP-2405] Don't set cart count cookie in branded checkout

### DIFF
--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -24,21 +24,27 @@ import { startMonth } from '../giftHelpers/giftDates.service'
 
 const cartTotalCookie = 'giveCartItemCount'
 const cartTotalCookieDomain = 'cru.org'
+const brandedCheckoutDomains = ['secure.cru.org']
 
 const serviceName = 'cartService'
 
 class Cart {
   /* @ngInject */
-  constructor (cortexApiService, commonService, designationsService, sessionService, hateoasHelperService, $cookies) {
+  constructor (cortexApiService, commonService, designationsService, sessionService, hateoasHelperService, $cookies, $location) {
     this.cortexApiService = cortexApiService
     this.commonService = commonService
     this.designationsService = designationsService
     this.sessionService = sessionService
     this.hateoasHelperService = hateoasHelperService
     this.$cookies = $cookies
+    this.$location = $location
   }
 
   setCartCountCookie (quantity) {
+    if (brandedCheckoutDomains.includes(this.$location.host())) {
+      return
+    }
+
     if (quantity) {
       this.$cookies.put(cartTotalCookie, quantity, {
         path: '/',

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -24,7 +24,6 @@ import { startMonth } from '../giftHelpers/giftDates.service'
 
 const cartTotalCookie = 'giveCartItemCount'
 const cartTotalCookieDomain = 'cru.org'
-const brandedCheckoutDomains = ['secure.cru.org']
 
 const serviceName = 'cartService'
 
@@ -41,7 +40,7 @@ class Cart {
   }
 
   setCartCountCookie (quantity) {
-    if (brandedCheckoutDomains.includes(this.$location.host())) {
+    if (!['give.cru.org', 'give-stage2.cru.org', 'give-stage2-next.cru.org'].includes(this.$location.host())) {
       return
     }
 

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -31,6 +31,7 @@ describe('cart service', () => {
     beforeEach(() => {
       jest.spyOn(self.cartService.$cookies, 'put').mockImplementation(() => {})
       jest.spyOn(self.cartService.$cookies, 'remove').mockImplementation(() => {})
+      jest.spyOn(self.cartService.$location, 'host').mockReturnValue('give.cru.org')
       jest.spyOn(self.cartService.commonService, 'getNextDrawDate').mockReturnValue(Observable.of('2016-10-01'))
       advanceTo(moment('2016-09-01').toDate()) // Make sure current date is before next draw date
     })
@@ -92,6 +93,22 @@ describe('cart service', () => {
         })
       self.$httpBackend.flush()
     })
+
+    it('should not set cart count cookie on other domains', () => {
+      self.cartService.$location.host.mockReturnValue('secure.cru.org')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/carts/crugive/default' +
+        '?zoom=lineitems:element,lineitems:element:availability,lineitems:element:item,lineitems:element:item:code,' +
+        'lineitems:element:item:definition,lineitems:element:rate,lineitems:element:total,' +
+        'lineitems:element:itemfields,ratetotals:element,total,total:cost')
+        .respond(200, cartResponse)
+
+      self.cartService.get()
+        .subscribe(() => {
+          expect(self.cartService.$cookies.put).not.toHaveBeenCalled()
+          expect(self.cartService.$cookies.remove).not.toHaveBeenCalled()
+        })
+      self.$httpBackend.flush()
+    })
   })
 
   describe('handleCartResponse', () => {
@@ -105,6 +122,7 @@ describe('cart service', () => {
     beforeEach(() => {
       jest.spyOn(self.cartService.$cookies, 'put').mockImplementation(() => {})
       jest.spyOn(self.cartService.$cookies, 'remove').mockImplementation(() => {})
+      jest.spyOn(self.cartService.$location, 'host').mockReturnValue('give.cru.org')
       advanceTo(moment('2016-09-01').toDate()) // Make sure current date is before next draw date
       transformedCartResponse = self.cartService.hateoasHelperService.mapZoomElements(cartResponse, zoom)
       transformedCartResponse.rateTotals[0].cost.amount = 51


### PR DESCRIPTION
Prevent branded checkout pages like `secure.cru.org` from setting the cart count cookie. That cookie was causing a (1) badge to show up on the `give.cru.org` cart even though the cart was empty.

https://jira.cru.org/browse/EP-2405