### PR TITLE
[EP-2486] Prevent invalid payment methods from being chosen

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -129,12 +129,10 @@ class ExistingPaymentMethodsController {
   }
 
   switchPayment () {
-    if (this.selectedPaymentMethod) {
-      this.onPaymentChange({ selectedPaymentMethod: this.selectedPaymentMethod })
-      if (this.selectedPaymentMethod['bank-name']) {
-        // This is an EFT payment method so we need to remove any fee coverage
-        this.orderService.storeCoverFeeDecision(false)
-      }
+    this.onPaymentChange({ selectedPaymentMethod: this.selectedPaymentMethod })
+    if (this.selectedPaymentMethod?.['bank-name']) {
+      // This is an EFT payment method so we need to remove any fee coverage
+      this.orderService.storeCoverFeeDecision(false)
     }
   }
 }

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -71,13 +71,14 @@ class ExistingPaymentMethodsController {
   }
 
   selectDefaultPaymentMethod () {
-    const chosenPaymentMethod = find(this.paymentMethods, { chosen: true })
+    const paymentMethods = this.paymentMethods.filter(paymentMethod => this.validPaymentMethod(paymentMethod))
+    const chosenPaymentMethod = find(paymentMethods, { chosen: true })
     if (chosenPaymentMethod) {
       // Select the payment method previously chosen for the order
       this.selectedPaymentMethod = chosenPaymentMethod
     } else {
       // Select the first payment method
-      this.selectedPaymentMethod = this.paymentMethods[0]
+      this.selectedPaymentMethod = paymentMethods[0]
     }
     this.switchPayment()
   }

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -156,6 +156,10 @@ describe('checkout', () => {
       })
 
       describe('selectDefaultPaymentMethod', () => {
+        beforeEach(() => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockReturnValue(true)
+        })
+
         it('should choose the payment method that is marked chosen in cortex', () => {
           self.controller.paymentMethods = [
             {
@@ -183,6 +187,38 @@ describe('checkout', () => {
           self.controller.selectDefaultPaymentMethod()
 
           expect(self.controller.selectedPaymentMethod).toEqual({ selectAction: 'first uri' })
+        })
+
+        it('should choose the first payment method if the one marked chosen in cortex is invalid', () => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockImplementation(paymentMethod => paymentMethod.selectAction === 'first uri')
+          self.controller.paymentMethods = [
+            {
+              selectAction: 'first uri'
+            },
+            {
+              selectAction: 'second uri',
+              chosen: true
+            }
+          ]
+          self.controller.selectDefaultPaymentMethod()
+
+          expect(self.controller.selectedPaymentMethod).toEqual({ selectAction: 'first uri' })
+        })
+
+        it('should set selectedPaymentMethod to undefined if none are valid', () => {
+          jest.spyOn(self.controller, 'validPaymentMethod').mockReturnValue(undefined)
+          self.controller.paymentMethods = [
+            {
+              selectAction: 'first uri'
+            },
+            {
+              selectAction: 'second uri',
+              chosen: true
+            }
+          ]
+          self.controller.selectDefaultPaymentMethod()
+
+          expect(self.controller.selectedPaymentMethod).toBeUndefined()
         })
 
         it('should check whether or not the fee coverage should be altered based on selected payment type', () => {

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.spec.js
@@ -309,14 +309,25 @@ describe('checkout', () => {
       })
 
       describe('switchPayment', () => {
-        it('should remove fees if the newly selected payment method is EFT', () => {
-          self.controller.selectedPaymentMethod = { 'bank-name': 'My Bank' }
+        beforeEach(() => {
           jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockImplementation(() => true)
           jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
+        })
+
+        it('should remove fees if the newly selected payment method is EFT', () => {
+          self.controller.selectedPaymentMethod = { 'bank-name': 'My Bank' }
 
           self.controller.switchPayment()
           expect(self.controller.onPaymentChange).toHaveBeenCalledWith({ selectedPaymentMethod: self.controller.selectedPaymentMethod })
           expect(self.controller.orderService.storeCoverFeeDecision).toHaveBeenCalledWith(false)
+        })
+
+        it('should handle undefined payment methods', () => {
+          self.controller.selectedPaymentMethod = undefined
+
+          self.controller.switchPayment()
+          expect(self.controller.onPaymentChange).toHaveBeenCalledWith({ selectedPaymentMethod: undefined })
+          expect(self.controller.orderService.storeCoverFeeDecision).not.toHaveBeenCalled()
         })
       })
     })

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -117,14 +117,14 @@ class Step2Controller {
   }
 
   getContinueDisabled () {
-    if (this.existingPaymentMethods && !this.selectedPaymentMethod) {
-      // All payment methods are invalid
-      return true
-    }
     if (this.loadingPaymentMethods) {
       return true
     }
     if (this.paymentFormState === 'loading' || this.paymentFormState === 'encrypting') {
+      return true
+    }
+    if (this.existingPaymentMethods && !this.selectedPaymentMethod) {
+      // All payment methods are invalid
       return true
     }
     return false

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -115,6 +115,20 @@ class Step2Controller {
       this.onStateChange({ state: 'errorSubmitting' })
     }
   }
+
+  getContinueDisabled () {
+    if (this.existingPaymentMethods && !this.selectedPaymentMethod) {
+      // All payment methods are invalid
+      return true
+    }
+    if (this.loadingPaymentMethods) {
+      return true
+    }
+    if (this.paymentFormState === 'loading' || this.paymentFormState === 'encrypting') {
+      return true
+    }
+    return false
+  }
 }
 
 export default angular

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -52,9 +52,12 @@ class Step2Controller {
   }
 
   handlePaymentChange (selectedPaymentMethod) {
-    const paymentType = selectedPaymentMethod['account-type'] || selectedPaymentMethod['card-type']
+    const paymentType = selectedPaymentMethod?.['account-type'] || selectedPaymentMethod?.['card-type']
+    this.selectedPaymentMethod = selectedPaymentMethod
     this.defaultPaymentType = paymentType
-    this.brandedAnalyticsFactory.savePaymentType(paymentType, Boolean(selectedPaymentMethod['card-type']))
+    if (selectedPaymentMethod) {
+      this.brandedAnalyticsFactory.savePaymentType(paymentType, Boolean(selectedPaymentMethod['card-type']))
+    }
   }
 
   handleExistingPaymentLoading (success, hasExistingPaymentMethods, error) {

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -21,6 +21,12 @@ describe('checkout', () => {
         })
     }))
 
+    describe('constructor', () => {
+      it('initializes selectedPaymentMethod to undefined', () => {
+        expect(self.controller.selectedPaymentMethod).toBeUndefined()
+      })
+    })
+
     describe('$onInit', () => {
       it('should call loadDonorDetails', () => {
         jest.spyOn(self.controller, 'loadDonorDetails').mockImplementation(() => {})
@@ -124,6 +130,7 @@ describe('checkout', () => {
         jest.spyOn(self.controller.brandedAnalyticsFactory, 'savePaymentType')
         self.controller.handlePaymentChange({'account-type': 'checking'})
 
+        expect(self.controller.selectedPaymentMethod).toEqual({'account-type': 'checking'})
         expect(self.controller.defaultPaymentType).toEqual('checking')
         expect(self.controller.brandedAnalyticsFactory.savePaymentType).toHaveBeenCalledWith('checking', false)
       })
@@ -132,8 +139,18 @@ describe('checkout', () => {
         jest.spyOn(self.controller.brandedAnalyticsFactory, 'savePaymentType')
         self.controller.handlePaymentChange({'card-type': 'visa'})
 
+        expect(self.controller.selectedPaymentMethod).toEqual({'card-type': 'visa'})
         expect(self.controller.defaultPaymentType).toEqual('visa')
         expect(self.controller.brandedAnalyticsFactory.savePaymentType).toHaveBeenCalledWith('visa', true)
+      })
+
+      it('should clear selectedPaymentMethod and defaultPaymentType when the selected payment method is undefined', () => {
+        jest.spyOn(self.controller.brandedAnalyticsFactory, 'savePaymentType')
+        self.controller.handlePaymentChange(undefined)
+
+        expect(self.controller.selectedPaymentMethod).toBeUndefined()
+        expect(self.controller.defaultPaymentType).toBeUndefined()
+        expect(self.controller.brandedAnalyticsFactory.savePaymentType).not.toHaveBeenCalled()
       })
     })
 

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -259,6 +259,15 @@ describe('checkout', () => {
         expect(self.controller.getContinueDisabled()).toBe(true)
       })
 
+      it('should return false when there are existing payment methods and at least one is valid', () => {
+        self.controller.handleExistingPaymentLoading(true, true)
+        self.controller.handlePaymentChange({})
+
+        expect(self.controller.existingPaymentMethods).toBe(true)
+        expect(self.controller.selectedPaymentMethod).not.toBeUndefined()
+        expect(self.controller.getContinueDisabled()).toBe(false)
+      })
+
       it('should return false when there are not existing payment methods', () => {
         self.controller.handleExistingPaymentLoading(true, false)
 

--- a/src/app/checkout/step-2/step-2.component.spec.js
+++ b/src/app/checkout/step-2/step-2.component.spec.js
@@ -121,21 +121,17 @@ describe('checkout', () => {
 
     describe('handlePaymentChange', () => {
       it('should change default payment type with bank account', () => {
-        jest.spyOn(self.controller, 'handlePaymentChange')
         jest.spyOn(self.controller.brandedAnalyticsFactory, 'savePaymentType')
         self.controller.handlePaymentChange({'account-type': 'checking'})
 
-        expect(self.controller.handlePaymentChange).toHaveBeenCalledWith({'account-type': 'checking'})
         expect(self.controller.defaultPaymentType).toEqual('checking')
         expect(self.controller.brandedAnalyticsFactory.savePaymentType).toHaveBeenCalledWith('checking', false)
       })
 
       it('should change default payment type with credit card', () => {
-        jest.spyOn(self.controller, 'handlePaymentChange')
         jest.spyOn(self.controller.brandedAnalyticsFactory, 'savePaymentType')
         self.controller.handlePaymentChange({'card-type': 'visa'})
 
-        expect(self.controller.handlePaymentChange).toHaveBeenCalledWith({'card-type': 'visa'})
         expect(self.controller.defaultPaymentType).toEqual('visa')
         expect(self.controller.brandedAnalyticsFactory.savePaymentType).toHaveBeenCalledWith('visa', true)
       })

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -42,7 +42,7 @@
       <button id="previousStepButton1" class="btn btn-default" ng-click="$ctrl.changeStep({newStep: 'contact'})">Previous Step</button>
     </div>
     <div class="col-sm-5 col-sm-offset-2">
-      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="!$ctrl.selectedPaymentMethod || $ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
+      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="$ctrl.getContinueDisabled()">
         Continue
       </button>
       <button id="previousStepButton2" class="btn btn-link btn-block visible-xs" ng-click="$ctrl.changeStep({newStep: 'contact'})"><i class="fa fa-angle-left"></i> Previous Step</button>

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -42,7 +42,7 @@
       <button id="previousStepButton1" class="btn btn-default" ng-click="$ctrl.changeStep({newStep: 'contact'})">Previous Step</button>
     </div>
     <div class="col-sm-5 col-sm-offset-2">
-      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
+      <button id="continueCheckoutButton" class="btn btn-primary pull-right btn-block-mobile" ng-click="$ctrl.submit()" ng-disabled="!$ctrl.selectedPaymentMethod || $ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'">
         Continue
       </button>
       <button id="previousStepButton2" class="btn btn-link btn-block visible-xs" ng-click="$ctrl.changeStep({newStep: 'contact'})"><i class="fa fa-angle-left"></i> Previous Step</button>


### PR DESCRIPTION
Prevent invalid payment methods from being selected by default on step 2 of checkout. This follow-up PR to #1091 fixes the bug that caused the Continue button on step 2 to always be disabled.

I tested a regular checkout flow in staging to ensure that the Continue button is enabled, but I wasn't able to test with expired credit cards in staging. I tested expired credit cards locally though.

https://jira.cru.org/browse/EP-2486