### PR TITLE
[EP-2483] Include next draw date when changing frequency

### DIFF
--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -201,7 +201,15 @@ export default class RecurringGiftModel {
   }
 
   get toObject () {
-    return this.gift
+    if (this.gift['updated-start-month'] === '') {
+      return this.gift
+    }
+
+    // When the start month changes the server needs the recurring day of month even if it didn't change
+    return {
+      ...this.gift,
+      'updated-recurring-day-of-month': this.gift['updated-recurring-day-of-month'] || this.parentDonation['recurring-day-of-month']
+    }
   }
 
   clone () {

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -564,6 +564,27 @@ describe('recurringGift model', () => {
     it('should return the object to send to the api', () => {
       expect(giftModel.toObject).toEqual(giftModel.gift)
     })
+
+    it('should include the recurring day of month when the month changes', () => {
+      giftModel.startMonth = '6'
+      expect(giftModel.toObject).toEqual({
+        ...giftModel.gift,
+        'updated-recurring-day-of-month': '15',
+        'updated-start-month': '06',
+        'updated-start-year': '2015',
+      })
+    })
+
+    it('should not override the modified recurring day of month when the month changes', () => {
+      giftModel.transactionDay = '20'
+      giftModel.startMonth = '6'
+      expect(giftModel.toObject).toEqual({
+        ...giftModel.gift,
+        'updated-recurring-day-of-month': '20',
+        'updated-start-month': '06',
+        'updated-start-year': '2015',
+      })
+    })
   })
 
   describe('clone', () => {


### PR DESCRIPTION
The API server needs the next draw date information when the frequency changes to something other than monthly.

https://jira.cru.org/browse/EP-2483