### PR TITLE
Restrict DataDog request instrumentation to /cortex URLs

### DIFF
--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -10,7 +10,7 @@ const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
       site: 'datadoghq.com',
       service: 'give-web',
       env: envServiceProvider.get(),
-      allowedTracingUrls: [envServiceProvider.read('apiUrl')],
+      allowedTracingUrls: [envServiceProvider.read('apiUrl') + '/cortex'],
       version: process.env.GITHUB_SHA,
       sessionSampleRate: envServiceProvider.is('staging') ? 100 : 10,
       sessionReplaySampleRate: envServiceProvider.is('staging') ? 100 : 1,


### PR DESCRIPTION
DataDog's network request instrumentation was causing CORS errors for the designation content requests on branded checkout pages. DataDog was adding headers to the requests, which caused the requests to require a CORS preflight request, which was failing because AEM doesn't implement the OPTIONS method for requests to URLs like `https://give.cru.org/content/give/us/en/designations/2/5/9/2/3/2592320.infinity.json`. This change restricts instrumentation to cortex gateway URLs.

https://secure.helpscout.net/conversation/2422586630/1052239?folderId=7296729