### PR TITLE
EP-2402 - Use right form

### DIFF
--- a/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
+++ b/src/common/services/api/fixtures/cortex-profile-paymentmethods-forms.fixture.js
@@ -1,8 +1,8 @@
 export default {
   self: {
     type: 'elasticpath.profiles.profile',
-    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform',
-    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform'
+    uri: '/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:selfservicepaymentinstrumentform',
+    href: 'https://give-stage2.cru.org/cortex/profiles/crugive/gnrdkojsge4dsljxhazwmljugmztillcgu3gkljqgm3tkytdmm3dmzrxme=?zoom=paymentmethods:element,paymentmethods:element:selfservicepaymentinstrumentform'
   },
   links: [{
     rel: 'addresses',
@@ -67,22 +67,23 @@ export default {
       },
       messages: [],
       links: [],
-      _paymentinstrumentform: [{
+      _selfservicepaymentinstrumentform: [{
         self: {
-          type: 'paymentinstruments.profile-payment-instrument-form',
-          uri: '/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form',
-          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+          type: 'selfservicepaymentinstruments.profile-self-service-payment-instrument-form',
+          uri: '/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/selfservicepaymentinstrument/form',
+          href: 'https://give-stage2.cru.og/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/selfservicepaymentinstrument/form'
         },
         messages: [],
         links: [{
           rel: 'createpaymentinstrumentaction',
-          type: 'paymentinstruments.profile-payment-instrument-form',
-          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form'
+          type: 'selfservicepaymentinstruments.profile-self-service-payment-instrument-form',
+          href: 'https://give-stage2.cru.og/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/selfservicepaymentinstrument/form'
         }],
         'default-on-profile': false,
         'payment-instrument-identification-form': {
           'account-type': '',
           'bank-name': '',
+          'display-name': '',
           'encrypted-account-number': '',
           'routing-number': ''
         }
@@ -98,17 +99,17 @@ export default {
       },
       messages: [],
       links: [],
-      _paymentinstrumentform: [{
+      _selfservicepaymentinstrumentform: [{
         self: {
-          type: 'paymentinstruments.profile-payment-instrument-form',
-          uri: '/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form',
-          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+          type: 'selfservicepaymentinstruments.profile-self-service-payment-instrument-form',
+          uri: '/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/selfservicepaymentinstrument/form',
+          href: 'https://give-stage2.cru.og/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/selfservicepaymentinstrument/form'
         },
         messages: [],
         links: [{
           rel: 'createpaymentinstrumentaction',
-          type: 'paymentinstruments.profile-payment-instrument-form',
-          href: 'https://give-stage2.cru.og/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form'
+          type: 'selfservicepaymentinstruments.profile-self-service-payment-instrument-form',
+          href: 'https://give-stage2.cru.og/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/selfservicepaymentinstrument/form'
         }],
         'billing-address': {
           address: {

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -249,14 +249,14 @@ class Profile {
       return this.cortexApiService.get({
         path: ['profiles', this.cortexApiService.scope, 'default'],
         zoom: {
-          paymentMethodForms: 'paymentmethods:element[],paymentmethods:element:paymentinstrumentform'
+          paymentMethodForms: 'paymentmethods:element[],paymentmethods:element:selfservicepaymentinstrumentform'
         }
       })
         .do((data) => {
           this.paymentMethodForms = data
 
           angular.forEach(this.paymentMethodForms, paymentMethodForm => {
-            if (!this.hateoasHelperService.getLink(paymentMethodForm.paymentinstrumentform, 'createpaymentinstrumentaction')) {
+            if (!this.hateoasHelperService.getLink(paymentMethodForm.selfservicepaymentinstrumentform, 'createpaymentinstrumentaction')) {
               this.$log.warn('Payment form request contains empty link', data)
             }
           })
@@ -301,8 +301,8 @@ class Profile {
   determinePaymentMethodFormLink (data, fieldName) {
     let link = ''
     angular.forEach(data.paymentMethodForms, paymentMethodForm => {
-      if (paymentMethodForm.paymentinstrumentform['payment-instrument-identification-form'][fieldName] !== undefined) {
-        link = this.hateoasHelperService.getLink(paymentMethodForm.paymentinstrumentform, 'createpaymentinstrumentaction')
+      if (paymentMethodForm.selfservicepaymentinstrumentform['payment-instrument-identification-form'][fieldName] !== undefined) {
+        link = this.hateoasHelperService.getLink(paymentMethodForm.selfservicepaymentinstrumentform, 'createpaymentinstrumentaction')
       }
     })
     return link

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -25,8 +25,8 @@ import cartResponse from './fixtures/cortex-cart-paymentmethodinfo-forms.fixture
 
 const paymentMethodForms = cloneDeep(paymentmethodsFormsResponse._paymentmethods[0]._element)
 angular.forEach(paymentMethodForms, form => {
-  form.paymentinstrumentform = form._paymentinstrumentform[0]
-  delete form._paymentinstrumentform
+  form.selfservicepaymentinstrumentform = form._selfservicepaymentinstrumentform[0]
+  delete form._selfservicepaymentinstrumentform
 })
 
 const paymentmethodsFormsResponseZoomMapped = {
@@ -135,7 +135,7 @@ describe('profile service', () => {
 
   describe('getPaymentMethodForms', () => {
     function setupRequest () {
-      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=paymentmethods:element,paymentmethods:element:paymentinstrumentform')
+      self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=paymentmethods:element,paymentmethods:element:selfservicepaymentinstrumentform')
         .respond(200, paymentmethodsFormsResponse)
     }
 
@@ -175,7 +175,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/paymentinstrument/form?FollowLocation=true',
+        'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/gftgenrymm4dgllega2geljug44dillcga3dollbhe2wcnbugazdgobqgy=/selfservicepaymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -208,7 +208,7 @@ describe('profile service', () => {
       delete expectedPostData['payment-instrument-identification-form'].cvv
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
+        'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/selfservicepaymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 
@@ -262,7 +262,7 @@ describe('profile service', () => {
       }
 
       self.$httpBackend.expectPOST(
-        'https://give-stage2.cru.org/cortex/paymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/paymentinstrument/form?FollowLocation=true',
+        'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/paymentmethods/profiles/crugive/mm3gkodgmztgcljtgm2dsljumu2teljygi2weljzgjsdomryha3tkzrymu=/g4ygeodbg42tilldha4wiljrgfswellbgvsdmllfgu4wenjxmu2ton3bgm=/selfservicepaymentinstrument/form?FollowLocation=true',
         expectedPostData
       ).respond(200, 'success')
 


### PR DESCRIPTION
We were using the out of the box payment instrument creation form, which did not send the payment instrument to Siebel. [Companion PR](https://github.com/CruGlobal/give-ep-commerce/pull/151)