### PR TITLE
EP-2412 - Force Logged-in During Save

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -303,18 +303,26 @@ class DesignationEditorController {
     this.loadingOverlay = true
     this.saveDesignationError = false
 
-    return this.designationEditorService.save(this.designationContent, this.designationNumber, this.campaignPage).then(() => {
-      this.saveStatus = 'success'
-      this.loadingOverlay = false
-      this.carouselImages = this.designationContent.secondaryPhotos || []
-      this.updateCarousel()
-    }, error => {
-      this.saveStatus = 'failure'
-      this.saveDesignationError = true
-      this.loadingOverlay = false
-      this.$log.error('Error saving designation editor content.', error)
-      this.$window.scrollTo(0, 0)
-    })
+    this.enforcerId = this.sessionEnforcerService([Roles.registered], {
+      [EnforcerCallbacks.signIn]: () => {
+        return this.designationEditorService.save(this.designationContent, this.designationNumber, this.campaignPage).then(() => {
+          this.saveStatus = 'success'
+          this.loadingOverlay = false
+          this.carouselImages = this.designationContent.secondaryPhotos || []
+          this.updateCarousel()
+        }, error => {
+          this.saveStatus = 'failure'
+          this.saveDesignationError = true
+          this.loadingOverlay = false
+          this.$log.error('Error saving designation editor content.', error)
+          this.$window.scrollTo(0, 0)
+        })
+      },
+      [EnforcerCallbacks.cancel]: () => {
+        // Authentication failure
+        this.$window.location = '/'
+      }
+    }, EnforcerModes.session)
   }
 
   isPerson () {

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -76,7 +76,8 @@ describe('Designation Editor', function () {
           location: '/designation-editor.html?d=' + designationSecurityResponse.designationNumber,
           document: {
             dispatchEvent: jest.fn()
-          }
+          },
+          scrollTo: jest.fn()
         }
       }
     )
@@ -448,27 +449,52 @@ describe('Designation Editor', function () {
   })
 
   describe('save', () => {
-    it('should save designation content', () => {
-      $httpBackend.expectPOST(designationConstants.designationEndpoint).respond(200)
-      $ctrl.designationContent = designationSecurityResponse
+    it('should save designation content', done => {
+      jest.spyOn($ctrl, 'sessionEnforcerService').mockImplementation((role, callbacks) => {
+        const signInAsync = () => {
+          return Promise.resolve(callbacks['sign-in']())
+        }
 
-      $ctrl.save().then(() => {
-        expect($ctrl.saveStatus).toEqual('success')
-        expect($ctrl.saveDesignationError).toEqual(false)
+        signInAsync().then(() => {
+          expect($ctrl.designationEditorService.save).toHaveBeenCalled()
+          done()
+        })
       })
-      $httpBackend.flush()
+      $ctrl.designationContent = designationSecurityResponse
+      jest.spyOn($ctrl.designationEditorService, 'save').mockImplementation(() => Promise.resolve({}))
+      $ctrl.save()
     })
 
-    it('should try to save designation content', () => {
-      $httpBackend.expectPOST(designationConstants.designationEndpoint).respond(500)
-      $ctrl.designationContent = designationSecurityResponse
-
-      $ctrl.save().then(() => {
-        expect($ctrl.saveStatus).toEqual('failure')
-        expect($ctrl.saveDesignationError).toEqual(true)
-        expect($ctrl.$log.error.logs[0]).toEqual(['Error saving designation editor content.', expect.any(Object)])
+    it('should try to save designation content', done => {
+      jest.spyOn($ctrl, 'sessionEnforcerService').mockImplementation((role, callbacks) => {
+        const signInAsync = () => {
+          return Promise.resolve(callbacks['sign-in']())
+        }
+        signInAsync().then(() => {
+          expect($ctrl.saveStatus).toEqual('failure')
+          expect($ctrl.saveDesignationError).toEqual(true)
+          expect($ctrl.$log.error.logs[0]).toEqual(['Error saving designation editor content.', expect.any(Object)])
+          done()
+        })
       })
-      $httpBackend.flush()
+      jest.spyOn($ctrl.designationEditorService, 'save').mockImplementation(() => Promise.reject(new Error('error')))
+      jest.spyOn($ctrl.$window, 'scrollTo').mockImplementation(() => {})
+      $ctrl.designationContent = designationSecurityResponse
+      $ctrl.save()
+    })
+
+    it('should handle cancelling the login', done => {
+      jest.spyOn($ctrl, 'sessionEnforcerService').mockImplementation((role, callbacks) => {
+        const signInAsync = () => {
+          return Promise.resolve(callbacks.cancel())
+        }
+
+        signInAsync().then(() => {
+          expect($ctrl.$window.location).toEqual('/')
+          done()
+        })
+      })
+      $ctrl.save()
     })
   })
 


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2412)
[Rollbar](https://app.rollbar.com/a/Cru/fix/item/give-web/64805)

Currently, the system allows you to navigate around and attempt to save changes on the designation editor even if your `give-session` cookie has expired (sometimes...). This PR forces a login if needed on save. One side effect I noticed in my testing is that is sends 2 POST requests instead of 1. I'm not sure why at this point, but I think it has to do with how the `sessionEnforcerService` works. In my automated tests, calling the `sign-in` function happened twice as well. That will be out of scope of this PR to improve.