### PR TITLE
[HS-1063275] Fix long opportunity names

### DIFF
--- a/src/app/searchResults/searchResults.tpl.html
+++ b/src/app/searchResults/searchResults.tpl.html
@@ -123,7 +123,7 @@
                     </h4>
                   </div>
 
-                  <div class="is-row clearfix" ng-repeat-end ng-repeat="r in hits">
+                  <div class="is-row" ng-repeat-end ng-repeat="r in hits">
                     <a ng-href="{{$ctrl.buildVanity(r.path)}}" class="is-row-thumb">
                       <img desig-src="{{r.designationNumber}}" campaign-page="{{r.campaignPage}}">
                     </a>

--- a/src/assets/scss/_search.scss
+++ b/src/assets/scss/_search.scss
@@ -278,6 +278,7 @@
 }
 
 .is-row {
+  display: flex;
   border-bottom: 1px solid $colorGrayscale-stone;
   padding-bottom: $gutter*.65;
   margin-bottom: $gutter*.65;
@@ -287,7 +288,6 @@
     padding-bottom: 0;
   }
   .is-row-thumb {
-    float: left;
     margin-right: $gutter*.5;
     min-width: 90px;
     img {
@@ -295,7 +295,7 @@
     }
   }
   .is-row-meta {
-    float: left;
+    flex: 1;
     span {
       display: block;
     }
@@ -309,9 +309,6 @@
       color: $colorCru-gray;
       font-size: 100%;
     }
-  }
-  .is-row-actions {
-    float: right;
   }
 }
 

--- a/src/assets/scss/_search.scss
+++ b/src/assets/scss/_search.scss
@@ -279,6 +279,8 @@
 
 .is-row {
   display: flex;
+  column-gap: $gutter*.5;
+  align-items: center;
   border-bottom: 1px solid $colorGrayscale-stone;
   padding-bottom: $gutter*.65;
   margin-bottom: $gutter*.65;
@@ -288,7 +290,6 @@
     padding-bottom: 0;
   }
   .is-row-thumb {
-    margin-right: $gutter*.5;
     min-width: 90px;
     img {
       max-width: 90px;


### PR DESCRIPTION
Fix long opportunity names displaying under the thumbnail image by switching from floating to flexbox.

Before:
<img width="839" alt="Screenshot 2023-12-05 at 11 16 52 AM" src="https://github.com/CruGlobal/give-web/assets/3740187/7db6e230-f70f-461d-8448-c66320cf5ade">

After:
<img width="835" alt="Screenshot 2023-12-05 at 11 16 36 AM" src="https://github.com/CruGlobal/give-web/assets/3740187/42facb10-7a7f-4347-964d-22198839f1e8">


https://secure.helpscout.net/conversation/2443333491/1063275?folderId=7296729