### PR TITLE
EP-2431 - Fix duplicate phone display

### DIFF
--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -199,6 +199,7 @@ class ProfileController {
     this.profileService.getPhoneNumbers()
       .subscribe(
         data => {
+          this.phoneNumbers = []
           this.phonesLoading = false
           angular.forEach(data, (item) => {
             item.ownerChanged = false

--- a/src/app/profile/profile.component.spec.js
+++ b/src/app/profile/profile.component.spec.js
@@ -490,6 +490,19 @@ describe('ProfileComponent', function () {
       expect($ctrl.phoneNumberError).toBe('loading')
       expect($ctrl.profileService.getPhoneNumbers).toHaveBeenCalled()
     })
+
+    it('should properly handle cache', () => {
+      const onlyPhoneNumber = {
+        'phone-number': '555-555-5555',
+        'phone-number-type': 'Mobile',
+        primary: true,
+        'is-spouse': false
+      }
+      jest.spyOn($ctrl.profileService, 'getPhoneNumbers').mockReturnValue(Observable.of([onlyPhoneNumber]))
+      $ctrl.phoneNumbers = [onlyPhoneNumber]
+      $ctrl.loadPhoneNumbers()
+      expect($ctrl.phoneNumbers.length).toEqual(1)
+    })
   })
 
   describe('addPhoneNumber()', () => {


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2431)

The problem was that in certain circumstances (maybe involving cookies), the login box would come up again (`$onInit` called) but the constructor is not called. This leaves the prior loaded phone numbers in the array, then we just push to it again. The fix here just empties the array right before loading the phone numbers from the API. It does not seem to cause issues with adding phone numbers.