### PR TITLE
EP-2555 - Improve Error Logging to DataDog RUM

### DIFF
--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -176,7 +176,7 @@ class Step3Controller {
         error.config.data['security-code'] = error.config.data['security-code'].replace(/./g, 'X') // Mask security-code
       }
       componentInstance.$log.error('Error submitting purchase:', error)
-      datadogRum.addError(new Error(`Error submitting purchase: ${JSON.stringify(error)}`)) // here in order to show up in Error Tracking in DD
+      datadogRum.addError(new Error(`Error submitting purchase: ${JSON.stringify(error)}`), { context: 'Checkout Submission', errorCode: error.status }) // here in order to show up in Error Tracking in DD
       componentInstance.onSubmitted()
       componentInstance.submissionErrorStatus = error.status
       componentInstance.submissionError = isString(error && error.data) ? (error && error.data).replace(/[:].*$/, '') : 'generic error' // Keep prefix before first colon for easier ng-switch matching

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -16,6 +16,7 @@ import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.componen
 import { SignInEvent } from 'common/services/session/session.service'
 import { startDate } from 'common/services/giftHelpers/giftDates.service'
 import recaptchaComponent from 'common/components/Recaptcha/RecaptchaWrapper'
+import { datadogRum } from '@datadog/browser-rum'
 
 import template from './step-3.tpl.html'
 
@@ -175,6 +176,7 @@ class Step3Controller {
         error.config.data['security-code'] = error.config.data['security-code'].replace(/./g, 'X') // Mask security-code
       }
       componentInstance.$log.error('Error submitting purchase:', error)
+      datadogRum.addError(new Error(`Error submitting purchase: ${JSON.stringify(error)}`)) // here in order to show up in Error Tracking in DD
       componentInstance.onSubmitted()
       componentInstance.submissionErrorStatus = error.status
       componentInstance.submissionError = isString(error && error.data) ? (error && error.data).replace(/[:].*$/, '') : 'generic error' // Keep prefix before first colon for easier ng-switch matching

--- a/src/common/components/Recaptcha/Recaptcha.test.tsx
+++ b/src/common/components/Recaptcha/Recaptcha.test.tsx
@@ -125,7 +125,7 @@ describe('Recaptcha component', () => {
     await waitFor(() => {
       const errorMessage = 'Captcha score was below the threshold: 0.2'
       expect($log.warn).toHaveBeenCalledWith(errorMessage)
-      expect(datadogRum.addError).toHaveBeenCalledWith(new Error(`Error submitting purchase: ${errorMessage}`))
+      expect(datadogRum.addError).toHaveBeenCalledWith(new Error(`Error submitting purchase: ${errorMessage}`), { context: 'Recaptcha', errorCode: 'lowScore' })
       expect(onFailure).toHaveBeenCalledTimes(1)
     })
   })
@@ -171,7 +171,7 @@ describe('Recaptcha component', () => {
       expect(onSuccess).not.toHaveBeenCalled()
       expect(onFailure).toHaveBeenCalled()
       expect($log.warn).toHaveBeenCalledWith(errorMessage)
-      expect(datadogRum.addError).toHaveBeenCalledWith(new Error(`Error submitting purchase: ${errorMessage}`))
+      expect(datadogRum.addError).toHaveBeenCalledWith(new Error(`Error submitting purchase: ${errorMessage}`), { context: 'Recaptcha', errorCode: 'invalidAction' })
     })
   })
 

--- a/src/common/components/Recaptcha/Recaptcha.tsx
+++ b/src/common/components/Recaptcha/Recaptcha.tsx
@@ -97,7 +97,7 @@ export const Recaptcha = ({
           if (data.score < 0.5) {
             const errorMessage = `Captcha score was below the threshold: ${data.score}`
             $log.warn(errorMessage)
-            datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`))
+            datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`), { context: 'Recaptcha', errorCode: 'lowScore' })
             onFailure(componentInstance)
             return
           }
@@ -112,7 +112,7 @@ export const Recaptcha = ({
         if (!isValidAction(data?.action)) {
           const errorMessage = `Invalid action: ${data?.action}`
           $log.warn(errorMessage)
-          datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`))
+          datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`), { context: 'Recaptcha', errorCode: 'invalidAction' })
           onFailure(componentInstance)
         }
       } catch (error) {

--- a/src/common/components/Recaptcha/Recaptcha.tsx
+++ b/src/common/components/Recaptcha/Recaptcha.tsx
@@ -1,6 +1,7 @@
 import angular from 'angular'
 import { react2angular } from 'react2angular'
 import React, { useCallback, useEffect, useState } from 'react'
+import { datadogRum } from '@datadog/browser-rum'
 
 const componentName = 'recaptcha'
 
@@ -94,7 +95,9 @@ export const Recaptcha = ({
 
         if (data?.success === true && isValidAction(data?.action)) {
           if (data.score < 0.5) {
-            $log.warn(`Captcha score was below the threshold: ${data.score}`)
+            const errorMessage = `Captcha score was below the threshold: ${data.score}`
+            $log.warn(errorMessage)
+            datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`))
             onFailure(componentInstance)
             return
           }
@@ -107,7 +110,9 @@ export const Recaptcha = ({
           return
         }
         if (!isValidAction(data?.action)) {
-          $log.warn(`Invalid action: ${data?.action}`)
+          const errorMessage = `Invalid action: ${data?.action}`
+          $log.warn(errorMessage)
+          datadogRum.addError(new Error(`Error submitting purchase: ${errorMessage}`))
           onFailure(componentInstance)
         }
       } catch (error) {


### PR DESCRIPTION
[Jira](https://jira.cru.org/browse/EP-2555)

This adds a few error logs that get sent to DD RUM in a way that shows up in [Error Tracking](https://app.datadoghq.com/error-tracking?query=%40application.id%3A3937053e-386b-4b5b-ab4a-c83217d2f953%20%22Error%20submitting%20purchase%3A%2A%22&fromUser=false&refresh_mode=sliding&source=browser&from_ts=1732889704580&to_ts=1733494504580&live=true). The console errors show up in the logs, but we can't create monitors based on logs, only based on errors. This will allow creation of a monitor like [this one](https://app.datadoghq.com/monitors/159738138) so we can watch for high numbers of checkout errors.

This is all in response to the Sev1 on Saturday (11/30/24) where there were front-end checkout errors present for 9 hours before we heard about them.