### PR TITLE
EP-2467 - Add a temporary message to the success of account verification

### DIFF
--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -34,6 +34,10 @@
     <p ng-if="$ctrl.skippedQuestions" translate ng-init="$ctrl.analyticsFactory.track('ga-registration-no-match-new-account-success')">
       Thank you for completing account registration. Your account has been activated.
     </p>
+    <p translate>
+      If you do not see saved payment methods that you are expecting to see, please try signing out and signing back in.
+      This should resolve the issue.
+    </p>
     <p>
       <button type="button" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.onSuccess()" translate>Close</button>
     </p>


### PR DESCRIPTION
There are issues with syncing billing addresses during the account verification flow. This prevents loading payment methods altogether, but should work if they logout and login again. This gives a message to that effect.