### PR TITLE
EP-2440 - Fix next draw date

### DIFF
--- a/src/common/services/api/common.service.js
+++ b/src/common/services/api/common.service.js
@@ -16,7 +16,7 @@ class Common {
       path: ['nextdrawdate'],
       cache: true
     })
-      .pluck('next-draw-date')
+      .pluck('next-draw-date', 'string')
   }
 }
 

--- a/src/common/services/api/common.service.spec.js
+++ b/src/common/services/api/common.service.spec.js
@@ -20,7 +20,11 @@ describe('common service', () => {
   describe('getNextDrawDate', () => {
     it('should get next draw date', () => {
       self.$httpBackend.expectGET('https://give-stage2.cru.org/cortex/nextdrawdate')
-        .respond(200, { 'next-draw-date': '2016-10-01' })
+        .respond(200, { 'next-draw-date': {
+            chars: '2016-10-01',
+            string: '2016-10-01',
+            valueType: 'STRING'
+          } })
       self.commonService.getNextDrawDate().subscribe(date => {
         expect(date).toEqual('2016-10-01')
       })


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2440)
Fix the handling of next draw date.

Old JSON:
```
{
  "2023-08-22"
}
```

New JSON:
```
{
  "chars": "2023-08-22",
  "string": "2023-08-22",
  "valueType": "STRING"
}
```