### PR TITLE
[no-Jira] Fix momentjs invalid date console warning

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -204,7 +204,7 @@ const analyticsFactory = /* @ngInject */ function ($window, $timeout, envService
         cart.item[0].attributes.donationType = 'one-time donation'
       } else {
         cart.item[0].attributes.donationType = 'recurring donation'
-        recurringDate = moment(`${moment().year()}-${itemConfig.RECURRING_START_MONTH}-${itemConfig.RECURRING_DAY_OF_MONTH} ${moment().format('h:mm:ss a')}`)
+        recurringDate = moment(`${moment().year()}-${itemConfig.RECURRING_START_MONTH}-${itemConfig.RECURRING_DAY_OF_MONTH}`, 'YYYY-MM-DD')
       }
 
       // Set donation frequency

--- a/src/app/analytics/analytics.factory.spec.js
+++ b/src/app/analytics/analytics.factory.spec.js
@@ -15,6 +15,8 @@ describe('analytics factory', () => {
 
     self.$window.sessionStorage.clear()
     self.$window.localStorage.clear()
+
+    Date.now = jest.fn(() => new Date("2023-04-05T01:02:03.000Z"));
   }))
 
   describe('handleCheckoutFormErrors', () => {
@@ -364,7 +366,7 @@ describe('analytics factory', () => {
 
     it('should create payment info and checkout step DataLayer events', () => {
       self.analyticsFactory.checkoutStepEvent('payment', cart)
-      
+
       expect(self.$window.dataLayer.length).toEqual(2)
       expect(self.$window.dataLayer[0]).toEqual({
         event: 'add_payment_info'
@@ -386,7 +388,7 @@ describe('analytics factory', () => {
 
     it('should create review order and checkout step DataLayer events', () => {
       self.analyticsFactory.checkoutStepEvent('review', cart)
-      
+
       expect(self.$window.dataLayer.length).toEqual(2)
       expect(self.$window.dataLayer[0]).toEqual({
         event: 'review_order',
@@ -407,7 +409,7 @@ describe('analytics factory', () => {
     })
   });
 
-  describe('checkoutStepOptionEvent', () => { 
+  describe('checkoutStepOptionEvent', () => {
     it('should add contact checkout option event to DataLayer', () => {
       self.analyticsFactory.checkoutStepOptionEvent('Household', 'contact')
       expect(self.$window.dataLayer.length).toEqual(1)
@@ -621,7 +623,7 @@ describe('analytics factory', () => {
       self.analyticsFactory.transactionEvent(purchaseData)
 
       expect(self.$window.sessionStorage.getItem('transactionId')).toEqual(purchaseData.rawData['purchase-number'])
-      
+
       expect(self.$window.dataLayer.length).toEqual(1)
       expect(self.$window.dataLayer[0].event).toEqual('purchase')
       expect(self.$window.dataLayer[0].paymentType).toEqual('credit card')
@@ -678,7 +680,7 @@ describe('analytics factory', () => {
 
       const totalWithFees = 51.2 * 3
       const totalWithoutFees = 50 * 3
-      
+
       expect(self.$window.dataLayer[0].ecommerce.processing_fee).toEqual((totalWithFees - totalWithoutFees).toFixed(2))
       expect(self.$window.dataLayer[0].ecommerce.value).toEqual((totalWithFees).toFixed(2))
       expect(self.$window.dataLayer[0].ecommerce.pays_processing).toEqual('yes')

--- a/src/app/analytics/analytics.factory.spec.js
+++ b/src/app/analytics/analytics.factory.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular'
 import 'angular-mocks'
+import moment from 'moment'
 
 import module from './analytics.factory'
 
@@ -179,7 +180,7 @@ describe('analytics factory', () => {
               "amountWithFees": 51.2,
               "designationNumber": "0048461",
               "productUri": "/items/crugive/a5t4fmspmhbkez6cvfmucmrkykwc7q4mykr4fps5ee=",
-              "giftStartDate": "2024-09-15T04:00:00.000Z",
+              "giftStartDate": moment(new Date(2024, 8, 15)),
               "giftStartDateDaysFromNow": 361,
               "giftStartDateWarning": true,
               "$$hashKey": "object:506"
@@ -240,7 +241,7 @@ describe('analytics factory', () => {
       "amountWithFees": 51.2,
       "designationNumber": "0048461",
       "productUri": "/items/crugive/a5t4fmspmhbkez6cv",
-      "giftStartDate": "2024-09-15T04:00:00.000Z",
+      "giftStartDate": moment(new Date(2024, 8, 15)),
       "giftStartDateDaysFromNow": 361,
       "giftStartDateWarning": true,
       "$$hashKey": "object:22",


### PR DESCRIPTION
Fix momentjs console warning (at least in tests) about parsing a date in an unexpected format introduced in #1054. Only the day/month/year of `recurringDate` is used, so I removed the time to fix the warning.