### PR TITLE
[HS-1112780] Force sign-in after 422 response in designation editor

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -10,6 +10,7 @@ import sessionEnforcerService, {
   EnforcerCallbacks,
   EnforcerModes
 } from 'common/services/session/sessionEnforcer.service'
+import sessionModalService from 'common/services/session/sessionModal.service'
 import sessionService, { Roles } from 'common/services/session/session.service'
 import designationEditorService from 'common/services/api/designationEditor.service'
 
@@ -37,12 +38,13 @@ const componentName = 'designationEditor'
 
 class DesignationEditorController {
   /* @ngInject */
-  constructor ($scope, $log, $q, $uibModal, $location, $window, $timeout, envService, sessionService, sessionEnforcerService, designationEditorService) {
+  constructor ($scope, $log, $q, $uibModal, $location, $window, $timeout, envService, sessionService, sessionEnforcerService, sessionModalService, designationEditorService) {
     this.$scope = $scope
     this.$log = $log
     this.$timeout = $timeout
     this.sessionService = sessionService
     this.sessionEnforcerService = sessionEnforcerService
+    this.sessionModalService = sessionModalService
     this.designationEditorService = designationEditorService
 
     this.imgDomain = envService.read('imgDomain')
@@ -100,6 +102,16 @@ class DesignationEditorController {
       this.carouselImages = this.extractCarouselUrls()
       this.updateCarousel()
     }, error => {
+      if (error.status === 422) {
+        this.sessionModalService.open('sign-in', {
+          backdrop: 'static',
+          keyboard: false
+        }).result.then(() => {
+          this.getDesignationContent()
+        })
+        return
+      }
+
       this.contentLoaded = false
       this.loadingOverlay = false
       this.loadingContentError = true
@@ -391,6 +403,7 @@ export default angular
     commonModule.name,
     sessionService.name,
     sessionEnforcerService.name,
+    sessionModalService.name,
     designationEditorService.name,
     titleModalController.name,
     pageOptionsModalController.name,

--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -95,7 +95,6 @@ class DesignationEditorController {
       // get designation photos
       this.designationEditorService.getPhotos(this.designationNumber)
     ]).then(responses => {
-      this.contentLoaded = true
       this.loadingOverlay = false
       this.designationContent = responses[0].data
       this.designationPhotos = responses[1].data
@@ -103,13 +102,12 @@ class DesignationEditorController {
       this.updateCarousel()
     }, error => {
       if (error.status === 422) {
-        this.sessionModalService.open('sign-in', {
+        return this.sessionModalService.open('sign-in', {
           backdrop: 'static',
           keyboard: false
         }).result.then(() => {
-          this.getDesignationContent()
+          return this.getDesignationContent()
         })
-        return
       }
 
       this.contentLoaded = false

--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -101,11 +101,12 @@ class DesignationEditorController {
       this.carouselImages = this.extractCarouselUrls()
       this.updateCarousel()
     }, error => {
-      if (error.status === 422) {
+      if (error.status === 422 && !this.retried) {
         return this.sessionModalService.open('sign-in', {
           backdrop: 'static',
           keyboard: false
         }).result.then(() => {
+          this.retried = true
           return this.getDesignationContent()
         })
       }
@@ -114,6 +115,8 @@ class DesignationEditorController {
       this.loadingOverlay = false
       this.loadingContentError = true
       this.$log.error('Error loading designation content or photos.', error)
+    }).finally(() => {
+      this.retried = false
     })
   }
 

--- a/src/app/designationEditor/designationEditor.spec.js
+++ b/src/app/designationEditor/designationEditor.spec.js
@@ -176,6 +176,24 @@ describe('Designation Editor', function () {
       $httpBackend.flush()
     })
 
+    it('to sign in and try again if the response is 422', () => {
+      $ctrl.designationNumber = designationSecurityResponse.designationNumber
+
+      jest.spyOn($ctrl.sessionModalService, 'open').mockReturnValue(() => ({ result: $q.resolve() }))
+      $httpBackend.expectGET(designationConstants.designationEndpoint + '?designationNumber=' + designationSecurityResponse.designationNumber)
+        .respond(422, null)
+      $httpBackend.expectGET(designationConstants.designationImagesEndpoint + '?designationNumber=' + designationSecurityResponse.designationNumber)
+        .respond(422, null)
+
+      $ctrl.getDesignationContent().then(() => {
+        expect($ctrl.sessionModalService.open).toHaveBeenCalled()
+        expect($ctrl.designationContent).toBeDefined()
+        expect($ctrl.contentLoaded).toEqual(true)
+        expect($ctrl.loadingContentError).toEqual(false)
+      })
+      $httpBackend.flush()
+    })
+
     it('should log an error if content fails', () => {
       $ctrl.designationNumber = '0123456'
       jest.spyOn($ctrl.designationEditorService, 'getContent').mockImplementation(() => {


### PR DESCRIPTION
Would this fix the issue? If loading the content responds with a 422, we ask the user to sign in again and try again to load the content.

I wasn't able to test in staging because of conflicts with Daniel's Okta work. But I did test it locally.

https://secure.helpscout.net/conversation/2525923620/1112780?viewId=7296729