### PR TITLE
AEM-603 - Add .html to AEM API calls

### DIFF
--- a/src/common/services/api/designationEditor.constants.js
+++ b/src/common/services/api/designationEditor.constants.js
@@ -1,6 +1,6 @@
 export default {
-  designationEndpoint: '/bin/crugive/designation',
-  designationImagesEndpoint: '/bin/crugive/image',
+  designationEndpoint: '/bin/crugive/designation.html',
+  designationImagesEndpoint: '/bin/crugive/image.html',
   designationNewsletter: '/bin/crugive/newsletter/signup.json',
   designationNewsletterSubscription: '/bin/crugive/newsletter/signup.json'
 }


### PR DESCRIPTION
Add .html to servlet endpoints. This is required for the cloud to not send a redirect.