### PR TITLE
EP-2518 - Remove ConfirmationStep

### DIFF
--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -75,8 +75,13 @@ class BrandedCheckoutController {
   next () {
     switch (this.checkoutStep) {
       case 'giftContactPayment':
-        this.checkoutStep = 'review'
-        this.fireAnalyticsEvents('review')
+        // If it is a single step form, the next step should be 'thankYou'
+        if (this.useV3 === 'true') {
+          this.checkoutStep = 'thankYou'
+        } else {
+          this.checkoutStep = 'review'
+          this.fireAnalyticsEvents('review')
+        }
         break
       case 'review':
         this.checkoutStep = 'thankYou'
@@ -182,6 +187,6 @@ export default angular
       onOrderFailed: '&',
       language: '@',
       showCoverFees: '@',
-      useV3: '@',
+      useV3: '@'
     }
   })

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -7,19 +7,25 @@ import checkoutStep2 from 'app/checkout/step-2/step-2.component'
 
 import cartService from 'common/services/api/cart.service'
 import orderService from 'common/services/api/order.service'
+import analyticsFactory from '../../analytics/analytics.factory'
 import brandedAnalyticsFactory from '../../branded/analytics/branded-analytics.factory'
-
 import { FEE_DERIVATIVE } from 'common/components/paymentMethods/coverFees/coverFees.component'
 
 import template from './branded-checkout-step-1.tpl.html'
+import 'rxjs/add/operator/catch'
+import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/finally'
 
 const componentName = 'brandedCheckoutStep1'
 
 class BrandedCheckoutStep1Controller {
   /* @ngInject */
-  constructor ($log, $filter, brandedAnalyticsFactory, cartService, orderService) {
+  constructor ($scope, $log, $filter, $window, analyticsFactory, brandedAnalyticsFactory, cartService, orderService) {
+    this.$scope = $scope
     this.$log = $log
     this.$filter = $filter
+    this.$window = $window
+    this.analyticsFactory = analyticsFactory
     this.brandedAnalyticsFactory = brandedAnalyticsFactory
     this.cartService = cartService
     this.orderService = orderService
@@ -154,11 +160,111 @@ class BrandedCheckoutStep1Controller {
   checkSuccessfulSubmission () {
     if (every(this.submission, 'completed')) {
       if (every(this.submission, { error: false })) {
-        this.next()
+        if (this.useV3 === 'true') {
+          this.submitOrderInternal()
+        } else {
+          this.next()
+        }
       } else {
         this.submitted = false
       }
     }
+  }
+
+  loadCart () {
+    this.errorLoadingCart = false
+
+    const cart = this.cartService.get()
+    cart.subscribe(
+      data => {
+        // Setting cart data and analytics
+        this.cartData = data
+        this.brandedAnalyticsFactory.saveCoverFees(this.orderService.retrieveCoverFeeDecision())
+        if (this.cartData && this.cartData.items) {
+          this.brandedAnalyticsFactory.saveItem(this.cartData.items[0])
+        }
+        this.brandedAnalyticsFactory.addPaymentInfo()
+      },
+      error => {
+        // Handle errors by setting flag and logging the error
+        this.errorLoadingCart = true
+        this.$log.error('Error loading cart data for branded checkout (single step)', error)
+      }
+    )
+    return cart
+  }
+
+  loadCurrentPayment () {
+    this.loadingCurrentPayment = true
+
+    const getCurrentPayment = this.orderService.getCurrentPayment()
+    getCurrentPayment.finally(() => {
+      this.loadingCurrentPayment = false
+    }).subscribe(
+      data => {
+        if (!data) {
+          this.$log.error('Error loading current payment info: current payment doesn\'t seem to exist')
+        } else if (data['account-type']) {
+          this.bankAccountPaymentDetails = data
+        } else if (data['card-type']) {
+          this.creditCardPaymentDetails = data
+        } else {
+          this.$log.error('Error loading current payment info: current payment type is unknown')
+        }
+      },
+      error => {
+        this.$log.error('Error loading current payment info', error)
+      }
+    )
+    return getCurrentPayment
+  }
+
+  checkErrors () {
+    // Then check for errors on the API
+    return this.orderService.checkErrors().do(
+      (data) => {
+        this.needinfoErrors = data
+      })
+      .catch(error => {
+        this.$log.error('Error loading checkErrors', error)
+      })
+  }
+
+  submitOrderInternal () {
+    this.loadingAndSubmitting = true
+    this.loadCart()
+      .mergeMap(() => {
+        return this.loadCurrentPayment()
+      })
+      .mergeMap(() => {
+        return this.checkErrors()
+      })
+      .mergeMap(() => {
+        return this.orderService.submitOrder(this)
+      })
+      .finally(() => {
+        this.loadingAndSubmitting = false
+      })
+      .subscribe(() => {
+        this.next()
+      })
+  }
+
+  handleRecaptchaFailure () {
+    this.analyticsFactory.checkoutFieldError('submitOrder', 'failed')
+    this.submittingOrder = false
+    this.loadingAndSubmitting = false
+    this.onSubmittingOrder({ value: false })
+
+    this.loadCart()
+
+    this.onSubmitted()
+    this.submissionError = 'generic error'
+    this.$window.scrollTo(0, 0)
+  }
+
+  canSubmitOrder () {
+    return !this.submittingOrder
   }
 }
 
@@ -169,6 +275,7 @@ export default angular
     checkoutStep2.name,
     cartService.name,
     orderService.name,
+    analyticsFactory.name,
     brandedAnalyticsFactory.name
   ])
   .component(componentName, {
@@ -189,6 +296,9 @@ export default angular
       onPaymentFailed: '&',
       radioStationApiUrl: '<',
       radioStationRadius: '<',
+      onSubmittingOrder: '&',
+      onSubmitted: '&',
       useV3: '<',
+      loadingAndSubmitting: '<'
     }
   })

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -4,6 +4,7 @@ import every from 'lodash/every'
 import productConfigForm from 'app/productConfig/productConfigForm/productConfigForm.component'
 import contactInfo from 'common/components/contactInfo/contactInfo.component'
 import checkoutStep2 from 'app/checkout/step-2/step-2.component'
+import checkoutErrorMessages from 'app/checkout/checkout-error-messages/checkout-error-messages.component'
 
 import cartService from 'common/services/api/cart.service'
 import orderService from 'common/services/api/order.service'
@@ -273,6 +274,7 @@ export default angular
     productConfigForm.name,
     contactInfo.name,
     checkoutStep2.name,
+    checkoutErrorMessages.name,
     cartService.name,
     orderService.name,
     analyticsFactory.name,

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -46,10 +46,26 @@
   </div>
   <div class="panel">
     <div class="panel-body text-right">
-      <button class="btn btn-primary"
+      <div class="checkout-cta pull-right" ng-if="$ctrl.useV3 === 'true'">
+       <recaptcha-wrapper
+              action="'branded_submit'"
+              on-success="$ctrl.submit"
+              on-failure="$ctrl.handleRecaptchaFailure"
+              component-instance="$ctrl"
+              button-id="'submitOrderButton'"
+              button-type="'submit'"
+              button-classes="'btn btn-primary btn-lg btn-block'"
+              button-disabled="$ctrl.errorLoadingProductConfig || !$ctrl.canSubmitOrder()"
+              button-label="'SUBMIT_GIFT'"></recaptcha-wrapper>
+        </div>
+
+      <button ng-if="$ctrl.useV3 !== 'true'" class="btn btn-primary"
               ng-click="$ctrl.submit()"
               ng-disabled="$ctrl.errorLoadingProductConfig"
               translate>{{'CONTINUE'}}</button>
-    </div>
+  </div>
   </div>
 </div>
+<loading type="fixed" ng-if="$ctrl.loadingAndSubmitting">
+  <translate>{{'SUBMITTING_GIFT'}}</translate>
+</loading>

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -1,3 +1,8 @@
+<checkout-error-messages
+  needinfo-errors="$ctrl.needinfoErrors"
+  submission-error="$ctrl.submissionError"
+  submission-error-status="$ctrl.submissionErrorStatus">
+</checkout-error-messages>
 <div class="panel">
   <div class="panel-body loading-overlay-parent">
     <loading ng-if="$ctrl.loadingProductConfig">

--- a/src/app/cart/cart.component.js
+++ b/src/app/cart/cart.component.js
@@ -10,7 +10,7 @@ import productModalService from 'common/services/productModal.service'
 import desigSrcDirective from 'common/directives/desigSrc.directive'
 
 import displayRateTotals from 'common/components/displayRateTotals/displayRateTotals.component'
-import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { cartUpdatedEvent } from 'common/lib/cartEvents'
 
 import analyticsFactory from 'app/analytics/analytics.factory'
 

--- a/src/app/cart/cart.component.spec.js
+++ b/src/app/cart/cart.component.spec.js
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
 
-import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { cartUpdatedEvent } from 'common/lib/cartEvents'
 
 describe('cart', () => {
   beforeEach(angular.mock.module(module.name))

--- a/src/app/checkout/cart-summary/cart-summary.component.js
+++ b/src/app/checkout/cart-summary/cart-summary.component.js
@@ -13,8 +13,9 @@ export const submitOrderEvent = 'submitOrderEvent'
 
 class CartSummaryController {
   /* @ngInject */
-  constructor (cartService, $scope) {
+  constructor (cartService, $scope, $rootScope) {
     this.$scope = $scope
+    this.$rootScope = $rootScope
     this.cartService = cartService
   }
 
@@ -22,12 +23,12 @@ class CartSummaryController {
     return this.cartService.buildCartUrl()
   }
 
-  handleRecaptchaFailure (componentInstance) {
-    componentInstance.$rootScope.$emit(recaptchaFailedEvent)
+  handleRecaptchaFailure () {
+    this.$rootScope.$emit(recaptchaFailedEvent)
   }
 
-  onSubmit (componentInstance) {
-    componentInstance.$rootScope.$emit(submitOrderEvent)
+  onSubmit () {
+    this.$rootScope.$emit(submitOrderEvent)
   }
 }
 

--- a/src/app/checkout/cart-summary/cart-summary.spec.js
+++ b/src/app/checkout/cart-summary/cart-summary.spec.js
@@ -31,17 +31,17 @@ describe('checkout', function () {
 
     describe('onSubmit', () => {
       it('should emit an event', () => {
-        jest.spyOn(componentInstance.$rootScope, '$emit').mockImplementation(() => {})
-        self.controller.onSubmit(componentInstance)
-        expect(componentInstance.$rootScope.$emit).toHaveBeenCalledWith(submitOrderEvent)
+        jest.spyOn(self.controller.$rootScope, '$emit').mockImplementation(() => {})
+        self.controller.onSubmit()
+        expect(self.controller.$rootScope.$emit).toHaveBeenCalledWith(submitOrderEvent)
       })
     })
 
     describe('handleRecaptchaFailure', () => {
       it('should emit an event', () => {
-        jest.spyOn(componentInstance.$rootScope, '$emit').mockImplementation(() => {})
-        self.controller.handleRecaptchaFailure(componentInstance)
-        expect(componentInstance.$rootScope.$emit).toHaveBeenCalledWith(recaptchaFailedEvent)
+        jest.spyOn(self.controller.$rootScope, '$emit').mockImplementation(() => {})
+        self.controller.handleRecaptchaFailure()
+        expect(self.controller.$rootScope.$emit).toHaveBeenCalledWith(recaptchaFailedEvent)
       })
     })
   })

--- a/src/app/checkout/checkout-error-messages/checkout-error-messages.component.js
+++ b/src/app/checkout/checkout-error-messages/checkout-error-messages.component.js
@@ -1,0 +1,19 @@
+import angular from 'angular'
+
+import template from './checkout-error-messages.tpl.html'
+
+const componentName = 'checkoutErrorMessages'
+
+class CheckoutErrorMessagesController {}
+
+export default angular
+  .module(componentName, [])
+  .component(componentName, {
+    controller: CheckoutErrorMessagesController,
+    templateUrl: template,
+    bindings: {
+      needinfoErrors: '<',
+      submissionError: '<',
+      submissionErrorStatus: '<'
+    }
+  })

--- a/src/app/checkout/checkout-error-messages/checkout-error-messages.tpl.html
+++ b/src/app/checkout/checkout-error-messages/checkout-error-messages.tpl.html
@@ -1,0 +1,44 @@
+<div class="alert alert-danger" role="alert" ng-if="$ctrl.needinfoErrors || $ctrl.submissionError">
+  <p ng-repeat="error in $ctrl.needinfoErrors" ng-switch="error">
+    <span ng-switch-when="need.email" translate>{{'REVIEW_EMAIL_ERROR'}}</span>
+    <span ng-switch-when="need.payment.method" translate>{{'REVIEW_PAYMENT_ERROR'}}</span>
+    <span ng-switch-when="need.billing.address" translate>{{'REVIEW_BILLING_ADDRESS_ERROR'}}</span>
+    <span ng-switch-default translate>
+      <span ng-if="$ctrl.submissionErrorStatus > -1" translate>
+        {{'REVIEW_MISSING_DATA_ERROR'}}
+      </span>
+      <span ng-if="$ctrl.submissionErrorStatus === -1" translate>
+        {{'REVIEW_TIME_OUT_ERROR'}}
+      </span>
+    </span>
+  </p>
+  <p ng-if="$ctrl.submissionError" ng-switch="$ctrl.submissionError">
+    <span ng-switch-when="Current payment type is unknown" translate>
+      {{'REVIEW_SUBMITTING_PAYMENT_ERROR'}}
+    </span>
+    <span ng-switch-when="CardExpiredException" translate>
+      {{'REVIEW_CARD_EXPIRED_ERROR'}}
+    </span>
+    <span ng-switch-when="CardErrorException" translate>
+      {{'REVIEW_INVALID_CARD_ERROR'}}
+    </span>
+    <span ng-switch-when="CardDeclinedException" translate>
+      {{'REVIEW_CARD_DECLINED_ERROR'}}
+    </span>
+    <span ng-switch-when="InsufficientFundException" translate>
+      {{'REVIEW_INSUFFICIENT_FUNDS_ERROR'}}
+    </span>
+    <span ng-switch-when="AuthorizedAmountExceededException" translate>
+      {{'REVIEW_EXCEEDS_BALANCE_ERROR'}}
+    </span>
+    <span ng-switch-when="InvalidCVV2Exception" translate>
+      {{'REVIEW_INVALID_SEC_CODE_ERROR'}}
+    </span>
+    <span ng-switch-when="InvalidAddressException" translate>
+      {{'REVIEW_ADDRESS_MISMATCH_ERROR'}}
+    </span>
+    <span ng-switch-default translate>
+      {{'REVIEW_DEFAULT_ERROR'}}
+    </span>
+  </p>
+</div>

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -2,6 +2,7 @@ import angular from 'angular'
 import 'rxjs/add/observable/throw'
 
 import displayAddressComponent from 'common/components/display-address/display-address.component'
+import checkoutErrorMessages from 'app/checkout/checkout-error-messages/checkout-error-messages.component'
 import displayRateTotals from 'common/components/displayRateTotals/displayRateTotals.component'
 
 import commonService from 'common/services/api/common.service'
@@ -163,7 +164,8 @@ export default angular
     analyticsFactory.name,
     cartService.name,
     commonService.name,
-    recaptchaComponent.name
+    recaptchaComponent.name,
+    checkoutErrorMessages.name
   ])
   .component(componentName, {
     controller: Step3Controller,

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -139,16 +139,16 @@ class Step3Controller {
     })
   }
 
-  handleRecaptchaFailure (componentInstance) {
-    componentInstance.analyticsFactory.checkoutFieldError('submitOrder', 'failed')
-    componentInstance.submittingOrder = false
-    componentInstance.onSubmittingOrder({ value: false })
+  handleRecaptchaFailure () {
+    this.analyticsFactory.checkoutFieldError('submitOrder', 'failed')
+    this.submittingOrder = false
+    this.onSubmittingOrder({ value: false })
 
-    componentInstance.loadCart()
+    this.loadCart()
 
-    componentInstance.onSubmitted()
-    componentInstance.submissionError = 'generic error'
-    componentInstance.$window.scrollTo(0, 0)
+    this.onSubmitted()
+    this.submissionError = 'generic error'
+    this.$window.scrollTo(0, 0)
   }
 }
 

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -4,7 +4,6 @@ import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
 
-import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
 import { SignInEvent } from 'common/services/session/session.service'
 
 import module from './step-3.component'
@@ -37,6 +36,7 @@ describe('checkout', () => {
           getCurrentPayment: () => Observable.of(self.loadedPayment),
           checkErrors: () => Observable.of(['email-info']),
           submit: () => Observable.of('called submit'),
+          submitOrder: () => Observable.of('called submitOrder'),
           retrieveCardSecurityCode: () => self.storedCvv,
           retrieveLastPurchaseLink: () => Observable.of('purchaseLink'),
           retrieveCoverFeeDecision: () => self.coverFeeDecision,
@@ -323,144 +323,18 @@ describe('checkout', () => {
       })
     })
 
-    describe('submitOrder', () => {
-      beforeEach(() => {
-        jest.spyOn(self.controller.orderService, 'submit')
-        jest.spyOn(self.controller.profileService, 'getPurchase')
-        jest.spyOn(self.controller.analyticsFactory, 'purchase')
-      })
-
-      describe('another order submission in progress', () => {
-        it('should not submit the order twice', () => {
-          self.controller.submittingOrder = true
-          self.controller.submitOrder()
-
-          expect(self.controller.onSubmittingOrder).not.toHaveBeenCalled()
-          expect(self.controller.onSubmitted).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('submit single order', () => {
-        beforeEach(() => {
-          jest.spyOn(self.controller.$scope, '$emit').mockImplementation(() => {})
-        })
-
-        afterEach(() => {
-          expect(self.controller.onSubmittingOrder).toHaveBeenCalledWith({ value: true })
-          expect(self.controller.onSubmittingOrder).toHaveBeenCalledWith({ value: false })
-          expect(self.controller.onSubmitted).toHaveBeenCalled()
-        })
-
-        it('should submit the order normally if paying with a bank account', () => {
-          self.controller.bankAccountPaymentDetails = {}
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalled()
-          expect(self.controller.analyticsFactory.purchase).toHaveBeenCalledWith(self.controller.donorDetails, self.controller.cartData, self.coverFeeDecision)
-          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled()
-          expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'thankYou' })
-          expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-        })
-
-        it('should handle an error submitting an order with a bank account', () => {
-          self.controller.orderService.submit.mockImplementation(() => Observable.throw({ data: 'error saving bank account' }))
-          self.controller.bankAccountPaymentDetails = {}
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalled()
-          expect(self.controller.loadCart).toHaveBeenCalled()
-          expect(self.controller.analyticsFactory.purchase).not.toHaveBeenCalled()
-          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'error saving bank account' }])
-          expect(self.controller.changeStep).not.toHaveBeenCalled()
-          expect(self.controller.submissionError).toEqual('error saving bank account')
-          expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0)
-        })
-
-        it('should submit the order with a CVV if paying with a credit card', () => {
-          self.controller.creditCardPaymentDetails = {}
-          self.storedCvv = '1234'
-          self.coverFeeDecision = true
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234')
-          expect(self.controller.analyticsFactory.purchase).toHaveBeenCalledWith(self.controller.donorDetails, self.controller.cartData, self.coverFeeDecision)
-          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled()
-          expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'thankYou' })
-          expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-        })
-
-        it('should submit the order without a CVV if paying with an existing credit card or the cvv in session storage is missing', () => {
-          self.controller.creditCardPaymentDetails = {}
-          self.storedCvv = undefined
-          self.coverFeeDecision = true
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalledWith(undefined)
-          expect(self.controller.analyticsFactory.purchase).toHaveBeenCalledWith(self.controller.donorDetails, self.controller.cartData, self.coverFeeDecision)
-          expect(self.controller.orderService.clearCardSecurityCodes).toHaveBeenCalled()
-          expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'thankYou' })
-          expect(self.controller.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-        })
-
-        it('should handle an error submitting an order with a credit card', () => {
-          self.controller.orderService.submit.mockImplementation(() => Observable.throw({ data: 'CardErrorException: Invalid Card Number: some details' }))
-          self.controller.creditCardPaymentDetails = {}
-          self.storedCvv = '1234'
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234')
-          expect(self.controller.analyticsFactory.purchase).not.toHaveBeenCalled()
-          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'CardErrorException: Invalid Card Number: some details' }])
-          expect(self.controller.changeStep).not.toHaveBeenCalled()
-          expect(self.controller.submissionError).toEqual('CardErrorException')
-          expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0)
-        })
-
-        it('should mask the security code on a credit card error', () => {
-          self.controller.orderService.submit.mockReturnValue(Observable.throw({ data: 'some error', config: { data: { 'security-code': '1234' } } }))
-          self.controller.creditCardPaymentDetails = {}
-          self.storedCvv = '1234'
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).toHaveBeenCalledWith('1234')
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'some error', config: { data: { 'security-code': 'XXXX' } } }])
-        })
-
-        it('should throw an error if neither bank account or credit card details are loaded', () => {
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.submit).not.toHaveBeenCalled()
-          expect(self.controller.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
-          expect(self.controller.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'Current payment type is unknown' }])
-          expect(self.controller.changeStep).not.toHaveBeenCalled()
-          expect(self.controller.submissionError).toEqual('Current payment type is unknown')
-          expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0)
-        })
-
-        it('should clear out cover fee data', () => {
-          self.controller.creditCardPaymentDetails = {}
-          self.controller.submitOrder()
-
-          expect(self.controller.orderService.clearCoverFees).toHaveBeenCalled()
-        })
-      })
-    })
-
     describe('handleRecaptchaFailure', () => {
       it('should show an error if recaptcha fails', () => {
-        const componentInstance = self.controller
-        jest.spyOn(componentInstance.analyticsFactory, 'checkoutFieldError').mockImplementation(() => {})
-        self.controller.handleRecaptchaFailure(componentInstance)
+        jest.spyOn(self.controller.analyticsFactory, 'checkoutFieldError').mockImplementation(() => {})
+        self.controller.handleRecaptchaFailure()
 
-        expect(componentInstance.analyticsFactory.checkoutFieldError).toHaveBeenCalledWith('submitOrder', 'failed')
-        expect(componentInstance.submittingOrder).toEqual(false)
-        expect(componentInstance.onSubmittingOrder).toHaveBeenCalledWith({ value: false })
-        expect(componentInstance.loadCart).toHaveBeenCalled()
-        expect(componentInstance.onSubmitted).toHaveBeenCalled()
-        expect(componentInstance.submissionError).toEqual('generic error')
-        expect(componentInstance.$window.scrollTo).toHaveBeenCalledWith(0, 0)
+        expect(self.controller.analyticsFactory.checkoutFieldError).toHaveBeenCalledWith('submitOrder', 'failed')
+        expect(self.controller.submittingOrder).toEqual(false)
+        expect(self.controller.onSubmittingOrder).toHaveBeenCalledWith({ value: false })
+        expect(self.controller.loadCart).toHaveBeenCalled()
+        expect(self.controller.onSubmitted).toHaveBeenCalled()
+        expect(self.controller.submissionError).toEqual('generic error')
+        expect(self.controller.$window.scrollTo).toHaveBeenCalledWith(0, 0)
       })
     })
 
@@ -474,7 +348,32 @@ describe('checkout', () => {
       it('should call handleRecaptchaFailure if the recaptchaFailedEvent is received', () => {
         jest.spyOn(self.controller, 'handleRecaptchaFailure').mockImplementation(() => {})
         self.controller.$rootScope.$emit(recaptchaFailedEvent)
-        expect(self.controller.handleRecaptchaFailure).toHaveBeenCalledWith(self.controller)
+        expect(self.controller.handleRecaptchaFailure).toHaveBeenCalled();
+      })
+    })
+
+    describe('submitOrder', () => {
+      beforeEach(() => {
+        jest.spyOn(self.controller.analyticsFactory, 'purchase')
+        jest.spyOn(self.controller.orderService, 'retrieveCoverFeeDecision').mockReturnValue(true)
+      })
+
+      it('should call analyticsFactory when it is not branded checkout', () => {
+        self.controller.isBranded = false
+        
+        self.controller.submitOrder()
+        
+        expect(self.controller.analyticsFactory.purchase).toHaveBeenCalledWith(self.controller.donorDetails, self.controller.cartData, self.controller.orderService.retrieveCoverFeeDecision())
+        expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'thankYou' })
+      })
+
+      it('should not call analyticsFactory when it is branded checkout', () => {
+        self.controller.isBranded = true
+
+        self.controller.submitOrder()
+        
+        expect(self.controller.analyticsFactory.purchase).not.toHaveBeenCalled()
+        expect(self.controller.changeStep).toHaveBeenCalledWith({ newStep: 'thankYou' })
       })
     })
   })

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -206,7 +206,7 @@
                            action="$ctrl.isBranded ? 'branded_submit' : 'submit_gift'"
                            on-success="$ctrl.submitOrder"
                            on-failure="$ctrl.handleRecaptchaFailure"
-                           component-instance="$ctrl.selfReference"
+                           component-instance="$ctrl"
                            button-id="'submitOrderButton'"
                            button-type="'submit'"
                            button-classes="'btn btn-primary btn-lg btn-block'"

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -1,48 +1,9 @@
 <div class="loading-overlay-parent">
-  <div class="alert alert-danger" role="alert" ng-if="$ctrl.needinfoErrors || $ctrl.submissionError">
-    <p ng-repeat="error in $ctrl.needinfoErrors" ng-switch="error">
-      <span ng-switch-when="need.email" translate>{{'REVIEW_EMAIL_ERROR'}}</span>
-      <span ng-switch-when="need.payment.method" translate>{{'REVIEW_PAYMENT_ERROR'}}</span>
-      <span ng-switch-when="need.billing.address" translate>{{'REVIEW_BILLING_ADDRESS_ERROR'}}</span>
-      <span ng-switch-default translate>
-        <span ng-if="$ctrl.submissionErrorStatus > -1" translate>
-          {{'REVIEW_MISSING_DATA_ERROR'}}
-        </span>
-       <span ng-if="$ctrl.submissionErrorStatus === -1" translate>
-         {{'REVIEW_TIME_OUT_ERROR'}}
-       </span>
-      </span>
-    </p>
-    <p ng-if="$ctrl.submissionError" ng-switch="$ctrl.submissionError">
-      <span ng-switch-when="Current payment type is unknown" translate>
-        {{'REVIEW_SUBMITTING_PAYMENT_ERROR'}}
-      </span>
-      <span ng-switch-when="CardExpiredException" translate>
-        {{'REVIEW_CARD_EXPIRED_ERROR'}}
-      </span>
-      <span ng-switch-when="CardErrorException" translate>
-        {{'REVIEW_INVALID_CARD_ERROR'}}
-      </span>
-      <span ng-switch-when="CardDeclinedException" translate>
-        {{'REVIEW_CARD_DECLINED_ERROR'}}
-      </span>
-      <span ng-switch-when="InsufficientFundException" translate>
-        {{'REVIEW_INSUFFICIENT_FUNDS_ERROR'}}
-      </span>
-      <span ng-switch-when="AuthorizedAmountExceededException" translate>
-        {{'REVIEW_EXCEEDS_BALANCE_ERROR'}}
-      </span>
-      <span ng-switch-when="InvalidCVV2Exception" translate>
-        {{'REVIEW_INVALID_SEC_CODE_ERROR'}}
-      </span>
-      <span ng-switch-when="InvalidAddressException" translate>
-        {{'REVIEW_ADDRESS_MISMATCH_ERROR'}}
-      </span>
-      <span ng-switch-default translate>
-        {{'REVIEW_DEFAULT_ERROR'}}
-      </span>
-    </p>
-  </div>
+  <checkout-error-messages
+    needinfo-errors="$ctrl.needinfoErrors"
+    submission-error="$ctrl.submissionError"
+    submission-error-status="$ctrl.submissionErrorStatus">
+  </checkout-error-messages>
   <div class="mb">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -204,7 +204,7 @@
               <div class="checkout-cta pull-right">
                 <recaptcha-wrapper
                            action="$ctrl.isBranded ? 'branded_submit' : 'submit_gift'"
-                           on-success="$ctrl.submitOrderInternal"
+                           on-success="$ctrl.submitOrder"
                            on-failure="$ctrl.handleRecaptchaFailure"
                            component-instance="$ctrl.selfReference"
                            button-id="'submitOrderButton'"

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -27,7 +27,7 @@ import {
 } from 'common/services/giftHelpers/giftDates.service'
 import desigSrcDirective from 'common/directives/desigSrc.directive'
 import showErrors from 'common/filters/showErrors.filter'
-import { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 import { giveGiftParams } from '../giveGiftParams'
 import loading from 'common/components/loading/loading.component'
 import analyticsFactory from 'app/analytics/analytics.factory'

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.spec.js
@@ -7,7 +7,7 @@ import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
 
 import module, { brandedCoverFeeCheckedEvent } from './productConfigForm.component'
-import { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 import { giveGiftParams } from '../giveGiftParams'
 import { brandedCheckoutAmountUpdatedEvent } from '../../../common/components/paymentMethods/coverFees/coverFees.component'
 

--- a/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.component.js
+++ b/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.component.js
@@ -5,7 +5,7 @@ import concat from 'lodash/concat'
 import step1SelectRecentRecipients from './step1/selectRecentRecipients.component'
 import step1SearchRecipients from './step1/searchRecipients.component'
 import step2EnterAmounts from './step2/enterAmounts.component'
-import { giftAddedEvent } from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent } from 'common/lib/cartEvents'
 
 import RecurringGiftModel from 'common/models/recurringGift.model'
 

--- a/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.component.spec.js
+++ b/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.component.spec.js
@@ -6,7 +6,7 @@ import 'rxjs/add/observable/from'
 import 'rxjs/add/observable/throw'
 
 import RecurringGiftModel from 'common/models/recurringGift.model'
-import { giftAddedEvent } from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent } from 'common/lib/cartEvents'
 
 import module from './giveOneTimeGift.modal.component'
 

--- a/src/common/components/Recaptcha/Recaptcha.test.tsx
+++ b/src/common/components/Recaptcha/Recaptcha.test.tsx
@@ -247,7 +247,6 @@ describe('Recaptcha component', () => {
       action='submit_gift'
       onSuccess={onSuccess}
       onFailure={onFailure}
-      componentInstance={{}}
       buttonId='id'
       buttonType={ButtonType.Submit}
       buttonClasses='btn'

--- a/src/common/components/Recaptcha/Recaptcha.tsx
+++ b/src/common/components/Recaptcha/Recaptcha.tsx
@@ -22,9 +22,8 @@ const isValidAction = (action: string): boolean => {
 
 interface RecaptchaProps {
   action: string
-  onSuccess: (componentInstance: any) => void
-  onFailure: (componentInstance: any) => void
-  componentInstance: any
+  onSuccess: () => void
+  onFailure: () => void
   buttonId: string
   buttonType?: ButtonType
   buttonClasses: string
@@ -40,7 +39,6 @@ export const Recaptcha = ({
   action,
   onSuccess,
   onFailure,
-  componentInstance,
   buttonId,
   buttonType,
   buttonClasses,
@@ -89,29 +87,29 @@ export const Recaptcha = ({
         if (data?.success === true && isValidAction(data?.action)) {
           if (data.score < 0.5) {
             $log.warn(`Captcha score was below the threshold: ${data.score}`)
-            onFailure(componentInstance)
+            onFailure()
             return
           }
-          onSuccess(componentInstance)
+          onSuccess()
           return
         }
         if (data?.success === false && isValidAction(data?.action)) {
           $log.warn('Recaptcha call was unsuccessful, continuing anyway')
-          onSuccess(componentInstance)
+          onSuccess()
           return
         }
         if (!data) {
           $log.warn('Data was missing!')
-          onSuccess(componentInstance)
+          onSuccess()
           return
         }
         if (!isValidAction(data?.action)) {
           $log.warn(`Invalid action: ${data?.action}`)
-          onFailure(componentInstance)
+          onFailure()
         }
       } catch (error) {
         $log.error(`Failed to verify recaptcha, continuing on: ${error}`)
-        onSuccess(componentInstance)
+        onSuccess()
       }
     })
   }, [grecaptcha, buttonId, ready])
@@ -135,7 +133,6 @@ export default angular
         'action',
         'onSuccess',
         'onFailure',
-        'componentInstance',
         'buttonId',
         'buttonType',
         'buttonClasses',

--- a/src/common/components/Recaptcha/RecaptchaWrapper.test.tsx
+++ b/src/common/components/Recaptcha/RecaptchaWrapper.test.tsx
@@ -16,6 +16,10 @@ describe('RecaptchaWrapper component', () => {
     warn: jest.fn()
   }
 
+  const $rootScope = {
+    $apply: jest.fn()
+  }
+
   const mockExecuteRecaptcha = jest.fn()
   const mockRecaptchaReady = jest.fn()
   const mockRecaptcha = {
@@ -48,6 +52,7 @@ describe('RecaptchaWrapper component', () => {
         envService={envService}
         $translate={$translate}
         $log={$log}
+        $rootScope={$rootScope}
       />
     )
     expect(getAllByRole('button')).toHaveLength(1)
@@ -75,6 +80,7 @@ describe('RecaptchaWrapper component', () => {
         envService={envService}
         $translate={$translate}
         $log={$log}
+        $rootScope={$rootScope}
       />
     )
     expect(document.getElementById('give-checkout-recaptcha')).not.toBeNull()

--- a/src/common/components/Recaptcha/RecaptchaWrapper.tsx
+++ b/src/common/components/Recaptcha/RecaptchaWrapper.tsx
@@ -13,8 +13,8 @@ declare global {
 
 interface RecaptchaWrapperProps {
   action: string
-  onSuccess: (componentInstance: any) => void
-  onFailure: (componentInstance: any) => void
+  onSuccess: () => void
+  onFailure: () => void
   componentInstance: any
   buttonId: string
   buttonType?: ButtonType
@@ -24,6 +24,7 @@ interface RecaptchaWrapperProps {
   envService: any
   $translate: any
   $log: any
+  $rootScope: any
 }
 
 export const RecaptchaWrapper = ({
@@ -38,7 +39,8 @@ export const RecaptchaWrapper = ({
   buttonLabel,
   envService,
   $translate,
-  $log
+  $log,
+  $rootScope
 }: RecaptchaWrapperProps): JSX.Element => {
   const recaptchaKey = envService.read('recaptchaKey')
   const apiUrl = envService.read('apiUrl')
@@ -50,11 +52,23 @@ export const RecaptchaWrapper = ({
     document.body.appendChild(script)
   }, [])
 
+  // Because The onSuccess and onFailure callbacks are called by a React component, AngularJS doesn't know that an event happened and doesn't know it needs to rerender. We have to use $apply to ensure that AngularJS rerenders after the event handlers return.
+  const onSuccessWrapped = (() => {
+    $rootScope.$apply(() => {
+      onSuccess.call(componentInstance)
+    })
+  })
+
+  const onFailureWrapped = (() => {
+    $rootScope.$apply(() => {
+      onFailure.call(componentInstance)
+    })
+  })
+
   return (
       <Recaptcha action={action}
-                 onSuccess={onSuccess}
-                 onFailure={onFailure}
-                 componentInstance={componentInstance}
+                 onSuccess={onSuccessWrapped}
+                 onFailure={onFailureWrapped}
                  buttonId={buttonId}
                  buttonType={buttonType}
                  buttonClasses={buttonClasses}
@@ -84,4 +98,4 @@ export default angular
         'buttonDisabled',
         'buttonLabel'
       ],
-      ['envService', '$translate', '$log']))
+      ['envService', '$translate', '$log', '$rootScope']))

--- a/src/common/components/loading/loading.scss
+++ b/src/common/components/loading/loading.scss
@@ -66,6 +66,13 @@ loading{
     z-index: 2;
   }
 
+  .loading-fixed:first-child {
+    position: fixed;
+    top: 50%; 
+    left: 50%;
+    z-index: 2;
+  }
+
   .loadingWrap{
     display: inline-block
   }

--- a/src/common/components/loading/loading.tpl.html
+++ b/src/common/components/loading/loading.tpl.html
@@ -1,6 +1,7 @@
 <div ng-class="{
-        'loading-centered': $ctrl.type === 'centered' || $ctrl.type === 'overlay',
-        'loading-overlay': $ctrl.type === 'overlay'
+        'loading-centered': $ctrl.type === 'centered' || $ctrl.type === 'overlay' || $ctrl.type === 'fixed',
+        'loading-overlay': $ctrl.type === 'overlay' || $ctrl.type === 'fixed',
+        'loading-fixed': $ctrl.type === 'fixed'
       }">
   <div>
     <span ng-class="{ 'mr-' : $ctrl.inline === 'true', 'center-block' : $ctrl.inline !== 'true'  }">

--- a/src/common/components/nav/navCart/navCart.component.js
+++ b/src/common/components/nav/navCart/navCart.component.js
@@ -7,9 +7,7 @@ import orderService from 'common/services/api/order.service'
 import analyticsFactory from 'app/analytics/analytics.factory'
 
 import template from './navCart.tpl.html'
-
-export const giftAddedEvent = 'giftAddedToCart'
-export const cartUpdatedEvent = 'cartUpdatedEvent'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 
 const componentName = 'navCart'
 

--- a/src/common/components/nav/navCart/navCart.component.spec.js
+++ b/src/common/components/nav/navCart/navCart.component.spec.js
@@ -4,7 +4,8 @@ import { Observable } from 'rxjs/Observable'
 import { Subject } from 'rxjs/Subject'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
-import module, { giftAddedEvent, cartUpdatedEvent } from './navCart.component'
+import module from './navCart.component'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 
 describe('navCart', () => {
   beforeEach(angular.mock.module(module.name))

--- a/src/common/components/nav/navCartIcon.component.js
+++ b/src/common/components/nav/navCartIcon.component.js
@@ -1,6 +1,7 @@
 import angular from 'angular'
 
-import navCart, { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import navCart from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 import uibDropdown from 'angular-ui-bootstrap/src/dropdown'
 import analyticsFactory from 'app/analytics/analytics.factory'
 

--- a/src/common/components/nav/navCartIcon.component.spec.js
+++ b/src/common/components/nav/navCartIcon.component.spec.js
@@ -2,7 +2,7 @@ import angular from 'angular'
 import 'angular-mocks'
 import module from './navCartIcon.component'
 
-import { giftAddedEvent, cartUpdatedEvent } from 'common/components/nav/navCart/navCart.component'
+import { giftAddedEvent, cartUpdatedEvent } from 'common/lib/cartEvents'
 
 describe('nav cart icon', function () {
   beforeEach(angular.mock.module(module.name))

--- a/src/common/lib/cartEvents.js
+++ b/src/common/lib/cartEvents.js
@@ -1,0 +1,2 @@
+export const giftAddedEvent = 'giftAddedToCart'
+export const cartUpdatedEvent = 'cartUpdatedEvent'

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -6,10 +6,14 @@ import 'rxjs/add/operator/combineLatest'
 import 'rxjs/add/operator/pluck'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
+import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/finally'
 import map from 'lodash/map'
 import omit from 'lodash/omit'
+import isString from 'lodash/isString'
 import sortPaymentMethods from 'common/services/paymentHelpers/paymentMethodSort'
 import extractPaymentAttributes from 'common/services/paymentHelpers/extractPaymentAttributes'
+import { cartUpdatedEvent } from 'common/lib/cartEvents'
 
 import cortexApiService from '../cortexApi.service'
 import cartService from './cart.service'
@@ -35,6 +39,7 @@ class Order {
     this.analyticsFactory = analyticsFactory
     this.sessionStorage = $window.sessionStorage
     this.localStorage = $window.localStorage
+    this.$window = $window
     this.$log = $log
     this.$filter = $filter
   }
@@ -398,6 +403,53 @@ class Order {
     } else {
       return startedOrderWithoutSpouse
     }
+  }
+
+  submitOrder (controller) {
+    delete controller.submissionError
+    delete controller.submissionErrorStatus
+    // Prevent multiple submissions
+    if (controller.submittingOrder) {
+      return Observable.empty()
+    }
+    controller.submittingOrder = true
+    controller.onSubmittingOrder({ value: true })
+
+    let submitRequest
+    if (controller.bankAccountPaymentDetails) {
+      submitRequest = this.submit()
+    } else if (controller.creditCardPaymentDetails) {
+      const cvv = this.retrieveCardSecurityCode()
+      submitRequest = this.submit(cvv)
+    } else {
+      submitRequest = Observable.throw({ data: 'Current payment type is unknown' })
+    }
+    return submitRequest
+      .do(() => {
+        this.clearCardSecurityCodes()
+        this.clearCoverFees()
+        controller.onSubmitted()
+        controller.$scope.$emit(cartUpdatedEvent)
+      },
+      (error) => {
+        // Handle the error side effects when the observable errors
+        this.analyticsFactory.checkoutFieldError('submitOrder', 'failed')
+
+        controller.loadCart()
+
+        if (error.config && error.config.data && error.config.data['security-code']) {
+          error.config.data['security-code'] = error.config.data['security-code'].replace(/./g, 'X') // Mask security-code
+        }
+        this.$log.error('Error submitting purchase:', error)
+        controller.onSubmitted()
+        controller.submissionErrorStatus = error.status
+        controller.submissionError = isString(error && error.data) ? (error && error.data).replace(/[:].*$/, '') : 'generic error' // Keep prefix before first colon for easier ng-switch matching
+        this.$window.scrollTo(0, 0)
+      })
+      .finally(() => {
+        controller.submittingOrder = false
+        controller.onSubmittingOrder({ value: false })
+      });
   }
 }
 

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -4,6 +4,7 @@ import omit from 'lodash/omit'
 import cloneDeep from 'lodash/cloneDeep'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
+import 'rxjs/add/observable/empty'
 import formatAddressForTemplate from '../addressHelpers/formatAddressForTemplate'
 import { Roles } from 'common/services/session/session.service'
 
@@ -17,6 +18,7 @@ import purchaseFormResponse from 'common/services/api/fixtures/cortex-order-purc
 import donorDetailsResponse from 'common/services/api/fixtures/cortex-donordetails.fixture.js'
 import needInfoResponse from 'common/services/api/fixtures/cortex-order-needinfo.fixture.js'
 import purchaseResponse from 'common/services/api/fixtures/cortex-purchase.fixture.js'
+import { cartUpdatedEvent } from 'common/lib/cartEvents'
 
 describe('order service', () => {
   beforeEach(angular.mock.module(module.name))
@@ -1204,6 +1206,159 @@ describe('order service', () => {
 
       expect(self.$window.localStorage.getItem('startedOrderWithoutSpouse')).toEqual('true')
       expect(self.$window.localStorage.getItem('currentOrder')).toEqual('order id 2')
+    })
+  })
+
+  describe('submitOrder', () => {
+    let mockController
+
+    beforeEach(() => {
+      mockController = {
+        submittingOrder: false,
+        onSubmittingOrder: jest.fn(),
+        onSubmitted: jest.fn(),
+        $scope: {
+          $emit: jest.fn(),
+        },
+      }
+
+      // Mock the submit() method to return a resolved observable
+      self.orderService.submit = jest.fn().mockReturnValue(Observable.of({}))
+    })
+
+    describe('another order submission in progress', () => {
+      it('should not submit the order twice', () => {
+        mockController.submittingOrder = true
+        // Call submitOrder
+        const result = self.orderService.submitOrder(mockController)
+
+        // The submit method should not be called
+        expect(self.orderService.submit).not.toHaveBeenCalled()
+
+        // It should return an empty observable
+        expect(result).toEqual(Observable.empty())
+      })
+    })
+
+    describe('submit single order', () => {
+      beforeEach(() => {
+          self.orderService.clearCardSecurityCodes = jest.fn()
+          self.orderService.retrieveCardSecurityCode = jest.fn()
+          self.orderService.clearCoverFees = jest.fn()
+          mockController.loadCart = jest.fn()
+          self.$window.scrollTo = jest.fn()
+        })
+        
+        afterEach(() => {
+          expect(mockController.onSubmittingOrder).toHaveBeenCalledWith({ value: true })
+          expect(mockController.onSubmittingOrder).toHaveBeenCalledWith({ value: false })
+          expect(mockController.onSubmitted).toHaveBeenCalled()
+        })
+        
+        it('should submit the order normally if paying with a bank account', (done) => {
+          mockController.bankAccountPaymentDetails = {}
+          self.orderService.submitOrder(mockController).subscribe(
+            () => {
+              expect(self.orderService.submit).toHaveBeenCalled()
+              expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+      
+              expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
+              done()
+            })
+      })
+
+      it('should handle an error submitting an order with a bank account', (done) => {
+        self.orderService.submit.mockImplementation(() => Observable.throw({ data: 'error saving bank account' }))
+
+        mockController.bankAccountPaymentDetails = {}
+        self.orderService.submitOrder(mockController).subscribe(
+          () => done("Observable unexpectedly succeeded"),
+          () => {
+            // Handle the error and continue with assertions
+            expect(self.orderService.submit).toHaveBeenCalled()
+            expect(mockController.loadCart).toHaveBeenCalled()
+            expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'error saving bank account' }])
+            expect(mockController.submissionError).toEqual('error saving bank account')
+            expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)
+    
+            done()
+          })
+      })
+
+      it('should submit the order with a CVV if paying with a credit card', (done) => {
+        self.orderService.retrieveCardSecurityCode = jest.fn().mockReturnValue('1234')
+        mockController.creditCardPaymentDetails = {}
+        mockController.coverFeeDecision = true
+        self.orderService.submitOrder(mockController).subscribe(() => {
+          expect(self.orderService.submit).toHaveBeenCalledWith('1234')
+          expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+          expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
+          done()
+        })
+      })
+
+      it('should submit the order without a CVV if paying with an existing credit card or the cvv in session storage is missing', (done) => {
+        mockController.creditCardPaymentDetails = {}
+        self.orderService.retrieveCardSecurityCode = jest.fn().mockReturnValue(undefined)
+        mockController.coverFeeDecision = true
+        self.orderService.submitOrder(mockController).subscribe(() => {
+          expect(self.orderService.submit).toHaveBeenCalledWith(undefined)
+          expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+          expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
+          done()
+        }, done)
+      })
+
+      it('should handle an error submitting an order with a credit card', (done) => {
+        self.orderService.submit.mockImplementation(() => Observable.throw({ data: 'CardErrorException: Invalid Card Number: some details' }))
+        mockController.creditCardPaymentDetails = {}
+        self.orderService.retrieveCardSecurityCode = jest.fn().mockReturnValue('1234')
+        self.orderService.submitOrder(mockController).subscribe(
+          () => done("Observable unexpectedly succeeded"),
+          () => { // error handler
+            expect(self.orderService.submit).toHaveBeenCalledWith('1234')
+            expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'CardErrorException: Invalid Card Number: some details' }])
+            expect(mockController.submissionError).toEqual('CardErrorException')
+            expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)
+            done()
+          })
+      })
+
+      it('should mask the security code on a credit card error', (done) => {
+        self.orderService.submit.mockReturnValue(Observable.throw({ data: 'some error', config: { data: { 'security-code': '1234' } } }))
+        self.orderService.retrieveCardSecurityCode = jest.fn().mockReturnValue('1234')
+        mockController.creditCardPaymentDetails = {}
+        self.orderService.submitOrder(mockController).subscribe(
+          () => done("Observable unexpectedly succeeded"),
+          () => { // error handler
+            expect(self.orderService.submit).toHaveBeenCalledWith('1234')
+            expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'some error', config: { data: { 'security-code': 'XXXX' } } }])
+            done()
+          })
+      })
+
+      it('should throw an error if neither bank account or credit card details are loaded', (done) => {
+        self.orderService.submitOrder(mockController).subscribe(
+          () => done("Observable unexpectedly succeeded"),
+          () => { // error handler
+            expect(self.orderService.submit).not.toHaveBeenCalled()
+            expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'Current payment type is unknown' }])
+            expect(mockController.submissionError).toEqual('Current payment type is unknown')
+            expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)
+            done()
+          })
+      })
+
+      it('should clear out cover fee data', (done) => {
+        mockController.creditCardPaymentDetails = {}
+        self.orderService.submitOrder(mockController).subscribe(() => {
+          done()
+        }, done)
+        expect(self.orderService.clearCoverFees).toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
### Description
There is a desire to remove step 2 of the branded checkout to reduce abandoned carts. This will mean the continue button on the first page should submit the gift and take the user to the thank you page.
https://jira.cru.org/browse/EP-2518

### Changes I Made:
- Move the submit logic to `order.service` and use it both in `branded-checkout-step-1` and `step-3`
- Conditionally show "Continue" or "Submit Your Gift" based on the `useV3` attribute
- Change `next()` page change based on the `useV3` attribute
- Add fullscreen fixed loading message
- Move checkout-error-messages to a new component that is used both in `branded-checkout-step-1` and `step-3`

