### PR TITLE
Record give-session sub in Rollbar

### DIFF
--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -74,13 +74,14 @@ const rollbarConfig = /* @ngInject */ function (envServiceProvider, $provide) {
   })
 }
 
-function updateRollbarPerson (session) {
+function updateRollbarPerson (session, giveSession) {
   let person = {}
   if (session) {
     person = {
       id: session.sub,
       username: session.first_name + ' ' + session.last_name,
-      email: session.email
+      email: session.email,
+      giveId: giveSession.sub
     }
   }
 

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -128,6 +128,8 @@ describe('rollbarConfig', () => {
           first_name: 'Fname',
           last_name: 'Lname',
           email: 'someone@email.com'
+        }, {
+          sub: 'cas|12345'
         })
 
         expect(self.rollbarSpies.configure).toHaveBeenCalledWith({
@@ -135,7 +137,8 @@ describe('rollbarConfig', () => {
             person: {
               id: 'cas|12345',
               username: 'Fname Lname',
-              email: 'someone@email.com'
+              email: 'someone@email.com',
+              giveId: 'cas|12345'
             }
           }
         })

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -36,7 +36,7 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
   const maximumTimeout = 30 * 1000
 
   // Set initial session on load
-  updateCurrentSession($cookies.get(Sessions.role))
+  updateCurrentSession()
 
   // Watch cortex-session cookie for changes and update existing session variable
   // This only detects changes made by $http or other angular services, not the browser expiring the cookie.
@@ -156,15 +156,10 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
   }
 
   /* Private Methods */
-  function updateCurrentSession (encoded_value) {
-    let cortexRole = {}; let cruProfile = {}
-    if (angular.isDefined(encoded_value)) {
-      cortexRole = jwtDecode(encoded_value)
-    }
-
-    if (angular.isDefined($cookies.get(Sessions.profile))) {
-      cruProfile = jwtDecode($cookies.get(Sessions.profile))
-    }
+  function updateCurrentSession () {
+    const cortexRole = decodeCookie(Sessions.role)
+    const cruProfile = decodeCookie(Sessions.profile)
+    const giveSession = decodeCookie(Sessions.give)
 
     // Set give-session expiration timeout if defined
     const timeout = giveSessionExpiration()
@@ -177,7 +172,12 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
     // Update sessionSubject with new value
     sessionSubject.next(session)
 
-    updateRollbarPerson(session)
+    updateRollbarPerson(session, giveSession)
+  }
+
+  function decodeCookie (cookieName) {
+    const jwt = $cookies.get(cookieName)
+    return angular.isDefined(jwt) ? jwtDecode(jwt) : {}
   }
 
   function setSessionTimeout (timeout) {
@@ -194,7 +194,7 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
       const expiration = giveSessionExpiration()
       if (angular.isUndefined(expiration)) {
         // Give session has expired
-        updateCurrentSession($cookies.get(Sessions.role))
+        updateCurrentSession()
       } else {
         setSessionTimeout(expiration)
       }


### PR DESCRIPTION
In an attempt to better debug issues like https://secure.helpscout.net/conversation/2184380957/909478/, record the `give-session` `ssoGuid` in Rollbar to see if it's sometimes missing, causing the 422 error when loading `/bin/crugive/image?designationNumber=XXXXXXX`.