### PR TITLE
[EP-2486] Prevent invalid payment methods from being chosen

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -71,13 +71,14 @@ class ExistingPaymentMethodsController {
   }
 
   selectDefaultPaymentMethod () {
-    const chosenPaymentMethod = find(this.paymentMethods, { chosen: true })
+    const paymentMethods = this.paymentMethods.filter(paymentMethod => this.validPaymentMethod(paymentMethod))
+    const chosenPaymentMethod = find(paymentMethods, { chosen: true })
     if (chosenPaymentMethod) {
       // Select the payment method previously chosen for the order
       this.selectedPaymentMethod = chosenPaymentMethod
     } else {
       // Select the first payment method
-      this.selectedPaymentMethod = this.paymentMethods[0]
+      this.selectedPaymentMethod = paymentMethods[0]
     }
     this.switchPayment()
   }

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -156,6 +156,10 @@ describe('checkout', () => {
       })
 
       describe('selectDefaultPaymentMethod', () => {
+        beforeEach(() => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockReturnValue(true)
+        })
+
         it('should choose the payment method that is marked chosen in cortex', () => {
           self.controller.paymentMethods = [
             {
@@ -183,6 +187,38 @@ describe('checkout', () => {
           self.controller.selectDefaultPaymentMethod()
 
           expect(self.controller.selectedPaymentMethod).toEqual({ selectAction: 'first uri' })
+        })
+
+        it('should choose the first payment method if the one marked chosen in cortex is invalid', () => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockImplementation(paymentMethod => paymentMethod.selectAction === 'first uri')
+          self.controller.paymentMethods = [
+            {
+              selectAction: 'first uri'
+            },
+            {
+              selectAction: 'second uri',
+              chosen: true
+            }
+          ]
+          self.controller.selectDefaultPaymentMethod()
+
+          expect(self.controller.selectedPaymentMethod).toEqual({ selectAction: 'first uri' })
+        })
+
+        it('should set selectedPaymentMethod to undefined if none are valid', () => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockReturnValue(undefined)
+          self.controller.paymentMethods = [
+            {
+              selectAction: 'first uri'
+            },
+            {
+              selectAction: 'second uri',
+              chosen: true
+            }
+          ]
+          self.controller.selectDefaultPaymentMethod()
+
+          expect(self.controller.selectedPaymentMethod).toBeUndefined()
         })
 
         it('should check whether or not the fee coverage should be altered based on selected payment type', () => {

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -42,7 +42,7 @@
       <button id="previousStepButton1" class="btn btn-default" ng-click="$ctrl.changeStep({newStep: 'contact'})">Previous Step</button>
     </div>
     <div class="col-sm-5 col-sm-offset-2">
-      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
+      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="!$ctrl.selectedPaymentMethod || $ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
         Continue
       </button>
       <button id="previousStepButton2" class="btn btn-link btn-block visible-xs" ng-click="$ctrl.changeStep({newStep: 'contact'})"><i class="fa fa-angle-left"></i> Previous Step</button>


### PR DESCRIPTION
Prevent invalid payment methods from being selected by default on step 2 of checkout.

When testing locally, I used the following change to simulate invalid payment methods:

```patch
diff --git a/src/common/services/api/order.service.js b/src/common/services/api/order.service.js
index fcbb2ad4..475cce6a 100644
--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -234,6 +234,7 @@ class Order {
           paymentMethods.unshift(selector.chosen)
         }
         return map(paymentMethods, paymentMethod => {
+          paymentMethod.description['payment-instrument-identification-attributes']['expiry-year'] = '2020'
           paymentMethod.description.selectAction = paymentMethod.self.uri
           if (paymentMethod.description['payment-instrument-identification-attributes']['street-address']) {
             paymentMethod.description.address =
```

https://jira.cru.org/browse/EP-2486