### PR TITLE
Preventing DD from producing errors when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "build": "webpack -p",
     "build:analyze": "webpack -p --env.analyze",
     "test": "jest",
+    "test:log": "jest --silent=false",
     "lint": "standard",
     "lint:write": "standard --fix",
     "lint:ts": "tsc"

--- a/src/common/datadog-shouldNotLoad.config.spec.js
+++ b/src/common/datadog-shouldNotLoad.config.spec.js
@@ -1,0 +1,23 @@
+import angular from 'angular'
+import 'angular-mocks'
+import * as module from './datadog.config'
+
+describe('dataDogConfig', () => {
+
+  describe('pipe $log to Rollbar', () => {
+    beforeEach(() => {
+      // Use rollbar config function somewhere
+      angular.module('testDataDogConfig', ['environment'])
+        .config(module.default)
+      // Init and run the test module
+      angular.mock.module('testDataDogConfig')
+      inject(() => {})
+    })
+
+    describe('DATADOG_RUM_CLIENT_TOKEN not defined', () => {
+      it('should make Window.datadogRum return undefined', () => {
+          expect(window.datadogRum).toEqual(undefined)
+      })
+    })
+  })
+})

--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -2,7 +2,7 @@ import 'angular-environment'
 import { datadogRum } from '@datadog/browser-rum'
 
 const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
-  const clientToken = process.env.DATADOG_RUM_CLIENT_TOKEN;
+  const clientToken = process.env.DATADOG_RUM_CLIENT_TOKEN
   if (clientToken) {
     const config = {
       applicationId: '3937053e-386b-4b5b-ab4a-c83217d2f953',

--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -2,24 +2,27 @@ import 'angular-environment'
 import { datadogRum } from '@datadog/browser-rum'
 
 const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
-  const config = {
-    applicationId: '3937053e-386b-4b5b-ab4a-c83217d2f953',
-    clientToken: process.env.DATADOG_RUM_CLIENT_TOKEN,
-    site: 'datadoghq.com',
-    service: 'give-web',
-    env: envServiceProvider.get(),
-    version: process.env.GITHUB_SHA,
-    sessionSampleRate: envServiceProvider.is('staging') ? 100 : 10,
-    sessionReplaySampleRate: envServiceProvider.is('staging') ? 100 : 1,
-    trackUserInteractions: true,
-    trackResources: true,
-    trackLongTasks: true,
-    defaultPrivacyLevel: 'mask-user-input'
-  }
+  const clientToken = process.env.DATADOG_RUM_CLIENT_TOKEN;
+  if (clientToken) {
+    const config = {
+      applicationId: '3937053e-386b-4b5b-ab4a-c83217d2f953',
+      clientToken,
+      site: 'datadoghq.com',
+      service: 'give-web',
+      env: envServiceProvider.get(),
+      version: process.env.GITHUB_SHA,
+      sessionSampleRate: envServiceProvider.is('staging') ? 100 : 10,
+      sessionReplaySampleRate: envServiceProvider.is('staging') ? 100 : 1,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: 'mask-user-input'
+    }
 
-  window.datadogRum = datadogRum
-  window.datadogRum && window.datadogRum.init(config)
-  window.datadogRum && window.datadogRum.startSessionReplayRecording()
+    window.datadogRum = datadogRum
+    window.datadogRum && window.datadogRum.init(config)
+    window.datadogRum && window.datadogRum.startSessionReplayRecording()
+  }
 }
 export {
   dataDogConfig as default

--- a/src/common/datadog.config.spec.js
+++ b/src/common/datadog.config.spec.js
@@ -1,0 +1,23 @@
+import angular from 'angular'
+import 'angular-mocks'
+import * as module from './datadog.config'
+
+describe('dataDogConfig', () => {
+  process.env.DATADOG_RUM_CLIENT_TOKEN = '1234'
+  describe('pipe $log to Rollbar', () => {
+    beforeEach(() => {
+      // Use rollbar config function somewhere
+      angular.module('testDataDogConfig', ['environment'])
+        .config(module.default)
+        // Init and run the test module
+        angular.mock.module('testDataDogConfig')
+        inject(() => {})
+    })
+
+    it('should send $log.log to rollbar and call through to $log', () => {
+      expect(window.datadogRum).not.toEqual(undefined)
+      expect(window.datadogRum.init).toEqual(expect.any(Function))
+      expect(window.datadogRum.startSessionReplayRecording).toEqual(expect.any(Function))
+    })
+  })
+})


### PR DESCRIPTION
## Description
When running tests, DataDog would produce an error/warning after every test as I didn't have the env var `DATADOG_RUM_CLIENT_TOKEN` on my local.
Added tests for DD.

## Changes
- Ensured DD is only initialised if env var is present.
- Creates 2 tests for DD, one without the Var and one with.
- Added new script for debugging tests.