### PR TITLE
EP-2488 - Fix payment link

### DIFF
--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.js
@@ -37,7 +37,7 @@ class RecipientGift {
 
       const paymentMethodRequests = []; const paymentMethodUris = []
       angular.forEach(this.recipient.donations, (donation) => {
-        const uri = donation['payment-method-link'] && donation['payment-method-link'].uri
+        const uri = donation['payment-instrument-link'] && donation['payment-instrument-link'].uri
         if (uri && paymentMethodUris.indexOf(uri) < 0) {
           paymentMethodUris.push(uri)
           paymentMethodRequests.push(this.profileService.getPaymentMethod(uri, true))
@@ -52,7 +52,7 @@ class RecipientGift {
             })
 
             angular.forEach(this.recipient.donations, (donation) => {
-              const uri = donation['payment-method-link'] && donation['payment-method-link'].uri
+              const uri = donation['payment-instrument-link'] && donation['payment-instrument-link'].uri
               donation.paymentmethod = paymentMethods[uri]
             })
 

--- a/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.spec.js
+++ b/src/app/profile/yourGiving/recipientView/recipientGift/recipientGift.component.spec.js
@@ -55,7 +55,7 @@ describe('your giving', function () {
 
           $ctrl.recipient = {
             donations: [{
-              'payment-method-link': {
+              'payment-instrument-link': {
                 uri: '/payment/uri'
               },
               'historical-donation-line': {
@@ -80,7 +80,7 @@ describe('your giving', function () {
           $ctrl.profileService.getPaymentMethod.mockReturnValue(Observable.throw('some error'))
           $ctrl.recipient = {
             donations: [{
-              'payment-method-link': {
+              'payment-instrument-link': {
                 uri: '/payment/uri'
               },
               'historical-donation-line': {

--- a/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recent-recipients.fixture.js
@@ -110,7 +110,7 @@ export default {
             'transaction-date': { 'display-value': '2017-02-20', value: 1487548800000 },
             'transaction-sub-type': 'Credit Card'
           },
-          'payment-method-link': {
+          'payment-instrument-link': {
             rel: 'paymentmethod',
             type: 'elasticpath.paymentmethods.payment-method',
             uri: '/paymentmethods/crugive/giydknjsg4='
@@ -136,7 +136,7 @@ export default {
             'transaction-date': { 'display-value': '2017-02-20', value: 1487548800000 },
             'transaction-sub-type': 'Credit Card'
           },
-          'payment-method-link': {
+          'payment-instrument-link': {
             rel: 'paymentmethod',
             type: 'elasticpath.paymentmethods.payment-method',
             uri: '/paymentmethods/crugive/giydknjsg4='
@@ -171,7 +171,7 @@ export default {
             'transaction-date': { 'display-value': '2017-02-16', value: 1487203200000 },
             'transaction-sub-type': 'Credit Card'
           },
-          'payment-method-link': {
+          'payment-instrument-link': {
             rel: 'paymentmethod',
             type: 'elasticpath.paymentmethods.payment-method',
             uri: '/paymentmethods/crugive/giydimbvg4='
@@ -197,7 +197,7 @@ export default {
             'transaction-date': { 'display-value': '2017-02-16', value: 1487203200000 },
             'transaction-sub-type': 'Credit Card'
           },
-          'payment-method-link': {
+          'payment-instrument-link': {
             rel: 'paymentmethod',
             type: 'elasticpath.paymentmethods.payment-method',
             uri: '/paymentmethods/crugive/giydimbvg4='

--- a/src/common/services/api/fixtures/cortex-donations-recipient.fixture.js
+++ b/src/common/services/api/fixtures/cortex-donations-recipient.fixture.js
@@ -33,7 +33,7 @@ export default {
         'transaction-date': { 'display-value': '2017-01-10', value: 1484006400000 },
         'transaction-sub-type': 'Credit Card'
       },
-      'payment-method-link': {
+      'payment-instrument-link': {
         rel: 'paymentmethod',
         type: 'elasticpath.paymentmethods.payment-method',
         uri: '/paymentmethods/crugive/giydambvga='
@@ -59,7 +59,7 @@ export default {
         'transaction-date': { 'display-value': '2017-01-10', value: 1484006400000 },
         'transaction-sub-type': 'Credit Card'
       },
-      'payment-method-link': {
+      'payment-instrument-link': {
         rel: 'paymentmethod',
         type: 'elasticpath.paymentmethods.payment-method',
         uri: '/paymentmethods/crugive/giydambvga='
@@ -193,7 +193,7 @@ export default {
         'transaction-date': { 'display-value': '2016-08-22', value: 1471824000000 },
         'transaction-sub-type': 'EFT'
       },
-      'payment-method-link': {
+      'payment-instrument-link': {
         rel: 'paymentmethod',
         type: 'elasticpath.paymentmethods.payment-method',
         uri: '/paymentmethods/crugive/giydambrg4='


### PR DESCRIPTION
When we migrated to EP 8.1, the link got renamed from `payment-method-link` to `payment-instrument-link`, but that change did not get updated on the front-end. This only fixes the recipient view of historical donations, not the monthly view. Either monthly will have to be fixed on the back-end, or #1095 will fix it.