### PR TITLE
[EP-2478] Connect Rollbar errors with DataDog RUM

### DIFF
--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -571,5 +571,6 @@ export default angular.module('appConfig', [
   'pascalprecht.translate'
 ])
   .config(appConfig)
-  .config(rollbarConfig)
+  // Configure DataDog before Rollbar so that the RUM session id can be added to the Rollbar payload
   .config(dataDogConfig)
+  .config(rollbarConfig)

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -40,7 +40,8 @@ const rollbarConfig = /* @ngInject */ function (envServiceProvider, $provide) {
           guess_uncaught_frames: true,
           code_version: process.env.GITHUB_SHA
         }
-      }
+      },
+      rumSessionId: window.datadogRum?.getInternalContext()?.session_id
     }
   }
   Rollbar = rollbar.init(config)


### PR DESCRIPTION
Extract the DataDog RUM session ID and add it to Rollbar logs.

This shouldn't be merged until after the code freeze.

https://jira.cru.org/browse/EP-2478