### PR TITLE
[EP-2405] Treat missing cru-profile as not logged in

### DIFF
--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -217,7 +217,7 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
 
   function currentRole () {
     if (angular.isDefined(session.role)) {
-      if (session.role === Roles.public) {
+      if (session.role === Roles.public || angular.isUndefined($cookies.get(Sessions.profile))) {
         return Roles.public
       }
       // Expired cookies are undefined

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -112,6 +112,7 @@ describe('session service', function () {
     describe('with \'IDENTIFIED\' cortex-session', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.identified)
+        $cookies.put(Sessions.profile, cruProfile)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })
@@ -121,15 +122,21 @@ describe('session service', function () {
       })
     })
 
-    describe('getRole with \'REGISTERED\' cortex-session', () => {
+    describe('with \'REGISTERED\' cortex-session', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.registered)
+        $cookies.put(Sessions.profile, cruProfile)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })
 
       it('returns \'IDENTIFIED\' with expired give-session', () => {
         expect(sessionService.getRole()).toEqual(Roles.identified)
+      })
+
+      it('returns \'PUBLIC\' with expired cru-profile', () => {
+        $cookies.remove(Sessions.profile)
+        expect(sessionService.getRole()).toEqual(Roles.public)
       })
 
       describe('with \'REGISTERED\' give-session', () => {
@@ -288,6 +295,7 @@ describe('session service', function () {
     describe('with \'IDENTIFIED\' role', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.identified)
+        $cookies.put(Sessions.profile, cortexRole.registered)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })
@@ -311,6 +319,7 @@ describe('session service', function () {
     describe('with skipEvent = true', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.identified)
+        $cookies.put(Sessions.profile, cortexRole.registered)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -295,7 +295,7 @@ describe('session service', function () {
     describe('with \'IDENTIFIED\' role', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.identified)
-        $cookies.put(Sessions.profile, cortexRole.registered)
+        $cookies.put(Sessions.profile, cruProfile)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })
@@ -319,7 +319,7 @@ describe('session service', function () {
     describe('with skipEvent = true', () => {
       beforeEach(() => {
         $cookies.put(Sessions.role, cortexRole.identified)
-        $cookies.put(Sessions.profile, cortexRole.registered)
+        $cookies.put(Sessions.profile, cruProfile)
         // Force digest so scope session watchers pick up changes.
         $rootScope.$digest()
       })


### PR DESCRIPTION
**Problem:**

When the user is logged in and then visits a branded checkout page, branded checkout will logout the user. If the branded checkout page is on a *.cru.org subdomain, the logout will clear the `cru-session` and `cru-profile` cookies because they are set on the root domain `cru.org`. However, a logout request to `DELETE https://secure.cru.org/cas/logout`, for example, will leave the `give-session`, `cortex-session`, and `cortex-role` cookies set on `give.cru.org` untouched because a request to `secure.cru.org` can't modify cookies set on `give.cru.org`. After the logout, the user will still have `cortex-role` set but no `cru-profile` anymore.

This PR treats users without a `cru-profile` as not logged in, even if they have a valid Cortex session.

Tested in staging ✅

https://jira.cru.org/browse/EP-2405