### PR TITLE
AEM-395 - Mitigate cache

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -345,14 +345,16 @@ class DesignationEditorController {
 
   getDoneEditingUrl () {
     const vanityPath = this.designationContent['sling:vanityPath']
+    const cacheBust = '?doneEditing'
+
     if (vanityPath) {
       if (isArray(vanityPath)) {
-        return vanityPath[0].replace('/content/give/us/en', '')
+        return `${vanityPath[0].replace('/content/give/us/en', '')}${cacheBust}`
       } else {
-        return vanityPath.replace('/content/give/us/en', '')
+        return `${vanityPath.replace('/content/give/us/en', '')}${cacheBust}`
       }
     } else {
-      return `/${this.designationNumber}`
+      return `/${this.designationNumber}${cacheBust}`
     }
   }
 }

--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -2,6 +2,7 @@ import angular from 'angular'
 import 'angular-sanitize'
 import find from 'lodash/find'
 import includes from 'lodash/includes'
+import isArray from 'lodash/isArray'
 import uibModal from 'angular-ui-bootstrap/src/modal'
 
 import commonModule from 'common/common.module'
@@ -339,6 +340,19 @@ class DesignationEditorController {
         cancelable: true
       }))
       this.carouselLoaded = true
+    }
+  }
+
+  getDoneEditingUrl () {
+    const vanityPath = this.designationContent['sling:vanityPath']
+    if (vanityPath) {
+      if (isArray(vanityPath)) {
+        return vanityPath[0].replace('/content/give/us/en', '')
+      } else {
+        return vanityPath.replace('/content/give/us/en', '')
+      }
+    } else {
+      return `/${this.designationNumber}`
     }
   }
 }

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -555,23 +555,24 @@ describe('Designation Editor', function () {
   })
 
   describe ('getDoneEditingUrl()', () => {
+    const cacheBust = '?doneEditing'
     it('should return the first vanity url', () => {
       $ctrl.designationContent = designationSecurityResponse
       $ctrl.designationContent['sling:vanityPath'] = ['/content/give/us/en/0123456']
-      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
     })
 
     it('should return the only vanity url', () => {
       $ctrl.designationContent = designationSecurityResponse
       $ctrl.designationContent['sling:vanityPath'] = '/content/give/us/en/0123456'
-      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
     })
 
     it('should fallback to the designation number page', () => {
       $ctrl.designationNumber = '0123456'
       $ctrl.designationContent = designationSecurityResponse
       $ctrl.designationContent['sling:vanityPath'] = undefined
-      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
     })
   })
 })

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -556,23 +556,25 @@ describe('Designation Editor', function () {
 
   describe ('getDoneEditingUrl()', () => {
     const cacheBust = '?doneEditing'
+    const designationNumber = '0123456'
+
     it('should return the first vanity url', () => {
       $ctrl.designationContent = designationSecurityResponse
-      $ctrl.designationContent['sling:vanityPath'] = ['/content/give/us/en/0123456']
-      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
+      $ctrl.designationContent['sling:vanityPath'] = [`/content/give/us/en/${designationNumber}`]
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/${designationNumber}${cacheBust}`)
     })
 
     it('should return the only vanity url', () => {
       $ctrl.designationContent = designationSecurityResponse
-      $ctrl.designationContent['sling:vanityPath'] = '/content/give/us/en/0123456'
-      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
+      $ctrl.designationContent['sling:vanityPath'] = `/content/give/us/en/${designationNumber}`
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/${designationNumber}${cacheBust}`)
     })
 
     it('should fallback to the designation number page', () => {
-      $ctrl.designationNumber = '0123456'
+      $ctrl.designationNumber = designationNumber
       $ctrl.designationContent = designationSecurityResponse
       $ctrl.designationContent['sling:vanityPath'] = undefined
-      expect($ctrl.getDoneEditingUrl()).toEqual(`/0123456${cacheBust}`)
+      expect($ctrl.getDoneEditingUrl()).toEqual(`/${designationNumber}${cacheBust}`)
     })
   })
 })

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -553,4 +553,25 @@ describe('Designation Editor', function () {
       expect($ctrl.$window.document.dispatchEvent).toHaveBeenCalled()
     })
   })
+
+  describe ('getDoneEditingUrl()', () => {
+    it('should return the first vanity url', () => {
+      $ctrl.designationContent = designationSecurityResponse
+      $ctrl.designationContent['sling:vanityPath'] = ['/content/give/us/en/0123456']
+      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+    })
+
+    it('should return the only vanity url', () => {
+      $ctrl.designationContent = designationSecurityResponse
+      $ctrl.designationContent['sling:vanityPath'] = '/content/give/us/en/0123456'
+      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+    })
+
+    it('should fallback to the designation number page', () => {
+      $ctrl.designationNumber = '0123456'
+      $ctrl.designationContent = designationSecurityResponse
+      $ctrl.designationContent['sling:vanityPath'] = undefined
+      expect($ctrl.getDoneEditingUrl()).toEqual('/0123456')
+    })
+  })
 })

--- a/src/app/designationEditor/designationEditor.tpl.html
+++ b/src/app/designationEditor/designationEditor.tpl.html
@@ -30,7 +30,7 @@
         </div>
 
         <div class="col-sm-6  col-xs-12 text-right">
-          <a id="doneEditingButton1" ng-href="{{$ctrl.designationContent['sling:vanityPath'][0].replace('/content/give/us/en', '')}}" class="btn btn-secondary"
+          <a id="doneEditingButton1" ng-href="{{$ctrl.getDoneEditingUrl()}}" class="btn btn-secondary"
              ng-if="$ctrl.contentLoaded" translate>
             Done Editing
           </a>


### PR DESCRIPTION
This basically adds a `?doneEditing` query parameter to the designation page after the person is done editing it. There is a no-cache rule that looks for this query parameter [here](https://github.com/CruGlobal/cru-aem-commons/pull/223)