### PR TITLE
[no-Jira] Upgrade angular to final version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/runtime-corejs2": "^7.25.9",
     "@cruglobal/cru-payments": "^1.2.4",
     "@datadog/browser-rum": "^5.16.0",
-    "angular": "^1.8.2",
+    "angular": "^1.8.3",
     "angular-cookies": "^1.8.2",
     "angular-environment": "https://github.com/jonshaffer/angular-environment.git#d3082c06fb16804d324faac9b7e753fd64a44e5d",
     "angular-filter": "^0.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,15 +2472,10 @@ angular-ui-router@^1.0.30:
   dependencies:
     "@uirouter/core" "6.0.8"
 
-angular@*:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
-  integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==
-
-angular@>=1.5, angular@>=1.5.0, angular@^1.8.0, angular@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.2.tgz#5983bbb5a9fa63e213cb7749199e0d352de3a2f1"
-  integrity sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw==
+angular@*, angular@>=1.5, angular@>=1.5.0, angular@^1.8.0, angular@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.3.tgz#851ad75d5163c105a7e329555ef70c90aa706894"
+  integrity sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==
 
 ansi-colors@^3.0.0:
   version "3.2.4"


### PR DESCRIPTION
The lockfile contained two versions of angular. I'm not sure if version 1.7.9 was actually used, but I manually deleted the `angular@*` section from the lockfile and ran `yarn` to update the lockfile. Now we only have angular version 1.8.3 in the lockfile. Version 1.8.3 is the final version for AngularJS. This resolves two XSS security vulnerabilities.