### PR TITLE
EP-2439 - Fix name swap

### DIFF
--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -10,8 +10,10 @@ const componentName = 'signInForm'
 
 class SignInFormController {
   /* @ngInject */
-  constructor ($log, sessionService, gettext) {
+  constructor ($log, $document, sessionService, gettext) {
     this.$log = $log
+    this.$document = $document
+    this.$injector = angular.injector()
     this.sessionService = sessionService
     this.gettext = gettext
   }
@@ -31,6 +33,12 @@ class SignInFormController {
     this.sessionService
       .signIn(this.username, this.password, this.mfa_token, this.trust_device, this.lastPurchaseId)
       .subscribe(() => {
+        const $injector = this.$injector
+        if (!$injector.has('sessionService')) {
+          $injector.loadNewModules(['sessionService'])
+        }
+        this.$document[0].body.dispatchEvent(
+          new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
         this.onSuccess()
       }, error => {
         this.isSigningIn = false

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -16,7 +16,16 @@ describe('signInForm', function () {
     $rootScope = _$rootScope_
     bindings = {
       onSuccess: jest.fn(),
-      onFailure: jest.fn()
+      onFailure: jest.fn(),
+      $document: [{
+        body: {
+          dispatchEvent: jest.fn()
+        }
+      }],
+      $injector: {
+        has: jest.fn(),
+        loadNewModules: jest.fn()
+      }
     }
 
     $ctrl = _$componentController_(module.name, {}, bindings)
@@ -79,8 +88,24 @@ describe('signInForm', function () {
       it('signs in successfully', () => {
         deferred.resolve({})
         $rootScope.$digest()
+        bindings.$injector.has.mockImplementation(() => true)
+        const $injector = bindings.$injector
 
         expect(bindings.onSuccess).toHaveBeenCalled()
+        expect(bindings.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
+          new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
+      })
+
+      it('adds the sessionService module', () => {
+        deferred.resolve({})
+        $rootScope.$digest()
+        bindings.$injector.has.mockImplementation(() => false)
+        bindings.$injector.loadNewModules.mockImplementation(() => {})
+        const $injector = bindings.$injector
+
+        expect($injector.loadNewModules).toHaveBeenCalledWith(['sessionService'])
+        expect(bindings.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
+          new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
       })
 
       it('requires multi-factor', () => {

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -18,9 +18,11 @@ const componentName = 'sessionModal'
 
 class SessionModalController {
   /* @ngInject */
-  constructor (sessionService, analyticsFactory) {
+  constructor (sessionService, analyticsFactory, $document) {
     this.sessionService = sessionService
     this.analyticsFactory = analyticsFactory
+    this.$document = $document
+    this.$injector = angular.injector()
     this.isLoading = false
     this.scrollModalToTop = scrollModalToTop
   }
@@ -36,6 +38,12 @@ class SessionModalController {
   }
 
   onSignInSuccess () {
+    const $injector = this.$injector
+    if (!$injector.has('sessionService')) {
+      $injector.loadNewModules(['sessionService'])
+    }
+    this.$document[0].body.dispatchEvent(
+      new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
     this.close()
   }
 

--- a/src/common/services/session/sessionModal.component.spec.js
+++ b/src/common/services/session/sessionModal.component.spec.js
@@ -15,7 +15,16 @@ describe('sessionModalController', function () {
           lastPurchaseId: '<some id>'
         },
         close: jest.fn(),
-        dismiss: jest.fn()
+        dismiss: jest.fn(),
+        $document: [{
+          body: {
+            dispatchEvent: jest.fn()
+          }
+        }],
+        $injector: {
+          has: jest.fn(),
+          loadNewModules: jest.fn()
+        }
       })
   }))
 
@@ -46,9 +55,24 @@ describe('sessionModalController', function () {
 
   describe('$ctrl.onSignInSuccess', () => {
     it('should close modal', () => {
+      $ctrl.$injector.has.mockImplementation(() => true)
       $ctrl.onSignInSuccess()
+      const $injector = $ctrl.$injector
 
       expect($ctrl.close).toHaveBeenCalled()
+      expect($ctrl.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
+        new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
+    })
+
+    it('should add the sessionService module', () => {
+      $ctrl.$injector.has.mockImplementation(() => false)
+      $ctrl.$injector.loadNewModules.mockImplementation(() => {})
+      $ctrl.onSignInSuccess()
+      const $injector = $ctrl.$injector
+
+      expect($injector.loadNewModules).toHaveBeenCalledWith(['sessionService'])
+      expect($ctrl.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
+        new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
     })
   })
 


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2439)

When logging in from the top navigation `Sign In` link, the `Sign In` wording changes to the user's name, but when logging in via the self-service page navigation, it does not work. This is because the AEM side is listening for the `giveloaded` event, which is not fired when login is successful. It fires before the login, but not after. This PR is adding an event that AEM will be listening for to do the same wording swap. Strictly speaking, I'm not sure if/when the sessionModal component code is called, it wasn't in my testing. If we want, I can remove that part of this PR.