### PR TITLE
[no-Jira] Dependabot upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "angular-ui-router": "^1.0.30",
     "bootstrap-sass": "^3.4.1",
     "change-case-object": "^2.0.0",
-    "crypto-js": "^3.1.9-1",
+    "crypto-js": "^4.2.0",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "change-case-object": "^2.0.0",
     "crypto-js": "^3.1.9-1",
     "jwt-decode": "^2.2.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/app/analytics/analytics.factory.spec.js
+++ b/src/app/analytics/analytics.factory.spec.js
@@ -188,7 +188,6 @@ describe('analytics factory', () => {
               "giftStartDate": moment(new Date(2024, 8, 15)),
               "giftStartDateDaysFromNow": 361,
               "giftStartDateWarning": true,
-              "$$hashKey": "object:506"
           }
       ],
       "frequencyTotals": [
@@ -216,7 +215,7 @@ describe('analytics factory', () => {
       self.analyticsFactory.buildProductVar(cartData)
 
       expect(self.$window.digitalData.cart.id).toEqual(cartData.id)
-      expect(self.$window.digitalData.cart.hash).not.toEqual(null)
+      expect(self.$window.digitalData.cart.hash).toEqual('330c050e7344971e9250')
       expect(self.$window.digitalData.cart.price.cartTotal).toEqual(cartData.cartTotal)
       expect(self.$window.digitalData.cart.item.length).toEqual(1)
     });
@@ -249,7 +248,6 @@ describe('analytics factory', () => {
       "giftStartDate": moment(new Date(2024, 8, 15)),
       "giftStartDateDaysFromNow": 361,
       "giftStartDateWarning": true,
-      "$$hashKey": "object:22",
       "removing": true
     }
 
@@ -532,7 +530,6 @@ describe('analytics factory', () => {
       "startMonth": null,
       "ministry": "Staff Giving",
       "orgId": "STAFF",
-      "$$hashKey": "object:26"
     }
     it('should add product-detail-click event', () => {
       self.analyticsFactory.productViewDetailsEvent(productData)
@@ -590,7 +587,6 @@ describe('analytics factory', () => {
       "giftStartDate": null,
       "giftStartDateDaysFromNow": 0,
       "giftStartDateWarning": false,
-      "$$hashKey": "object:66"
     }
     const transactionCart = {
       "id": "grsgezrxhfqtsljrga3gkljugvtdaljygjqtcl",
@@ -602,7 +598,6 @@ describe('analytics factory', () => {
               "amountWithFees": 51.2,
               "total": "$50.00",
               "totalWithFees": "$51.20",
-              "$$hashKey": "object:68"
           }
       ],
       "cartTotal": 50,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7021,12 +7021,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.20, lodash@^4.17.4:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,10 +3680,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 css-loader@^3.2.0:
   version "3.6.0"


### PR DESCRIPTION
This is the last of the dependabot warnings that look relevant to me. The rest are related to dev dependencies (mostly pulled in by `webpack-dev-server`, which isn't used in production), a couple of ReDOS vulnerabilities in Angular, and possible XSS in Internet Explorer.

The crypto-js warning isn't in a function we're using, but I'm upgrading it anyway. I'm not sure if the lodash vulnerabilities are exploitable in our code, but I'm upgrading it anyway also.