### PR TITLE
Missed some things when retaining Google Analytics query parameters

### DIFF
--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.js
@@ -13,11 +13,12 @@ const componentName = 'productConfigModal'
 
 class ProductConfigModalController {
   /* @ngInject */
-  constructor ($window, $location, modalStateService, designationsService) {
+  constructor ($window, $location, modalStateService, designationsService, cartService) {
     this.$window = $window
     this.$location = $location
     this.modalStateService = modalStateService
     this.designationsService = designationsService
+    this.cartService = cartService
   }
 
   $onInit () {
@@ -111,10 +112,14 @@ class ProductConfigModalController {
         this.close()
 
         if (this.isMobile && !this.isEdit) {
-          this.$window.location = '/cart.html'
+          this.$window.location = `/${this.cartService.buildCartUrl()}`
         }
         break
     }
+  }
+
+  buildCartUrl () {
+    return `/${this.cartService.buildCartUrl()}`
   }
 }
 

--- a/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.component.spec.js
@@ -25,6 +25,9 @@ describe('product config modal', function () {
         },
         designationsService: {
           suggestedAmounts: jest.fn()
+        },
+        cartService: {
+          buildCartUrl: jest.fn()
         }
       },
       {
@@ -221,6 +224,25 @@ describe('product config modal', function () {
 
       expect($ctrl.close).toHaveBeenCalled()
       expect($ctrl.$window.location).toEqual('/cart.html')
+    })
+
+    it('should go to the cart page if mobile and state is submitted', () => {
+      $ctrl.$window.location = '/search-results.html'
+      $ctrl.isMobile = true
+      $ctrl.isEdit = false
+      jest.spyOn($ctrl.cartService, 'buildCartUrl').mockImplementationOnce(() => 'cart.html?two=2')
+      $ctrl.onStateChange('submitted')
+
+      expect($ctrl.close).toHaveBeenCalled()
+      expect($ctrl.$window.location).toEqual('/cart.html?two=2')
+    })
+  })
+
+  describe('buildCartUrl', () => {
+    it('should return the cart url ', () => {
+      jest.spyOn($ctrl.cartService, 'buildCartUrl').mockImplementationOnce(() => 'cart.html?one=1')
+      const cartUrl = $ctrl.buildCartUrl()
+      expect(cartUrl).toEqual('/cart.html?one=1')
     })
   })
 })

--- a/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
+++ b/src/app/productConfig/productConfigModal/productConfig.modal.tpl.html
@@ -41,7 +41,7 @@
             type="button"
             tabindex="-1"
             ng-if="$ctrl.state === 'errorAlreadyInCart'"
-            ng-click="$ctrl.close(); $ctrl.$window.location = '/cart.html'"
+            ng-click="$ctrl.close(); $ctrl.$window.location = $ctrl.buildCartUrl()"
             translate>
       View Cart
     </button>

--- a/src/common/services/api/cart.service.js
+++ b/src/common/services/api/cart.service.js
@@ -236,7 +236,14 @@ class Cart {
   }
 
   buildCartUrl () {
-    return `cart.html${this.$window.location.search}`
+    const url = new URL(this.$window.location.href)
+    const queryParameters = url.searchParams
+    const parametersToDelete = ['modal', 'd', 'a', 'q']
+    parametersToDelete.forEach((parameterToDelete) => {
+      queryParameters.delete(parameterToDelete)
+    })
+
+    return queryParameters.toString() ? `cart.html?${queryParameters.toString()}` : 'cart.html'
   }
 }
 

--- a/src/common/services/api/cart.service.spec.js
+++ b/src/common/services/api/cart.service.spec.js
@@ -394,13 +394,33 @@ describe('cart service', () => {
   })
 
   describe('buildCartUrl', () => {
+    const queryParametersToKeep = '?one=1&two=2'
+    const urlWithParameters = `cart.html${queryParametersToKeep}`
+
+    beforeEach(() => {
+      self.cartService.$window.location.href = 'https://give-stage2.cru.org'
+    })
+
     it('should build a url without query parameters', () => {
       expect(self.cartService.buildCartUrl()).toEqual('cart.html')
     })
 
     it('should build a url with query parameters', () => {
-      self.cartService.$window.location.search = '?one=1&two=2'
-      expect(self.cartService.buildCartUrl()).toEqual('cart.html?one=1&two=2')
+      self.cartService.$window.location.search = queryParametersToKeep
+      self.cartService.$window.location.href += self.cartService.$window.location.search
+      expect(self.cartService.buildCartUrl()).toEqual(urlWithParameters)
+    })
+
+    it('should filter out certain query parameters', () => {
+      self.cartService.$window.location.search = `${queryParametersToKeep}&modal=give-gift&d=0123456&a=50`
+      self.cartService.$window.location.href += self.cartService.$window.location.search
+      expect(self.cartService.buildCartUrl()).toEqual(urlWithParameters)
+    })
+
+    it('should filter out a subset of query parameters', () => {
+      self.cartService.$window.location.search = `${queryParametersToKeep}&q=0123456&d=0123456&a=50`
+      self.cartService.$window.location.href += self.cartService.$window.location.search
+      expect(self.cartService.buildCartUrl()).toEqual(urlWithParameters)
     })
   })
 })


### PR DESCRIPTION
On mobile, the product config modal goes straight to the cart page. I did not handle this link for keeping query parameters when doing #1036.