### PR TITLE
Filter suggestedAmounts to remove zero amounts or empty objects

### DIFF
--- a/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
+++ b/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
@@ -12,7 +12,7 @@ class ModalInstanceCtrl {
     this.facebookPixelId = facebookPixelId
 
     this.suggestedAmounts = transform(suggestedAmounts, (result, value, key) => {
-      if (key === 'jcr:primaryType') { return }
+      if (key === 'jcr:primaryType' || !value?.amount) return;
       result.push({
         amount: Number(value.amount),
         description: value.description,
@@ -23,10 +23,9 @@ class ModalInstanceCtrl {
   }
 
   transformSuggestedAmounts () {
-    const onlyAmountsWithValue = this.suggestedAmounts.filter((amount) => amount?.amount);
-    return transform(onlyAmountsWithValue, (result, value, i) => {
+    const filterOutZeroAmounts = this.suggestedAmounts.filter((amount) => amount?.amount);
+    return transform(filterOutZeroAmounts, (result, value, i) => {
       delete value.order
-      value.amount = value.amount || 0
       result[i + 1] = value
     }, {})
   }

--- a/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
+++ b/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
@@ -23,7 +23,8 @@ class ModalInstanceCtrl {
   }
 
   transformSuggestedAmounts () {
-    return transform(this.suggestedAmounts, (result, value, i) => {
+    const onlyAmountsWithValue = this.suggestedAmounts.filter((amount) => amount?.amount);
+    return transform(onlyAmountsWithValue, (result, value, i) => {
       delete value.order
       value.amount = value.amount || 0
       result[i + 1] = value

--- a/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
+++ b/src/app/designationEditor/pageOptionsModal/pageOptions.modal.js
@@ -12,7 +12,7 @@ class ModalInstanceCtrl {
     this.facebookPixelId = facebookPixelId
 
     this.suggestedAmounts = transform(suggestedAmounts, (result, value, key) => {
-      if (key === 'jcr:primaryType' || !value?.amount) return;
+      if (key === 'jcr:primaryType' || !value?.amount) return
       result.push({
         amount: Number(value.amount),
         description: value.description,
@@ -23,7 +23,7 @@ class ModalInstanceCtrl {
   }
 
   transformSuggestedAmounts () {
-    const filterOutZeroAmounts = this.suggestedAmounts.filter((amount) => amount?.amount);
+    const filterOutZeroAmounts = this.suggestedAmounts.filter((amount) => amount?.amount)
     return transform(filterOutZeroAmounts, (result, value, i) => {
       delete value.order
       result[i + 1] = value

--- a/src/app/designationEditor/pageOptionsModal/pageOptions.spec.js
+++ b/src/app/designationEditor/pageOptionsModal/pageOptions.spec.js
@@ -15,7 +15,9 @@ describe('Designation Editor Page Options', function () {
       facebookPixelId: '635334562464',
       suggestedAmounts: { 'jcr:primaryType': 'nt:unstructured',
         1: { 'jcr:primaryType': 'nt:unstructured', description: '1 Bible', amount: 100 },
-        2: { 'jcr:primaryType': 'nt:unstructured', description: '2 Bibles', amount: 200 } },
+        2: { 'jcr:primaryType': 'nt:unstructured', description: '2 Bibles', amount: 200 },
+        3: { 'jcr:primaryType': 'nt:unstructured', description: '2 Bibles', amount: 0 },
+        4: {  }, },
       $scope: $scope
     })
   }))
@@ -42,4 +44,24 @@ describe('Designation Editor Page Options', function () {
       2: { amount: 200, description: '2 Bibles' }
     })
   })
+
+  it('should remove zero or empty objects', function () {
+    $ctrl.suggestedAmounts.push({
+      amount: 0,
+      description: '3 Bibles',
+    });
+    $ctrl.suggestedAmounts.push({
+      amount: 400,
+      description: '4 Bibles',
+    });
+    $ctrl.suggestedAmounts.push({ description: '5 Bibles' });
+
+    expect($ctrl.transformSuggestedAmounts()).toEqual({
+      1: { amount: 100, description: '1 Bible' },
+      2: { amount: 200, description: '2 Bibles' },
+      3: { amount: 400, description: '4 Bibles' }
+    })
+  })
+
+
 })

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -138,7 +138,7 @@ class ProductConfigFormController {
 
     const suggestedAmountsObservable = this.designationsService.suggestedAmounts(this.code, this.itemConfig)
       .do(suggestedAmounts => {
-        this.suggestedAmounts = suggestedAmounts
+        this.suggestedAmounts = suggestedAmounts.filter((amount) => amount?.amount);
         this.useSuggestedAmounts = !isEmpty(this.suggestedAmounts)
       })
 
@@ -173,7 +173,7 @@ class ProductConfigFormController {
     const amountOptions = isEmpty(this.suggestedAmounts)
       ? this.selectableAmounts
       : map(this.suggestedAmounts, 'amount')
-
+      
     if (this.itemConfig.amount) {
       if (amountOptions.indexOf(this.itemConfig.amount) === -1) {
         this.changeCustomAmount(this.itemConfig.amount)

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -138,7 +138,7 @@ class ProductConfigFormController {
 
     const suggestedAmountsObservable = this.designationsService.suggestedAmounts(this.code, this.itemConfig)
       .do(suggestedAmounts => {
-        this.suggestedAmounts = suggestedAmounts.filter((amount) => amount?.amount);
+        this.suggestedAmounts = suggestedAmounts.filter((amount) => amount?.amount)
         this.useSuggestedAmounts = !isEmpty(this.suggestedAmounts)
       })
 
@@ -173,7 +173,7 @@ class ProductConfigFormController {
     const amountOptions = isEmpty(this.suggestedAmounts)
       ? this.selectableAmounts
       : map(this.suggestedAmounts, 'amount')
-      
+
     if (this.itemConfig.amount) {
       if (amountOptions.indexOf(this.itemConfig.amount) === -1) {
         this.changeCustomAmount(this.itemConfig.amount)

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -161,7 +161,7 @@ describe('product config form component', function () {
 
       jest.spyOn($ctrl.commonService, 'getNextDrawDate').mockReturnValue(Observable.of('2016-10-02'))
 
-      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 5 }, { amount: 10 }]))
+      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 5 }, { amount: 10 }, , { amount: 0 }, , { }]))
 
       jest.spyOn($ctrl.designationsService, 'givingLinks').mockReturnValue(Observable.of([]))
       jest.spyOn($ctrl.analyticsFactory, 'giveGiftModal').mockReturnValue(() => {})
@@ -228,6 +228,19 @@ describe('product config form component', function () {
       expect($ctrl.onStateChange).toHaveBeenCalledWith({ state: 'errorLoading' })
       expect($ctrl.$log.error.logs[0]).toEqual(['Error loading data for product config form', 'some error'])
       expect($ctrl.loading).toEqual(false)
+    })
+  })
+
+
+  describe('loadData but suggestedAmounts only has 0 amounts or empty objects', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 0 }, , { }]))
+    })
+
+    it('should use default amounts', () => {
+      $ctrl.loadData()
+      expect($ctrl.suggestedAmounts).toEqual([])
+      expect($ctrl.useSuggestedAmounts).toEqual(false)
     })
   })
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -161,7 +161,7 @@ describe('product config form component', function () {
 
       jest.spyOn($ctrl.commonService, 'getNextDrawDate').mockReturnValue(Observable.of('2016-10-02'))
 
-      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 5 }, { amount: 10 }, , { amount: 0 }, , { }]))
+      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 5 }, { amount: 10 }, { amount: 0 }, { }]))
 
       jest.spyOn($ctrl.designationsService, 'givingLinks').mockReturnValue(Observable.of([]))
       jest.spyOn($ctrl.analyticsFactory, 'giveGiftModal').mockReturnValue(() => {})
@@ -234,7 +234,7 @@ describe('product config form component', function () {
 
   describe('loadData but suggestedAmounts only has 0 amounts or empty objects', () => {
     beforeEach(() => {
-      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 0 }, , { }]))
+      jest.spyOn($ctrl.designationsService, 'suggestedAmounts').mockReturnValue(Observable.of([{ amount: 0 }, { }]))
     })
 
     it('should use default amounts', () => {


### PR DESCRIPTION
## Description
Ensuring we do not show zero amounts on giving modal and we show the detail amounts if all suggested amounts are zero.


## Changes
- When saving suggested amounts, filter out zero and empty objects.
- Removing zero amounts on initial load.
- Filer out zero amounts when rendering amounts on a gift modal.