### PR TITLE
[no-Jira] Hide welcome back message when name is missing

### DIFF
--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -5,7 +5,7 @@
     <hr class="horizontal-divider"/>
     <h4 class="text-center" translate>If you already have a Cru username, use it to sign in so we can link it to your giving</h4>
   </div>
-  <p ng-if="$ctrl.identified" class="text-center">
+  <p ng-if="$ctrl.identified && $ctrl.sessionService.session.first_name && $ctrl.sessionService.session.last_name" class="text-center">
     <strong>Welcome back, {{$ctrl.sessionService.session.first_name}} {{$ctrl.sessionService.session.last_name}}!</strong>
   </p>
   <sign-in-form on-success="$ctrl.onSuccess()" last-purchase-id="$ctrl.lastPurchaseId"></sign-in-form>


### PR DESCRIPTION
Hide the "Welcome back" message when the first and last name are missing from the `cru-profile` cookie because otherwise it shows as "Welcome back !"

HelpScout issue: https://secure.helpscout.net/conversation/2224911680/932874?folderId=7296729

Cherry-picked from `EP-2362-okta-login`

Tested in staging ✅