### PR TITLE
Only expose giving links to national staff

### DIFF
--- a/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.modal.js
@@ -25,6 +25,7 @@ class ModalInstanceCtrl {
     this.givingLinks = sortBy(this.givingLinks, 'order')
 
     this.tab = 'newsletter'
+    this.givingLinksAvailable = designationType === 'National Staff'
   }
 
   transformGivingLinks () {

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
@@ -4,9 +4,9 @@ import module from './personalOptions.modal'
 
 describe('Designation Editor Personal Options', function () {
   beforeEach(angular.mock.module(module.name))
-  var $ctrl
+  let $ctrl
 
-  var controllerInjections = {
+  const controllerInjections = {
     designationNumber: '000555',
     designationType: 'Staff',
     giveDomain: 'https://give.cru.org',

--- a/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
+++ b/src/app/designationEditor/personalOptionsModal/personalOptions.spec.js
@@ -6,19 +6,23 @@ describe('Designation Editor Personal Options', function () {
   beforeEach(angular.mock.module(module.name))
   var $ctrl
 
+  var controllerInjections = {
+    designationNumber: '000555',
+    designationType: 'Staff',
+    giveDomain: 'https://give.cru.org',
+    givingLinks: {
+      'jcr:primaryType': 'nt:unstructured',
+      1: { 'jcr:primaryType': 'nt:unstructured', url: 'https://example.com', name: 'Name' }
+    },
+    showNewsletterForm: true,
+    hasNewsletter: true,
+  }
+
   beforeEach(inject(function ($rootScope, $controller) {
     const $scope = $rootScope.$new()
 
     $ctrl = $controller(module.name, {
-      designationNumber: '000555',
-      designationType: 'Staff',
-      giveDomain: 'https://give.cru.org',
-      givingLinks: {
-        'jcr:primaryType': 'nt:unstructured',
-        1: { 'jcr:primaryType': 'nt:unstructured', url: 'https://example.com', name: 'Name' }
-      },
-      showNewsletterForm: true,
-      hasNewsletter: true,
+      ...controllerInjections,
       $scope: $scope
     })
     $scope.$close = jest.fn()
@@ -38,6 +42,28 @@ describe('Designation Editor Personal Options', function () {
   it('transforms giving links', function () {
     expect($ctrl.transformGivingLinks()).toEqual({
       1: { name: 'Name', url: 'https://example.com' }
+    })
+  })
+
+  describe('givingLinksAvailable', () => {
+    describe('for national staff', () => {
+      beforeEach(inject(function ($rootScope, $controller) {
+        const $scope = $rootScope.$new()
+
+        $ctrl = $controller(module.name, {
+          ...controllerInjections,
+          designationType: 'National Staff',
+          $scope: $scope
+        })
+      }))
+
+      it('is true', () => {
+        expect($ctrl.givingLinksAvailable).toBe(true)
+      })
+    })
+
+    it('otherwise is false', () => {
+      expect($ctrl.givingLinksAvailable).toBe(false)
     })
   })
 

--- a/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
+++ b/src/app/designationEditor/personalOptionsModal/personalOptionsModal.tpl.html
@@ -6,7 +6,7 @@
         <a href="" ng-click="$ctrl.tab = 'newsletter'">
           MPDX Newsletter <span class="xs-hide">Form</span>
         </a>
-        <a href="" ng-click="$ctrl.tab = 'givingLinks'">
+        <a href="" ng-click="$ctrl.tab = 'givingLinks'" ng-if="$ctrl.givingLinksAvailable">
           Giving Links
         </a>
       </li>


### PR DESCRIPTION
Only allow national staff to edit their giving links.

To test, overwrite the `designationType` of the response for the `GET /bin/crugive/designation.html?designationNumber=0864190` request in DevTools to `"National Staff"` and anything else.

@wrandall22 Let me know if you know of a cleaner way to inject `designationType === 'National Staff'` into that one test case. I tried a couple of approaches that didn't work.

https://secure.helpscout.net/conversation/2406630583/1042488/