### PR TITLE
[EP-2485] Prevent duplicate purchase analytics events in branded checkout

### DIFF
--- a/src/app/thankYou/summary/thankYouSummary.component.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.js
@@ -21,9 +21,10 @@ const componentName = 'thankYouSummary'
 
 class ThankYouSummaryController {
   /* @ngInject */
-  constructor ($rootScope, $window, analyticsFactory, orderService, profileService, sessionModalService, designationsService, $log) {
+  constructor ($rootScope, $window, analyticsFactory, envService, orderService, profileService, sessionModalService, designationsService, $log) {
     this.$rootScope = $rootScope
     this.$window = $window
+    this.envService = envService
     this.orderService = orderService
     this.profileService = profileService
     this.sessionModalService = sessionModalService
@@ -73,7 +74,9 @@ class ThankYouSummaryController {
 
         this.analyticsFactory.pageLoaded()
         this.analyticsFactory.setPurchaseNumber(data.rawData['purchase-number'])
-        this.analyticsFactory.transactionEvent(this.purchase)
+        if (!this.envService.read('isBrandedCheckout')) {
+          this.analyticsFactory.transactionEvent(this.purchase)
+        }
       },
       (error) => {
         this.$log.error('Error loading purchase data for thank you component', error)

--- a/src/app/thankYou/summary/thankYouSummary.component.spec.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.spec.js
@@ -114,6 +114,7 @@ describe('thank you summary', () => {
     it('should load all data from the last completed purchase', () => {
       jest.spyOn(self.controller.profileService, 'getPurchase')
       jest.spyOn(self.controller.analyticsFactory, 'transactionEvent')
+      jest.spyOn(self.controller.envService, 'read').mockReturnValue(false)
       self.controller.loadLastPurchase()
 
       expect(self.controller.profileService.getPurchase).toHaveBeenCalledWith('/purchases/crugive/iiydanbt=')
@@ -137,6 +138,14 @@ describe('thank you summary', () => {
         $event: { purchase: self.mockPurchase }
       })
       expect(self.controller.analyticsFactory.transactionEvent).toHaveBeenCalledWith(self.mockPurchase)
+    })
+
+    it('does not trigger analytics event in branded checkout', () => {
+      jest.spyOn(self.controller.analyticsFactory, 'transactionEvent')
+      jest.spyOn(self.controller.envService, 'read').mockReturnValue(true)
+      self.controller.loadLastPurchase()
+
+      expect(self.controller.analyticsFactory.transactionEvent).not.toHaveBeenCalled()
     })
 
     it('should not request purchase data if lastPurchaseLink is not defined', () => {


### PR DESCRIPTION
Previously, a `purchase` event was being fired by the regular checkout code and by branded checkout on the confirmation page, resulting in duplicate `purchase` events in branded checkout. This PR makes sure that only one `purchase` event is fired in branded checkout.

https://jira.cru.org/browse/EP-2485