### PR TITLE
[no-Jira] Fix missing add_to_cart event

### DIFF
--- a/src/app/analytics/analytics.factory.js
+++ b/src/app/analytics/analytics.factory.js
@@ -12,7 +12,9 @@ function suppressErrors (func) {
   return function wrapper (...args) {
     try {
       return func.apply(this, args)
-    } catch (e) { }
+    } catch (e) {
+      console.error(e)
+    }
   }
 }
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -275,8 +275,9 @@ class ProductConfigFormController {
   }
 
   changeCustomAmount (amount, retainCoverFees) {
-    this.checkAmountChanged(amount)
-    this.itemConfig.AMOUNT = amount
+    const amountAsNumber = parseFloat(amount)
+    this.checkAmountChanged(amountAsNumber)
+    this.itemConfig.AMOUNT = amountAsNumber
     this.customAmount = amount
     this.customInputActive = true
     if (!retainCoverFees && this.amountChanged) {

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -492,6 +492,16 @@ describe('product config form component', function () {
       expect($ctrl.updateQueryParam).toHaveBeenCalledWith({ key: giveGiftParams.amount, value: 300 })
     })
 
+    it('sets itemConfig amount with string', () => {
+      $ctrl.itemConfig = {}
+      $ctrl.changeCustomAmount('300')
+
+      expect($ctrl.itemConfig.AMOUNT).toEqual(300)
+      expect($ctrl.customAmount).toEqual('300')
+      expect($ctrl.customInputActive).toEqual(true)
+      expect($ctrl.updateQueryParam).toHaveBeenCalledWith({ key: giveGiftParams.amount, value: '300' })
+    })
+
     it('should clear cover fees if we are not explicitly retaining them and the amount changed', () => {
       jest.spyOn($ctrl.orderService, 'clearCoverFees').mockImplementation(() => {})
       jest.spyOn($ctrl.$scope, '$emit').mockImplementation(() => {})


### PR DESCRIPTION
# Context

The `add_to_cart` datalayer event was not being fired when the user input a custom amount. This is because the amount would be a string instead of a number and `itemConfig.AMOUNT.toFixed(2)` was throwing an exception that `suppressErrors` was silently hiding.

# Fix

Parse the custom amount string into a number. Also, log caught exceptions to make it easier to diagnose issues like this in the future.

Tested in staging ✅