### PR TITLE
[EP-2314] Image upload improvements

### DIFF
--- a/src/app/designationEditor/carouselModal/carouselModal.tpl.html
+++ b/src/app/designationEditor/carouselModal/carouselModal.tpl.html
@@ -60,8 +60,9 @@
         </div>
         <img desig-img-src="{{photo.thumbnail}}" />
       </div>
-      <div class="cover-thumb" ng-repeat="photo in $ctrl.getProcessingPhotos() track by $index">
+      <div class="cover-thumb processing" ng-repeat="blobUrl in $ctrl.getProcessingPhotos() track by $index">
         <loading type="centered">Processing...</loading>
+        <img ng-src="{{blobUrl}}" />
       </div>
     </div>
   </div>
@@ -82,9 +83,9 @@
           url="/bin/crugive/image.html?designationNumber={{$ctrl.designationNumber}}"
           on-invalid-file-type="$ctrl.invalidFileType = true"
           on-complete="$ctrl.invalidFileType = false"
-          on-upload="$ctrl.uploading = true"
-          on-success="$ctrl.uploadComplete(response)"
-          on-error="$ctrl.uploading = false"
+          on-upload="$ctrl.uploadStart(file)"
+          on-success="$ctrl.uploadComplete(response, file)"
+          on-error="$ctrl.uploadError(file)"
         />
       </div>
 

--- a/src/app/designationEditor/carouselModal/carouselModal.tpl.html
+++ b/src/app/designationEditor/carouselModal/carouselModal.tpl.html
@@ -28,7 +28,7 @@
           </div>
         </td>
         <td>
-          <img ng-src="{{pic.url}}.transform/GiveDesignationThumbnail/img.jpg"/>
+          <img desig-img-src="{{pic.url}}.transform/GiveDesignationThumbnail/img.jpg"/>
         </td>
         <td>
           <button class="btn btn-default"
@@ -44,7 +44,7 @@
 
   <hr />
 
-  <div class="give-available-photos-container" ng-if="$ctrl.photos.length">
+  <div class="give-available-photos-container" ng-if="$ctrl.photos.length || $ctrl.numProcessingPhotos > 0">
     <h3 translate>Available Photos</h3>
     <h5 translate>Click + to add photos to the carousel.</h5>
     <div class="alert alert-danger" role="alert" ng-if="$ctrl.maxCarouselError">
@@ -58,7 +58,10 @@
         <div class="add-trigger" ng-click="$ctrl.addImageToCarousel(photo)">
           <i class="fa fa-plus" aria-label="Add to carousel"></i>
         </div>
-        <img ng-src="{{photo.thumbnail}}" />
+        <img desig-img-src="{{photo.thumbnail}}" />
+      </div>
+      <div class="cover-thumb" ng-repeat="photo in $ctrl.getProcessingPhotos() track by $index">
+        <loading type="centered">Processing...</loading>
       </div>
     </div>
   </div>
@@ -78,10 +81,11 @@
           class="form-control"
           url="/bin/crugive/image.html?designationNumber={{$ctrl.designationNumber}}"
           on-invalid-file-type="$ctrl.invalidFileType = true"
-          on-upload="$ctrl.uploading = true"
           on-complete="$ctrl.invalidFileType = false"
-          on-success="$ctrl.uploadComplete()"
-          on-error="$ctrl.uploading = false"/>
+          on-upload="$ctrl.uploading = true"
+          on-success="$ctrl.uploadComplete(response)"
+          on-error="$ctrl.uploading = false"
+        />
       </div>
 
       <label ng-if="$ctrl.uploading" translate>Uploading...</label>

--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -29,14 +29,18 @@ import carouselModalTemplate from './carouselModal/carouselModal.tpl.html'
 import textEditorModalTemplate from './textEditorModal/textEditorModal.tpl.html'
 import websiteModalTemplate from './websiteModal/websiteModal.tpl.html'
 
+import desigImgSrcDirective from 'common/directives/desigImgSrc.directive'
+
 import './designationEditor.scss'
 
 const componentName = 'designationEditor'
 
 class DesignationEditorController {
   /* @ngInject */
-  constructor ($log, $q, $uibModal, $location, $window, envService, sessionService, sessionEnforcerService, designationEditorService) {
+  constructor ($scope, $log, $q, $uibModal, $location, $window, $timeout, envService, sessionService, sessionEnforcerService, designationEditorService) {
+    this.$scope = $scope
     this.$log = $log
+    this.$timeout = $timeout
     this.sessionService = sessionService
     this.sessionEnforcerService = sessionEnforcerService
     this.designationEditorService = designationEditorService
@@ -44,6 +48,7 @@ class DesignationEditorController {
     this.imgDomain = envService.read('imgDomain')
     this.imgDomainDesignation = envService.read('imgDomainDesignation')
     this.giveDomain = envService.read('publicGive')
+    this.carouselImages = []
 
     this.$location = $location
     this.$q = $q
@@ -54,7 +59,6 @@ class DesignationEditorController {
   $onInit () {
     this.designationNumber = this.$location.search().d
     this.campaignPage = this.$location.search().campaign
-    this.carouselLoaded = false
 
     // designationNumber is required
     if (!this.designationNumber) {
@@ -93,6 +97,8 @@ class DesignationEditorController {
       this.loadingOverlay = false
       this.designationContent = responses[0].data
       this.designationPhotos = responses[1].data
+      this.carouselImages = this.extractCarouselUrls()
+      this.updateCarousel()
     }, error => {
       this.contentLoaded = false
       this.loadingOverlay = false
@@ -173,9 +179,8 @@ class DesignationEditorController {
       }, angular.noop)
   }
 
-  selectPhotos (photoLocation, selectedPhotos) {
-    const imageUrls = this.getImageUrls(selectedPhotos)
-    const selectedUrls = imageUrls.map(url => ({ url }))
+  selectPhotos (photoLocation) {
+    const selectedUrls = this.carouselImages.map(url => ({ url }))
 
     const modalOptions = {
       templateUrl: carouselModalTemplate,
@@ -240,12 +245,22 @@ class DesignationEditorController {
     return find(this.designationPhotos, { original: originalUrl })
   }
 
-  images () {
+  extractCarouselUrls () {
     const designController = this.designationContent['design-controller']
     if (designController && designController.carousel) {
       return this.getImageUrls(designController.carousel)
     }
     return []
+  }
+
+  updateCarousel () {
+    // The carousel element needs to be removed and re-added to the DOM for the AEM component to
+    // pick up on the changes. Toggling contentLoaded off then back on will cause the ng-if on
+    // `.secondaryPhoto` will forcibly recreate the carousel DOM element.
+    this.contentLoaded = false
+    this.$scope.$applyAsync(() => {
+      this.contentLoaded = true
+    })
   }
 
   editText (field) {
@@ -291,6 +306,8 @@ class DesignationEditorController {
     return this.designationEditorService.save(this.designationContent, this.designationNumber, this.campaignPage).then(() => {
       this.saveStatus = 'success'
       this.loadingOverlay = false
+      this.carouselImages = this.designationContent.secondaryPhotos
+      this.updateCarousel()
     }, error => {
       this.saveStatus = 'failure'
       this.saveDesignationError = true
@@ -373,6 +390,7 @@ export default angular
     photoModalController.name,
     textEditorModalController.name,
     websiteModalController.name,
+    desigImgSrcDirective.name,
     uibModal
   ])
   .component(componentName, {

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -328,13 +328,14 @@ describe('Designation Editor', function () {
         modalPromise = _$q_.defer()
         jest.spyOn($ctrl.$uibModal, 'open').mockReturnValue({ result: modalPromise.promise })
         $ctrl.designationContent = designationSecurityResponse
+        $ctrl.carouselImages = $ctrl.extractCarouselUrls()
       }))
 
       it('should open modal', () => {
         let photos = []
         $ctrl.designationPhotos = photos
 
-        $ctrl.selectPhotos('secondaryPhotos', designationSecurityResponse['design-controller'].carousel)
+        $ctrl.selectPhotos('secondaryPhotos')
 
         let selectedPhotos = [
           { url: '/content/dam/give/designations/0/1/2/3/4/0123456/some-image.jpg' },
@@ -503,7 +504,7 @@ describe('Designation Editor', function () {
     })
   })
 
-  describe('images', () => {
+  describe('extractCarouselUrls', () => {
     it('should return all of the selected images for the carousel', () => {
       $ctrl.designationContent = designationSecurityResponse
       let expectedImageUrls = [
@@ -512,14 +513,26 @@ describe('Designation Editor', function () {
         '/content/dam/give/designations/0/1/2/3/4/0123456/third-image.jpg'
       ]
 
-      expect($ctrl.images()).toEqual(expectedImageUrls)
+      expect($ctrl.extractCarouselUrls()).toEqual(expectedImageUrls)
     })
 
     it('should return an empty array if there is no carousel', () => {
       $ctrl.designationContent = {
         designationNumber: '0123456'
       }
-      expect($ctrl.images()).toEqual([])
+      expect($ctrl.extractCarouselUrls()).toEqual([])
+    })
+  })
+
+  describe('updateCarousel', () => {
+    it('should hide then show the carousel', () => {
+      $ctrl.updateCarousel()
+
+      expect($ctrl.contentLoaded).toBe(false)
+
+      $rootScope.$digest()
+
+      expect($ctrl.contentLoaded).toBe(true)
     })
   })
 

--- a/src/app/designationEditor/designationEditor.tpl.html
+++ b/src/app/designationEditor/designationEditor.tpl.html
@@ -58,7 +58,7 @@
         <img ng-src="{{$ctrl.imgDomain}}/assets/img/photo-placeholder.png"
              ng-if="!$ctrl.photoUrl($ctrl.designationContent.coverPhoto)"
              class="panel-cover-image">
-        <img ng-src="{{$ctrl.imgDomainDesignation + $ctrl.photoUrl($ctrl.designationContent.coverPhoto).cover}}"
+        <img desig-img-src="{{$ctrl.photoUrl($ctrl.designationContent.coverPhoto).cover}}"
              ng-if="$ctrl.photoUrl($ctrl.designationContent.coverPhoto)"
              class="panel-cover-image">
       </div>
@@ -68,30 +68,30 @@
         <div class="col-md-10 col-md-offset-1">
           <div href="" class="pull-right secondary-wrapper ml mb">
             <div class="edit-trigger" ng-if="$ctrl.contentLoaded"
-                 ng-click="$ctrl.contentLoaded && $ctrl.selectPhotos('secondaryPhotos', $ctrl.designationContent['design-controller'].carousel)">
+                 ng-click="$ctrl.contentLoaded && $ctrl.selectPhotos('secondaryPhotos')">
               <i class="fa fa-camera"></i>
             </div>
 
             <img ng-src="{{$ctrl.imgDomain}}/assets/img/photo-placeholder.png"
-                 ng-if="$ctrl.contentLoaded && !$ctrl.images().length">
-            <div class="secondaryPhoto" ng-if="$ctrl.contentLoaded && $ctrl.images().length">
+                 ng-if="$ctrl.contentLoaded && !$ctrl.carouselImages.length">
+            <div class="secondaryPhoto" ng-if="$ctrl.contentLoaded && $ctrl.carouselImages.length">
               <div class="cmp-carousel" data-cmp-delay="5000" data-cmp-is="carousel">
                 <div class="cmp-carousel__content">
-                  <div ng-repeat="image in $ctrl.images()"
+                  <div ng-repeat="image in $ctrl.carouselImages"
                        role="tabpanel"
                        class="cmp-carousel__item {{$first ? 'cmp-carousel__item--active' : ''}}"
                        data-cmp-hook-carousel="item"
                        aria-hidden="{{!$first}}">
                     <div class="image">
                       <div class="cmp-image">
-                        <img ng-src="{{$ctrl.imgDomainDesignation + $ctrl.photoUrl(image).secondary}}"
+                        <img desig-img-src="{{$ctrl.photoUrl(image).secondary}}"
                              class="cmp-image__image"
                              itemprop="contentUrl"
                              data-cmp-hook-image="image">
                       </div>
                     </div>
                   </div>
-                  <div ng-if="$ctrl.images().length > 1" class="cmp-carousel__actions">
+                  <div ng-if="$ctrl.carouselImages.length > 1" class="cmp-carousel__actions">
                     <button class="cmp-carousel__action cmp-carousel__action--previous"
                             data-cmp-hook-carousel="previous"
                             aria-label="Previous">
@@ -106,14 +106,13 @@
                     </button>
                   </div>
                   <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
-                    <li ng-repeat="image in $ctrl.images()"
+                    <li ng-repeat="image in $ctrl.carouselImages"
                         role="tab" class="cmp-carousel__indicator {{$first ? 'cmp-carousel__indicator--active' : ''}}"
                         data-cmp-hook-carousel="indicator"
                         aria-selected="{{$first}}"
                         tabindex="{{$first ? '0' : '-1'}}"></li>
                   </ol>
                 </div>
-                {{$ctrl.carouselLoad()}}
               </div>
             </div>
           </div>
@@ -136,7 +135,7 @@
             <img ng-src="{{$ctrl.imgDomain}}/assets/img/signature.png"
                  ng-if="!$ctrl.photoUrl($ctrl.designationContent.signatureImage)"
                  class="signature-image">
-            <img ng-src="{{$ctrl.imgDomainDesignation + $ctrl.photoUrl($ctrl.designationContent.signatureImage).original}}"
+            <img desig-img-src="{{$ctrl.photoUrl($ctrl.designationContent.signatureImage).original}}"
                  ng-if="$ctrl.photoUrl($ctrl.designationContent.signatureImage)"
                  class="signature-image">
 

--- a/src/app/designationEditor/photoModal/photo.modal.js
+++ b/src/app/designationEditor/photoModal/photo.modal.js
@@ -1,15 +1,30 @@
 import angular from 'angular'
+import 'angular-environment'
 
+import loading from 'common/components/loading/loading.component'
 import imageUploadDirective from 'common/directives/imageUpload.directive'
 import designationEditorService from 'common/services/api/designationEditor.service'
+import imageCacheService from 'common/services/imageCache.service'
+import retryService from 'common/services/retry.service'
 
 const controllerName = 'photoCtrl'
 
 class ModalInstanceCtrl {
   /* @ngInject */
-  constructor ($timeout, designationNumber, campaignPage, photos, photoLocation, selectedPhoto, designationEditorService) {
+  constructor ($timeout, $interval, $http, $q, $window, designationEditorService, envService, imageCacheService, retryService, designationNumber, campaignPage, photos, photoLocation, selectedPhoto) {
     this.$timeout = $timeout
+    this.$interval = $interval
+    this.$http = $http
+    this.$q = $q
+    this.$window = $window
     this.designationEditorService = designationEditorService
+    this.imageCacheService = imageCacheService
+    this.retryService = retryService
+
+    this.imgDomain = envService.read('imgDomain')
+    this.numProcessingPhotos = 0
+    this.RETRY_DELAY_MS = 3000
+    this.MAX_RETRIES = 20
 
     this.designationNumber = designationNumber
     this.campaignPage = campaignPage
@@ -20,14 +35,52 @@ class ModalInstanceCtrl {
     this.maxNumberOfPhotos = 6
   }
 
-  uploadComplete () {
-    // refresh photos (set timeout to give Adobe time to add to DAM)
-    this.$timeout(() => {
-      this.designationEditorService.getPhotos(this.designationNumber).then((response) => {
-        this.photos = response.data
-        this.uploading = false
-      }, angular.noop)
-    }, 3500)
+  uploadComplete (response) {
+    this.uploading = false
+    ++this.numProcessingPhotos
+
+    this.refreshPhotos(new URL(response.headers('location'), this.$window.location).pathname).then((photos) => {
+      this.photos = photos
+    }, angular.noop).finally(() => {
+      --this.numProcessingPhotos
+    })
+  }
+
+  // ng-repeat needs an array to iterate over, so generate an array with one element per processing photo
+  getProcessingPhotos () {
+    return new Array(this.numProcessingPhotos).fill(undefined)
+  }
+
+  // Attempt to load a recently uploaded photo because newly uploaded photos will 404 for several seconds
+  // Rejects if a photo with the `original` URL can't be found
+  tryLoadUploadedPhoto (expectedUrl) {
+    return this.designationEditorService.getPhotos(this.designationNumber).then((response) => {
+      const photos = response.data
+      const photo = photos.find(entry => entry.original === expectedUrl)
+      if (!photo) {
+        // Not available yet
+        return this.$q.reject()
+      }
+
+      return {
+        expectedPhoto: photo,
+        allPhotos: photos
+      }
+    })
+  }
+
+  // Reload the photos until a photo with the URL `expectedUrl` exists
+  refreshPhotos (expectedUrl) {
+    // Step 1: Load the photos list until we find a photo with the original URL expectedUrl
+    // Step 2: Load the cover, secondary, and thumbnail URLs independently until each of them succeeds once
+    return this.executeWithRetries(() => this.tryLoadUploadedPhoto(expectedUrl)).then(({ expectedPhoto, allPhotos }) =>
+      this.$q.all([expectedPhoto.cover, expectedPhoto.original, expectedPhoto.secondary, expectedPhoto.thumbnail].map(url => this.imageCacheService.cache(url)))
+        .then(() => allPhotos)
+    )
+  }
+
+  executeWithRetries (execute) {
+    return this.retryService.executeWithRetries(execute, this.MAX_RETRIES, this.RETRY_DELAY_MS)
   }
 
   addImageToCarousel (photo) {
@@ -49,7 +102,11 @@ class ModalInstanceCtrl {
 
 export default angular
   .module(controllerName, [
+    'environment',
+    loading.name,
     imageUploadDirective.name,
-    designationEditorService.name
+    designationEditorService.name,
+    imageCacheService.name,
+    retryService.name
   ])
   .controller(controllerName, ModalInstanceCtrl)

--- a/src/app/designationEditor/photoModal/photoModal.spec.js
+++ b/src/app/designationEditor/photoModal/photoModal.spec.js
@@ -4,13 +4,19 @@ import module from './photo.modal'
 
 describe('Designation Editor Photo', function () {
   beforeEach(angular.mock.module(module.name))
-  var $rootScope, $ctrl, $q, $timeout
+  let $ctrl, $flushPendingTasks, $q, $verifyNoPendingTasks
 
-  beforeEach(inject(function (_$rootScope_, _$controller_, _$q_, _$timeout_) {
-    var $scope = _$rootScope_.$new()
-    $rootScope = _$rootScope_
-    $timeout = _$timeout_
+  beforeEach(angular.mock.module(($provide) => {
+    $provide.value('envService', {
+      read: () => 'https://img-domain.com'
+    })
+  }))
+
+  beforeEach(inject(function (_$rootScope_, _$controller_, _$flushPendingTasks_, _$q_, _$verifyNoPendingTasks_) {
+    const $scope = _$rootScope_.$new()
+    $flushPendingTasks = _$flushPendingTasks_
     $q = _$q_
+    $verifyNoPendingTasks = _$verifyNoPendingTasks_
 
     $ctrl = _$controller_(module.name, {
       designationNumber: '000555',
@@ -21,6 +27,10 @@ describe('Designation Editor Photo', function () {
       $scope: $scope
     })
   }))
+
+  afterEach(() => {
+    $verifyNoPendingTasks()
+  })
 
   it('to be defined', function () {
     expect($ctrl).toBeDefined()
@@ -34,17 +44,94 @@ describe('Designation Editor Photo', function () {
   })
 
   it('uploadComplete', function () {
-    let getPhotosPromise = $q.defer()
-    jest.spyOn($ctrl.designationEditorService, 'getPhotos').mockReturnValue(getPhotosPromise.promise)
+    const photos = [{
+      original: '/content/photo1.jpg'
+    }, {
+      original: '/content/photo2.jpg'
+    }, {
+      original: '/content/photo3.jpg'
+    }]
+    jest.spyOn($ctrl, 'refreshPhotos').mockReturnValueOnce($q.resolve(photos))
 
-    $ctrl.uploadComplete()
-    $timeout.flush()
+    $ctrl.uploadComplete({ headers: () => '/content/photo3.jpg' })
+    expect($ctrl.numProcessingPhotos).toBe(1)
 
-    getPhotosPromise.resolve({ data: [] })
-    $rootScope.$digest()
+    $flushPendingTasks()
+    expect($ctrl.numProcessingPhotos).toBe(0)
 
-    expect($ctrl.designationEditorService.getPhotos).toHaveBeenCalled()
-    expect($ctrl.photos).toEqual([])
+    expect($ctrl.refreshPhotos).toHaveBeenCalledWith('/content/photo3.jpg')
+    expect($ctrl.photos).toBe(photos)
+  })
+
+  it('getProcessingPhotos returns an array of processing photos', () => {
+    $ctrl.numProcessingPhotos = 3
+    expect($ctrl.getProcessingPhotos()).toHaveLength(3)
+  })
+
+  describe('tryLoadUploadedPhoto', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl.designationEditorService, 'getPhotos').mockReturnValueOnce($q.resolve({
+        data: [{
+          original: '/content/photo1.jpg'
+        }, {
+          original: '/content/photo2.jpg'
+        }]
+      }))
+    })
+
+    it('resolves if the photo is found', () => {
+      expect($ctrl.tryLoadUploadedPhoto('/content/photo1.jpg')).resolves.toEqual({
+        expectedPhoto: {
+          original: '/content/photo1.jpg'
+        },
+        allPhotos: [{
+          original: '/content/photo1.jpg'
+        }, {
+          original: '/content/photo2.jpg'
+        }]
+      })
+      $flushPendingTasks()
+    })
+
+    it('rejects if the photo is not found', () => {
+      expect($ctrl.tryLoadUploadedPhoto('/content/photo3.jpg')).rejects.toBeUndefined()
+      $flushPendingTasks()
+    })
+  })
+
+  it('refreshPhotos', () => {
+    jest.spyOn($ctrl, 'tryLoadUploadedPhoto').mockReturnValueOnce($q.resolve({
+      expectedPhoto: {
+        original: '/content/photo3.jpg',
+        cover: '/content/photo3.cover.jpg',
+        secondary: '/content/photo3.secondary.jpg',
+        thumbnail: '/content/photo3.thumbnail.jpg'
+      },
+      allPhotos: [{
+        original: '/content/photo1.jpg'
+      }, {
+        original: '/content/photo2.jpg'
+      }, {
+        original: '/content/photo3.jpg',
+        cover: '/content/photo3.cover.jpg',
+        secondary: '/content/photo3.secondary.jpg',
+        thumbnail: '/content/photo3.thumbnail.jpg'
+      }]
+    }))
+
+    jest.spyOn($ctrl.imageCacheService, 'cache').mockImplementation((url) => $q.resolve(`blob:${url}`))
+
+    expect($ctrl.refreshPhotos('/content/photo3.jpg')).resolves.toEqual([{
+      original: '/content/photo1.jpg'
+    }, {
+      original: '/content/photo2.jpg'
+    }, {
+      original: '/content/photo3.jpg',
+      cover: '/content/photo3.cover.jpg',
+      secondary: '/content/photo3.secondary.jpg',
+      thumbnail: '/content/photo3.thumbnail.jpg',
+    }])
+    $flushPendingTasks()
   })
 
   describe('addImageToCarousel(photo)', () => {

--- a/src/app/designationEditor/photoModal/photoModal.tpl.html
+++ b/src/app/designationEditor/photoModal/photoModal.tpl.html
@@ -17,9 +17,9 @@
           url="/bin/crugive/image.html?designationNumber={{$ctrl.designationNumber}}"
           on-invalid-file-type="$ctrl.invalidFileType = true"
           on-complete="$ctrl.invalidFileType = false"
-          on-upload="$ctrl.uploading = true"
-          on-success="$ctrl.uploadComplete(response)"
-          on-error="$ctrl.uploading = false"
+          on-upload="$ctrl.uploadStart(file)"
+          on-success="$ctrl.uploadComplete(response, file)"
+          on-error="$ctrl.uploadError(file)"
         />
       </div>
 
@@ -40,7 +40,8 @@
           <img desig-img-src="{{photo.thumbnail}}" />
         </label>
       </div>
-      <div class="cover-thumb" ng-repeat="photo in $ctrl.getProcessingPhotos() track by $index">
+      <div class="cover-thumb processing" ng-repeat="blobUrl in $ctrl.getProcessingPhotos() track by $index">
+        <img ng-src="{{blobUrl}}" />
         <loading type="centered">Processing...</loading>
       </div>
     </div>

--- a/src/app/designationEditor/photoModal/photoModal.tpl.html
+++ b/src/app/designationEditor/photoModal/photoModal.tpl.html
@@ -18,16 +18,16 @@
           on-invalid-file-type="$ctrl.invalidFileType = true"
           on-complete="$ctrl.invalidFileType = false"
           on-upload="$ctrl.uploading = true"
-          on-success="$ctrl.uploadComplete()"
+          on-success="$ctrl.uploadComplete(response)"
           on-error="$ctrl.uploading = false"
-        >
+        />
       </div>
 
       <label ng-if="$ctrl.uploading" translate>Uploading...</label>
     </div>
   </div>
 
-  <div class="give-available-photos-container" ng-if="$ctrl.photos.length">
+  <div class="give-available-photos-container" ng-if="$ctrl.photos.length || $ctrl.numProcessingPhotos > 0">
     <div class="give-thumbs-container">
       <div class="cover-thumb" ng-repeat="photo in $ctrl.photos">
         <input
@@ -37,8 +37,11 @@
           ng-value="photo.original"
         />
         <label for="cover-thumb{{$index}}">
-          <img ng-src="{{photo.thumbnail}}" />
+          <img desig-img-src="{{photo.thumbnail}}" />
         </label>
+      </div>
+      <div class="cover-thumb" ng-repeat="photo in $ctrl.getProcessingPhotos() track by $index">
+        <loading type="centered">Processing...</loading>
       </div>
     </div>
 

--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -302,6 +302,15 @@ hr.horizontal-divider {
       transform: translateY(-50%);
     }
   }
+  .cover-thumb.processing {
+    height: 98.25px;
+    object-fit: contain;
+    object-position: center;
+    overflow: hidden;
+  }
+  .cover-thumb.processing img {
+    opacity: 50%;
+  }
   .cover-thumb-remove {
     background: rgba(0, 0, 0, .5);
     border-radius: 100px;
@@ -555,7 +564,7 @@ hr.horizontal-divider {
 		label {
 			text-align: right;
 			padding: 0;
-			font-weight: normal;			
+			font-weight: normal;
 		}
 		input[type=checkbox], input[type=radio] {
 			margin-left: $gutter*.25;

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -38,7 +38,7 @@ const appConfig = /* @ngInject */ function (envServiceProvider, $compileProvider
       development: {
         apiUrl: 'https://give-stage2.cru.org',
         imgDomain: '',
-        imgDomainDesignation: 'https://give-stage2.cru.org',
+        imgDomainDesignation: 'https://localhost.cru.org:9000',
         publicCru: 'https://stage.cru.org',
         publicGive: 'https://give-stage2.cru.org',
         acsUrl: 'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey='

--- a/src/common/directives/desigImgSrc.directive.js
+++ b/src/common/directives/desigImgSrc.directive.js
@@ -1,0 +1,23 @@
+import angular from 'angular'
+
+import imageCacheService from '../services/imageCache.service'
+
+const directiveName = 'desigImgSrc'
+
+// Similar to ng-src, desig-img-src takes an image pathname (i.e. a URL without a domain), and sets the `src` attribute,
+// adding the designation image domain and also handling locally cached images
+const desigImgSrc = /* @ngInject */ (imageCacheService) => ({
+  restrict: 'A',
+  scope: {
+    src: '@desigImgSrc'
+  },
+  link: (scope, element) => {
+    scope.$watch('src', () => {
+      element.attr('src', imageCacheService.get(scope.src))
+    })
+  }
+})
+
+export default angular
+  .module(directiveName, [imageCacheService.name])
+  .directive(directiveName, desigImgSrc)

--- a/src/common/directives/desigImgSrc.directive.spec.js
+++ b/src/common/directives/desigImgSrc.directive.spec.js
@@ -1,0 +1,37 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './desigImgSrc.directive'
+
+describe('desigImgSrc', () => {
+  beforeEach(angular.mock.module(module.name))
+
+  beforeEach(angular.mock.module(($provide) => {
+    $provide.value('envService', {
+      read: () => 'https://cdn.domain.com'
+    })
+  }))
+
+  let $compile, $scope, imageCacheService
+  beforeEach(() => {
+    inject(($injector, $rootScope) => {
+      $scope = $rootScope.$new()
+      $compile = $injector.get('$compile')
+      imageCacheService = $injector.get('imageCacheService')
+    })
+  })
+
+  it('should set the src for pathname', () => {
+    const element = $compile('<img desig-img-src="/image.jpg" />')($scope)
+    $scope.$digest()
+    expect(element.attr('src')).toBe('https://cdn.domain.com/image.jpg')
+  })
+
+  it('should set the src for cached URLs', () => {
+    jest.spyOn(imageCacheService, 'get').mockReturnValue('blob:https://domain.com/uuid')
+
+    const element = $compile('<img desig-img-src="/image.jpg" />')($scope)
+    $scope.$digest()
+    expect(element.attr('src')).toBe('blob:https://domain.com/uuid')
+    expect(imageCacheService.get).toHaveBeenCalledWith('/image.jpg')
+  })
+})

--- a/src/common/directives/imageUpload.directive.js
+++ b/src/common/directives/imageUpload.directive.js
@@ -38,7 +38,7 @@ const imageUpload = /* @ngInject */ ($http) => ({
       }
 
       scope.$apply(() => {
-        scope.onUpload({ files })
+        scope.onUpload({ file })
       })
 
       const formData = new FormData()
@@ -52,11 +52,11 @@ const imageUpload = /* @ngInject */ ($http) => ({
         },
         data: formData
       }).then((response) => {
-        scope.onSuccess({ response })
-        scope.onComplete({ response })
+        scope.onSuccess({ response, file })
+        scope.onComplete({ response, file })
       }).catch((response) => {
-        scope.onError({ response })
-        scope.onComplete({ response })
+        scope.onError({ response, file })
+        scope.onComplete({ response, file })
       }
       )
     })

--- a/src/common/services/imageCache.service.js
+++ b/src/common/services/imageCache.service.js
@@ -26,7 +26,7 @@ class ImageCache {
 
   // Cache an image by its pathname and return a promise that resolves to its blob URL
   cache (url) {
-    return this.retryService.executeWithRetries(() => this.$http.get(this.makeAbsoluteUrl(url), { responseType: 'blob' }), 30, 0)
+    return this.retryService.executeWithRetries(() => this.$http.get(this.makeAbsoluteUrl(url), { responseType: 'blob' }), 30, 3000)
       .then(response => {
         const blob = URL.createObjectURL(response.data)
         this.blobCache.set(url, blob)

--- a/src/common/services/imageCache.service.js
+++ b/src/common/services/imageCache.service.js
@@ -1,0 +1,43 @@
+import angular from 'angular'
+import 'angular-environment'
+import retryService from './retry.service'
+
+const serviceName = 'imageCacheService'
+
+class ImageCache {
+  /* @ngInject */
+  constructor ($q, $http, envService, retryService) {
+    this.$q = $q
+    this.$http = $http
+    this.envService = envService
+    this.retryService = retryService
+    this.blobCache = new Map()
+  }
+
+  // Convert an image pathname into its absolute URL
+  makeAbsoluteUrl (url) {
+    return this.envService.read('imgDomainDesignation') + url
+  }
+
+  // Lookup an image pathname and return its blob URL if it is cached or its absolute URL otherwise
+  get (url) {
+    return this.blobCache.get(url) || this.makeAbsoluteUrl(url)
+  }
+
+  // Cache an image by its pathname and return a promise that resolves to its blob URL
+  cache (url) {
+    return this.retryService.executeWithRetries(() => this.$http.get(this.makeAbsoluteUrl(url), { responseType: 'blob' }), 30, 0)
+      .then(response => {
+        const blob = URL.createObjectURL(response.data)
+        this.blobCache.set(url, blob)
+        return blob
+      })
+  }
+}
+
+export default angular
+  .module(serviceName, [
+    'environment',
+    retryService.name
+  ])
+  .service(serviceName, ImageCache)

--- a/src/common/services/imageCache.service.spec.js
+++ b/src/common/services/imageCache.service.spec.js
@@ -1,0 +1,49 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './imageCache.service'
+
+describe('imageCacheService', () => {
+  beforeEach(angular.mock.module(module.name))
+
+  beforeEach(angular.mock.module(($provide) => {
+    $provide.value('envService', {
+      read: () => 'https://cdn.domain.com'
+    })
+  }))
+
+  let $flushPendingTasks, $httpBackend, $q, $verifyNoPendingTasks, imageCacheService
+  beforeEach(() => {
+    inject(($injector) => {
+      $flushPendingTasks = $injector.get('$flushPendingTasks')
+      $httpBackend = $injector.get('$httpBackend')
+      $q = $injector.get('$q')
+      $verifyNoPendingTasks = $injector.get('$verifyNoPendingTasks')
+      imageCacheService = $injector.get('imageCacheService')
+    })
+
+    $httpBackend.whenGET('https://cdn.domain.com/content/photo1.jpg').respond(200, 'content')
+
+    URL.createObjectURL = jest.fn().mockReturnValue('blob:url')
+  })
+
+  afterEach(() => {
+    $verifyNoPendingTasks()
+  })
+
+  it('loads a photo URL as a blob', () => {
+    expect(imageCacheService.cache('/content/photo1.jpg')).resolves.toBe('blob:url')
+    $httpBackend.flush()
+    $flushPendingTasks()
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith('content')
+  })
+
+  it('retrieves cached photos', () => {
+    imageCacheService.cache('/content/photo1.jpg')
+    $httpBackend.flush()
+    $flushPendingTasks()
+
+    expect(imageCacheService.get('/content/photo1.jpg')).toBe('blob:url')
+    expect(imageCacheService.get('/content/photo2.jpg')).toBe('https://cdn.domain.com/content/photo2.jpg')
+  })
+})

--- a/src/common/services/retry.service.js
+++ b/src/common/services/retry.service.js
@@ -1,0 +1,34 @@
+import angular from 'angular'
+
+const serviceName = 'retryService'
+
+class Retry {
+  /* @ngInject */
+  constructor ($q, $timeout) {
+    this.$q = $q
+    this.$timeout = $timeout
+  }
+
+  executeWithRetries (execute, maxRetries, retryDelay) {
+    return this.$q((resolve, reject) => {
+      let attempts = 0
+      const attempt = () => {
+        ++attempts
+
+        execute().then(resolve).catch((err) => {
+          if (attempts > maxRetries) {
+            reject(err)
+          } else {
+            this.$timeout(attempt, retryDelay)
+          }
+        })
+      }
+
+      attempt()
+    })
+  }
+}
+
+export default angular
+  .module(serviceName, [])
+  .service(serviceName, Retry)

--- a/src/common/services/retry.service.spec.js
+++ b/src/common/services/retry.service.spec.js
@@ -1,0 +1,54 @@
+import angular from 'angular'
+import 'angular-mocks'
+import module from './retry.service'
+
+describe('retryService', () => {
+  beforeEach(angular.mock.module(module.name))
+
+  let $flushPendingTasks, $q, $verifyNoPendingTasks, retryService
+  beforeEach(() => {
+    inject(($injector) => {
+      $flushPendingTasks = $injector.get('$flushPendingTasks')
+      $q = $injector.get('$q')
+      $verifyNoPendingTasks = $injector.get('$verifyNoPendingTasks')
+      retryService = $injector.get('retryService')
+    })
+  })
+
+  afterEach(() => {
+    $verifyNoPendingTasks()
+  })
+
+  it('retries then succeeds', () => {
+    const execute = jest.fn()
+      .mockReturnValueOnce($q.reject(new Error('Failed')))
+      .mockReturnValueOnce($q.resolve(true))
+
+    expect(retryService.executeWithRetries(execute, 3, 100)).resolves.toBe(true)
+    $flushPendingTasks()
+    $flushPendingTasks()
+    expect(execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries the right number of times', () => {
+    const execute = jest.fn().mockImplementation(() => $q.reject(new Error('Failed')))
+
+    expect(retryService.executeWithRetries(execute, 3, 100)).rejects.toThrow('Failed')
+    $flushPendingTasks()
+    $flushPendingTasks()
+    $flushPendingTasks()
+    $flushPendingTasks()
+    expect(execute).toHaveBeenCalledTimes(4)
+  })
+
+  it('rejects with the last error after running out of attempts', () => {
+    let attempt = 0
+    const execute = jest.fn().mockImplementation(() => $q.reject(new Error(`Failure ${++attempt}}`)))
+
+    expect(retryService.executeWithRetries(execute, 3, 100)).rejects.toThrow('Failure 4')
+    $flushPendingTasks()
+    $flushPendingTasks()
+    $flushPendingTasks()
+    $flushPendingTasks()
+  })
+})


### PR DESCRIPTION
Adds several improvements to the image upload flow.

* Locally caches uploaded images so that they can be displayed while AEM is still replicating them
* Updates the carousel after the selected images change

When testing, inspect the `<img>` tag of newly-uploaded images in the upload modal and on the page. The `src` should start with `blob:` instead of being a normal URL. When you manually refresh the page all the images should be normal URLs.

Tested in staging ✅