### PR TITLE
[no-jira] Handle missing secondaryPhotos

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -306,7 +306,7 @@ class DesignationEditorController {
     return this.designationEditorService.save(this.designationContent, this.designationNumber, this.campaignPage).then(() => {
       this.saveStatus = 'success'
       this.loadingOverlay = false
-      this.carouselImages = this.designationContent.secondaryPhotos
+      this.carouselImages = this.designationContent.secondaryPhotos || []
       this.updateCarousel()
     }, error => {
       this.saveStatus = 'failure'


### PR DESCRIPTION
When a user has never added a carousel photo before, `secondaryPhotos` will be undefined, so default it to an empty array.