### PR TITLE
Reword branded checkout device id instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The `<branded-checkout>` element is where the branded checkout Angular app will 
 1. Figure out what domain you will be hosting the branded checkout form on. For example, `myministry.org`
 2. Make sure HTTPS is enabled on that domain
 3. You will need to setup a subdomain for the give.cru.org API. We've experienced cross-domain cookie issues trying to hit the give.cru.org API directly from a custom domain. Create a CNAME record for `brandedcheckout.myministry.org` (the subdomain could be different but using that suggested subdomain makes it consistent with other sites) and point it at `give-site-production-alb-1251385984.us-east-1.elb.amazonaws.com`.
-4. In order to accept credit cards on your own domain, you will need to setup a TSYS merchant account. Contact the Cru's Financial Services Group ([hazel.mcpherson@cru.org](mailto:hazel.mcpherson@cru.org)) if you don't already have one. You will need a TSYS device id (a numeric id around 14 digits) to complete step 6.
+4. In order to accept credit cards on your own domain, you will need a new TSYS device id (a numeric id around 14 digits) associated with one of our Merchant Accounts. Contact the Cru's Financial Services Group ([hazel.mcpherson@cru.org](mailto:hazel.mcpherson@cru.org)) and request one. You will use the device id to complete step 6.
 5. To prepare for the next step, think of a unique identifier like `"jesusfilm"` or `"aia"` that uniquely identifies your ministry and domain. We can create this for you but we need enough information about your ministry to do so.
 6. Once you have completed the steps above, contact Cru's Digital Products and Services (DPS) department ([help@cru.org](mailto:help@cru.org)). Below is an example email: (replace the `{{}}`s with the info for your site)
 


### PR DESCRIPTION
Previously, the instructions made it sound like a new merchant account was needed. It's not. In most cases, Cru's main merchant account should be reused for the new device id.

This came out of a conversation I had with Steve Hackney regarding Story Runner's desire for branded checkout on their site.