### PR TITLE
AEM-568 - Turn full urls into vanity urls for nice hover effect

### DIFF
--- a/src/app/searchResults/searchResults.component.js
+++ b/src/app/searchResults/searchResults.component.js
@@ -91,8 +91,8 @@ class SearchResultsController {
    * @returns {*} the vanity url
    */
   buildVanity (originalPath) {
-    const pattern = /\/designations\/([0-9])\/([0-9])\/([0-9])\/([0-9])\/([0-9])\/([0-9]{7})\.html/g
-    return originalPath.replace(pattern, '/$6')
+    const pattern = /\/designations\/(\d\/){5}(\d{7})\.html/g
+    return originalPath.replace(pattern, '/$2')
   }
 }
 

--- a/src/app/searchResults/searchResults.component.js
+++ b/src/app/searchResults/searchResults.component.js
@@ -83,6 +83,17 @@ class SearchResultsController {
   productViewDetailsAnalyticsEvent (product) {
     this.analyticsFactory.productViewDetailsEvent(product)
   }
+
+  /**
+   * Go from a full url such as https://give-stage2.cru.org/designations/0/1/2/3/4/0123456.html
+   * to a vanity url of the pattern https://give-stage2.cru.org/0123456
+   * @param originalPath the full url
+   * @returns {*} the vanity url
+   */
+  buildVanity (originalPath) {
+    const pattern = /\/designations\/([0-9])\/([0-9])\/([0-9])\/([0-9])\/([0-9])\/([0-9]{7})\.html/g
+    return originalPath.replace(pattern, '/$6')
+  }
 }
 
 export default angular

--- a/src/app/searchResults/searchResults.spec.js
+++ b/src/app/searchResults/searchResults.spec.js
@@ -107,4 +107,22 @@ describe('searchResults', function () {
       expect($ctrl.analyticsFactory.productViewDetailsEvent).toHaveBeenCalledWith('product')
     })
   })
+
+  describe('buildVanity', () => {
+    it('should replace a full url with a proper vanity', () => {
+      const fullUrl = 'https://localhost.cru.org/designations/0/1/2/3/4/0123456.html'
+      const expectedVanity = 'https://localhost.cru.org/0123456'
+      expect($ctrl.buildVanity(fullUrl)).toEqual(expectedVanity)
+    })
+
+    it('should not break an already-vanity url', () => {
+      const fullUrl = 'https://localhost.cru.org/0123456'
+      expect($ctrl.buildVanity(fullUrl)).toEqual(fullUrl)
+    })
+
+    it('should not break a non-staff page url', () => {
+      const fullUrl = 'https://localhost.cru.org/give-all-money-now'
+      expect($ctrl.buildVanity(fullUrl)).toEqual(fullUrl)
+    })
+  })
 })

--- a/src/app/searchResults/searchResults.tpl.html
+++ b/src/app/searchResults/searchResults.tpl.html
@@ -124,11 +124,11 @@
                   </div>
 
                   <div class="is-row clearfix" ng-repeat-end ng-repeat="r in hits">
-                    <a ng-href="{{r.path}}" class="is-row-thumb">
+                    <a ng-href="{{$ctrl.buildVanity(r.path)}}" class="is-row-thumb">
                       <img desig-src="{{r.designationNumber}}" campaign-page="{{r.campaignPage}}">
                     </a>
                     <div class="is-row-meta">
-                      <a ng-href="{{r.path}}">
+                      <a ng-href="{{$ctrl.buildVanity(r.path)}}">
                         <span class="is-row-title">{{r.name}}</span>
                         <span class="is-row-num">#{{r.designationNumber}}</span>
                       </a>
@@ -136,7 +136,7 @@
                     <div class="is-row-actions hidden-xs">
                       <product-config product-code="{{r.designationNumber}}" campaign-page="{{r.campaignPage}}" button-label="Give a Gift" button-size="sm"></product-config>
                       &nbsp;
-                      <a ng-href="{{r.path}}" class="btn btn-sm btn-subtle" ng-click="$ctrl.productViewDetailsAnalyticsEvent(r)" translate>Details</a>
+                      <a ng-href="{{$ctrl.buildVanity(r.path)}}" class="btn btn-sm btn-subtle" ng-click="$ctrl.productViewDetailsAnalyticsEvent(r)" translate>Details</a>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
When we move to the AEM cloud servers we are going to lose some of our vanity urls when it comes to link creation. The dispatcher (web server) still understands these vanity urls so we can recreate the links in the proper format here.