### PR TITLE
AEM-Cloud cc init

### DIFF
--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -135,7 +135,11 @@ class CreditCardController {
           }) // Send masked card number when card number is not updated
         : this.tsysService.getManifest()
           .mergeMap(data => {
-            cruPayments.creditCard.init(this.envService.get(), data.deviceId, data.manifest)
+            const productionEnvironments = ['production', 'prodcloud']
+            const actualEnvironment = this.envService.get()
+            const ccpEnvironment = productionEnvironments.includes(actualEnvironment) ? 'production' : actualEnvironment
+
+            cruPayments.creditCard.init(ccpEnvironment, data.deviceId, data.manifest)
             return cruPayments.creditCard.encrypt(this.creditCardPayment.cardNumber, this.hideCvv ? null : this.creditCardPayment.securityCode, this.creditCardPayment.expiryMonth, this.creditCardPayment.expiryYear)
           })
       tokenObservable.subscribe(tokenObj => {

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -238,6 +238,22 @@ describe('credit card form', () => {
       expect(self.outerScope.onPaymentFormStateChange).toHaveBeenCalledWith({ state: 'loading', payload: expectedData })
     })
 
+    it('should handle prodcloud environment properly', () => {
+      self.controller.envService.set('prodcloud')
+      self.controller.creditCardPayment = {
+        cardNumber: '4111111111111111',
+        cardholderName: 'Person Name',
+        expiryMonth: 12,
+        expiryYear: 2019,
+        securityCode: '123'
+      }
+      self.controller.useMailingAddress = true
+      self.formController.$valid = true
+      self.controller.savePayment()
+
+      expect(cruPayments.creditCard.init).toHaveBeenCalledWith('production', '<device id>', '<manifest>')
+    })
+
     it('should handle an error retrieving the manifest from TSYS', () => {
       self.formController.$valid = true
       self.controller.tsysService.getManifest.mockReturnValue(Observable.throw('some error'))


### PR DESCRIPTION
This allows us to tokenize credit cards on give-prod-cloud.cru.org (using Referer Control browser plugin).