### PR TITLE
[EP-2362] Save contact info after sign up

### DIFF
--- a/src/common/components/contactInfoModal/contactInfoModal.component.js
+++ b/src/common/components/contactInfoModal/contactInfoModal.component.js
@@ -44,6 +44,7 @@ export default angular
     templateUrl: template,
     bindings: {
       modalTitle: '=',
+      signUpDonorDetails: '<?',
       onStateChange: '&',
       onSuccess: '&',
       onCancel: '&'

--- a/src/common/components/contactInfoModal/contactInfoModal.tpl.html
+++ b/src/common/components/contactInfoModal/contactInfoModal.tpl.html
@@ -1,4 +1,8 @@
-<contact-info submitted="$ctrl.submitted" on-submit="$ctrl.onSubmit(success)"></contact-info>
+<contact-info
+  submitted="$ctrl.submitted"
+  on-submit="$ctrl.onSubmit(success)"
+  donor-details="$ctrl.signUpDonorDetails"
+></contact-info>
 <div class="row">
   <div class="col-sm-5 hidden-xs">
     <button id="cancelButtonTop" class="btn btn-default" ng-click="$ctrl.onCancel()" translate>Cancel</button>

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -87,6 +87,10 @@ class RegisterAccountModalController {
     this.stateChanged('sign-up')
   }
 
+  onSignIn () {
+    this.stateChanged('sign-in')
+  }
+
   onIdentitySuccess () {
     this.sessionService.removeOktaRedirectIndicator()
 

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -13,6 +13,14 @@ import userMatchModal from 'common/components/userMatchModal/userMatchModal.comp
 import contactInfoModal from 'common/components/contactInfoModal/contactInfoModal.component'
 import failedVerificationModal from 'common/components/failedVerificationModal/failedVerificationModal.component'
 
+import { Observable } from 'rxjs/Observable'
+import 'rxjs/add/observable/forkJoin'
+import 'rxjs/add/observable/of'
+import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/map'
+import 'rxjs/add/operator/switchMap'
+import merge from 'lodash/merge'
+
 const componentName = 'registerAccountModal'
 
 class RegisterAccountModalController {
@@ -42,7 +50,7 @@ class RegisterAccountModalController {
 
   $onInit () {
     this.$rootScope.$on(LoginOktaOnlyEvent, () => {
-      this.getDonorDetails()
+      this.checkDonorDetails()
     })
 
     // Ensure loading icon isn't rendered on screen.
@@ -57,7 +65,7 @@ class RegisterAccountModalController {
     // Step 1. Sign-In/Up (skipped if already Signed In)
     if (this.sessionService.getRole() === Roles.registered) {
       // Proceed to Step 2
-      this.getDonorDetails()
+      this.checkDonorDetails()
     } else {
       // Proceed to Step 1.
       this.stateChanged('sign-in')
@@ -67,7 +75,7 @@ class RegisterAccountModalController {
     this.subscription = this.sessionService.sessionSubject.subscribe(() => {
       if (this.sessionService.getRole() === Roles.registered) {
         // Proceed to Step 2
-        this.getDonorDetails()
+        this.checkDonorDetails()
       }
     })
   }
@@ -83,6 +91,12 @@ class RegisterAccountModalController {
     }
   }
 
+  // Called after the user finishes creating a new Okta account
+  onSignUpSuccess (signUpDonorDetails) {
+    this.checkDonorDetails(signUpDonorDetails)
+  }
+
+  // Called when the user requests to sign up from the sign in modal
   onSignUp () {
     this.stateChanged('sign-up')
   }
@@ -95,7 +109,7 @@ class RegisterAccountModalController {
     this.sessionService.removeOktaRedirectIndicator()
 
     // Success Sign-In/Up, Proceed to Step 2.
-    this.getDonorDetails()
+    this.checkDonorDetails()
   }
 
   onIdentityFailure () {
@@ -112,7 +126,7 @@ class RegisterAccountModalController {
     this.onSuccess()
   }
 
-  getDonorDetails () {
+  checkDonorDetails (signUpDonorDetails) {
     // Show loading state
     this.modalTitle = this.gettext('Checking your donor account')
     this.stateChanged('loading')
@@ -121,7 +135,27 @@ class RegisterAccountModalController {
     if (angular.isDefined(this.getDonorDetailsSubscription)) {
       this.getDonorDetailsSubscription.unsubscribe()
     }
-    this.getDonorDetailsSubscription = this.orderService.getDonorDetails().subscribe({
+    this.getDonorDetailsSubscription = this.orderService.getDonorDetails().switchMap((donorDetails) => {
+      if (signUpDonorDetails && donorDetails['registration-state'] === 'NEW') {
+        // Save the contact info from signup
+        merge(donorDetails, signUpDonorDetails)
+
+        // Send each of the requests and pass donorDetails to the next step after the requests complete
+        return Observable.forkJoin([
+          this.orderService.updateDonorDetails(donorDetails),
+          this.orderService.addEmail(donorDetails.email, donorDetails.emailFormUri)
+        ]).map(() => donorDetails).do({
+          error: () => {
+            // If there was an error, save the donor details from sign up so that they will be added
+            // to the contact info form. The error handler below will change the step to contact-info.
+            this.signUpDonorDetails = signUpDonorDetails
+          }
+        })
+      }
+
+      // Pass donorDetails to the next step
+      return Observable.of(donorDetails)
+    }).subscribe({
       next: (donorDetails) => {
         // Workflow Complete if 'registration-state' is COMPLETED
         if (donorDetails['registration-state'] === 'COMPLETED') {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -22,7 +22,11 @@ describe('registerAccountModal', function () {
     }
     locals = {
       $element: [{ dataset: {} }],
-      orderService: { getDonorDetails: jest.fn() },
+      orderService: {
+        getDonorDetails: jest.fn(),
+        updateDonorDetails: jest.fn(),
+        addEmail: jest.fn()
+      },
       verificationService: { postDonorMatches: jest.fn() },
       sessionService: {
         getRole: jest.fn(),
@@ -189,8 +193,67 @@ describe('registerAccountModal', function () {
       })
 
       describe('\'registration-state\' NEW', () => {
+        const signUpDonorDetails = {
+          name: {
+            'given-name': 'First',
+            'family-name': 'Last'
+          },
+          'donor-type': 'Household',
+          email: 'first.last@cru.org',
+          phone: '111-222-3333',
+          mailingAddress: {
+            streetAddress: '123 First St',
+            locality: 'Orlando',
+            region: 'FL',
+            postalCode: '12345',
+            country: 'US'
+          }
+        }
+
+        const emailFormUri = '/emails/crugive'
+
+        beforeEach(() => {
+          $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({
+            'registration-state': 'NEW',
+            name: {
+              'given-name': 'Existing',
+              'family-name': 'Existing'
+            },
+            'donor-type': '',
+            email: 'existing.email@cru.org',
+            phone: '',
+            mailingAddress: {
+              streetAddress: '',
+              locality: '',
+              region: '',
+              postalCode: '',
+              country: 'CANADA'
+            },
+            emailFormUri
+          }))
+          $ctrl.orderService.addEmail.mockImplementation(() => Observable.of({}))
+        })
+
+        describe('with sign up details', () => {
+          it('saves sign up contact info merged with existing contact info', () => {
+            $ctrl.checkDonorDetails(signUpDonorDetails)
+
+            expect($ctrl.orderService.updateDonorDetails).toHaveBeenCalledWith(expect.objectContaining(signUpDonorDetails))
+            expect($ctrl.orderService.addEmail).toHaveBeenCalledWith(signUpDonorDetails.email, emailFormUri)
+            expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')
+          })
+
+          it('remembers contact info after error', () => {
+            $ctrl.orderService.addEmail.mockImplementation(() => Observable.throw(new Error('Error adding email')))
+
+            $ctrl.checkDonorDetails(signUpDonorDetails)
+
+            expect($ctrl.signUpDonorDetails).toBe(signUpDonorDetails)
+            expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')
+          })
+        })
+
         it('changes state to \'contact-info\'', () => {
-          $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'NEW' }))
           $ctrl.checkDonorDetails()
 
           expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -46,15 +46,15 @@ describe('registerAccountModal', function () {
 
   describe('$onInit()', () => {
     beforeEach(() => {
-      jest.spyOn($ctrl, 'getDonorDetails').mockImplementation(() => {})
+      jest.spyOn($ctrl, 'checkDonorDetails').mockImplementation(() => {})
       jest.spyOn($ctrl, 'stateChanged').mockImplementation(() => {})
     })
 
     it('should get donor details', () => {
       $ctrl.$onInit()
-      expect($ctrl.getDonorDetails).not.toHaveBeenCalled()
+      expect($ctrl.checkDonorDetails).not.toHaveBeenCalled()
       $rootScope.$broadcast(LoginOktaOnlyEvent)
-      expect($ctrl.getDonorDetails).toHaveBeenCalled()
+      expect($ctrl.checkDonorDetails).toHaveBeenCalled()
     })
 
     describe('with \'REGISTERED\' cortex-session', () => {
@@ -64,7 +64,7 @@ describe('registerAccountModal', function () {
       })
 
       it('proceeds to donor details', () => {
-        expect($ctrl.getDonorDetails).toHaveBeenCalled()
+        expect($ctrl.checkDonorDetails).toHaveBeenCalled()
         expect($ctrl.stateChanged).not.toHaveBeenCalled()
       })
     })
@@ -76,7 +76,7 @@ describe('registerAccountModal', function () {
       })
 
       it('proceeds to sign-in', () => {
-        expect($ctrl.getDonorDetails).not.toHaveBeenCalled()
+        expect($ctrl.checkDonorDetails).not.toHaveBeenCalled()
         expect($ctrl.stateChanged).toHaveBeenCalledWith('sign-in')
       })
 
@@ -84,13 +84,13 @@ describe('registerAccountModal', function () {
         $ctrl.sessionService.sessionSubject.next({
           firstName: 'Daniel'
         })
-        expect($ctrl.getDonorDetails).not.toHaveBeenCalled()
+        expect($ctrl.checkDonorDetails).not.toHaveBeenCalled()
 
         $ctrl.sessionService.getRole.mockReturnValue(Roles.registered)
         $ctrl.sessionService.sessionSubject.next({
           firstName: 'Daniel'
         })
-        expect($ctrl.getDonorDetails).toHaveBeenCalled()
+        expect($ctrl.checkDonorDetails).toHaveBeenCalled()
       })
     })
 
@@ -114,7 +114,7 @@ describe('registerAccountModal', function () {
       $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ }))
       $ctrl.verificationService.postDonorMatches.mockImplementation(() => Observable.of({}))
       $ctrl.$onInit()
-      $ctrl.getDonorDetails()
+      $ctrl.checkDonorDetails()
       $ctrl.postDonorMatches()
       expect($ctrl.getTotalQuantitySubscription.closed).toEqual(false)
       expect($ctrl.subscription.closed).toEqual(false)
@@ -128,15 +128,15 @@ describe('registerAccountModal', function () {
   })
 
   describe('onIdentitySuccess()', () => {
-    it('calls getDonorDetails', () => {
-      jest.spyOn($ctrl, 'getDonorDetails').mockImplementation(() => {})
+    it('calls checkDonorDetails', () => {
+      jest.spyOn($ctrl, 'checkDonorDetails').mockImplementation(() => {})
       $ctrl.onIdentitySuccess()
-      expect($ctrl.getDonorDetails).toHaveBeenCalled()
+      expect($ctrl.checkDonorDetails).toHaveBeenCalled()
     });
   })
 
   describe('onIdentityFailure()', () => {
-    it('calls getDonorDetails', () => {
+    it('calls checkDonorDetails', () => {
       jest.spyOn($ctrl.sessionService, 'removeOktaRedirectIndicator')
       $ctrl.onIdentityFailure()
       expect($ctrl.sessionService.removeOktaRedirectIndicator).toHaveBeenCalled()
@@ -169,16 +169,16 @@ describe('registerAccountModal', function () {
     })
   })
 
-  describe('getDonorDetails()', () => {
+  describe('checkDonorDetails()', () => {
     beforeEach(() => {
       jest.spyOn($ctrl, 'stateChanged').mockImplementation(() => {})
     })
 
-    describe('orderService.getDonorDetails success', () => {
+    describe('orderService.checkDonorDetails success', () => {
       describe('\'registration-state\' COMPLETED', () => {
         it('changes state to \'contact-info\'', () => {
           $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'COMPLETED' }))
-          $ctrl.getDonorDetails()
+          $ctrl.checkDonorDetails()
 
           expect($ctrl.modalTitle).toEqual('Checking your donor account')
           expect($ctrl.stateChanged).toHaveBeenCalledWith('loading')
@@ -191,7 +191,7 @@ describe('registerAccountModal', function () {
       describe('\'registration-state\' NEW', () => {
         it('changes state to \'contact-info\'', () => {
           $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'NEW' }))
-          $ctrl.getDonorDetails()
+          $ctrl.checkDonorDetails()
 
           expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()
           expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')
@@ -202,17 +202,17 @@ describe('registerAccountModal', function () {
     describe('\'registration-state\' FAILED', () => {
       it('changes state to \'failed-verification\'', () => {
         $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'FAILED' }))
-        $ctrl.getDonorDetails()
+        $ctrl.checkDonorDetails()
 
         expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()
         expect($ctrl.stateChanged).toHaveBeenCalledWith('failed-verification')
       })
     })
 
-    describe('orderService.getDonorDetails failure', () => {
+    describe('orderService.checkDonorDetails failure', () => {
       it('changes state to \'contact-info\'', () => {
         $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.throw({}))
-        $ctrl.getDonorDetails()
+        $ctrl.checkDonorDetails()
 
         expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()
         expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -32,7 +32,7 @@
   ></sign-in-modal>
   <sign-up-modal
     ng-switch-when="sign-up"
-    on-sign-up="$ctrl.onSignUp()"
+    on-sign-up="$ctrl.onSignUpSuccess(donorDetails)"
     on-sign-in="$ctrl.onSignIn()"
     is-inside-another-modal="true"
   ></sign-up-modal>
@@ -42,6 +42,7 @@
   <contact-info-modal
     ng-switch-when="contact-info"
     modal-title="$ctrl.modalTitle"
+    sign-up-donor-details="$ctrl.signUpDonorDetails"
     on-success="$ctrl.onContactInfoSuccess()"
     on-cancel="$ctrl.onCancel()"
   ></contact-info-modal>

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -32,9 +32,8 @@
   ></sign-in-modal>
   <sign-up-modal
     ng-switch-when="sign-up"
-    on-state-change="$ctrl.stateChanged(state)"
-    on-success="$ctrl.onIdentitySuccess()"
-    on-failure="$ctrl.onIdentityFailure()"
+    on-sign-up="$ctrl.onSignUp()"
+    on-sign-in="$ctrl.onSignIn()"
     is-inside-another-modal="true"
   ></sign-up-modal>
   <div ng-switch-when="loading">

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -191,6 +191,28 @@ class SignUpModalController {
             }
             onSuccess(postData)
           }
+        },
+        postSubmit: (response, onSuccess) => {
+          const donorDetails = {
+            name: {
+              'given-name': this.$scope.firstName,
+              'family-name': this.$scope.lastName
+            },
+            'donor-type': this.$scope.accountType,
+            'organization-name': this.$scope.organizationName,
+            email: this.$scope.email,
+            phone: this.$scope.primaryPhone,
+            mailingAddress: {
+              streetAddress: this.$scope.streetAddress,
+              locality: this.$scope.city,
+              region: this.$scope.state,
+              postalCode: this.$scope.zipCode,
+              country: this.$scope.countryCode
+            }
+          }
+          this.$scope.$apply(() => this.onSignUp({ donorDetails }))
+
+          onSuccess(response)
         }
       }
     })
@@ -299,9 +321,6 @@ class SignUpModalController {
         this.loadingDonorDetails = false
       })
   }
-
-  // On registration complete we need to send the data to Cortex and then redirect the user to the next step
-  // this.onSignUp()
 }
 
 export default angular
@@ -314,7 +333,7 @@ export default angular
     controller: SignUpModalController,
     templateUrl: template,
     bindings: {
-      // Called after the user creates an account with Okta
+      // Called with `donorDetails` after the user creates an account with Okta
       onSignUp: '&',
       // Called when the user clicks back to sign in link
       onSignIn: '&',

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -30,7 +30,7 @@ class SignUpModalController {
 
   $onInit () {
     if (includes([Roles.identified, Roles.registered], this.sessionService.getRole())) {
-      this.onStateChange({ state: 'sign-in' })
+      this.onSignIn()
     }
     this.currentStep = 1
     this.donorDetails = {}
@@ -217,7 +217,7 @@ class SignUpModalController {
 
     // Send users to the login modal if they try to go to the login form
     if (context.controller === 'primary-auth') {
-      this.$scope.$apply(() => this.onStateChange({ state: 'sign-in' }))
+      this.$scope.$apply(() => this.onSignIn())
     }
 
     this.injectBackButton()
@@ -301,7 +301,7 @@ class SignUpModalController {
   }
 
   // On registration complete we need to send the data to Cortex and then redirect the user to the next step
-  // this.onStateChange({ state: 'sign-up-activation' })
+  // this.onSignUp()
 }
 
 export default angular
@@ -314,8 +314,11 @@ export default angular
     controller: SignUpModalController,
     templateUrl: template,
     bindings: {
-      onStateChange: '&',
-      onFailure: '&',
+      // Called after the user creates an account with Okta
+      onSignUp: '&',
+      // Called when the user clicks back to sign in link
+      onSignIn: '&',
+      // Called with the user dismisses the modal via the close button
       onCancel: '&',
       isInsideAnotherModal: '='
     }

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -16,13 +16,12 @@ describe('signUpForm', function () {
   beforeEach(inject(function (_$rootScope_,  _$componentController_) {
     $rootScope = _$rootScope_
     bindings = {
-      onStateChange: jest.fn(),
-      onSuccess: jest.fn(),
+      onSignIn: jest.fn(),
+      onSignUp: jest.fn(),
       signUpForm: {
         $valid: false,
         $setSubmitted: jest.fn()
       },
-      onSubmit: jest.fn()
     }
     const scope = { $apply: jest.fn() }
     scope.$apply.mockImplementation(() => {})
@@ -51,17 +50,17 @@ describe('signUpForm', function () {
       })
 
       it('Redirects user to sign in modal', () => {
-        jest.spyOn($ctrl, 'onStateChange')
+        jest.spyOn($ctrl, 'onSignIn')
         $ctrl.$onInit()
 
-        expect($ctrl.onStateChange).toHaveBeenCalled()
+        expect($ctrl.onSignIn).toHaveBeenCalled()
       })
     })
 
     it('Loads user cart details', () => {
       $ctrl.isInsideAnotherModal = false
       jest.spyOn($ctrl.cartService, 'getTotalQuantity').mockImplementation(() => Observable.from([5]))
- 
+
       $ctrl.$onInit()
 
       expect($ctrl.cartCount).toEqual(5)
@@ -83,7 +82,7 @@ describe('signUpForm', function () {
       },
       email: 'email@cru.org',
     };
-    
+
     it('Inherits data from orderService', (done) => {
       jest.spyOn($ctrl.orderService, 'getDonorDetails').mockImplementation(() => Observable.from(
         [signUpFormData]

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -48,6 +48,10 @@ class SessionModalController {
     this.scrollModalToTop()
   }
 
+  onSignIn () {
+    this.stateChanged('register-account')
+  }
+
   onSignUpSuccess () {
     this.analyticsFactory.track('ga-sign-in-create-login')
     this.sessionService.removeOktaRedirectIndicator()

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -3,7 +3,8 @@
     <sign-up-modal ng-switch-when="sign-up"
       modal-title="$ctrl.modalTitle"
       last-purchase-id="$ctrl.lastPurchaseId"
-      on-state-change="$ctrl.stateChanged(state)"
+      on-sign-up="$ctrl.onSignUpSuccess()"
+      on-sign-in="$ctrl.onSignIn()"
       on-cancel="$ctrl.close()"
     ></sign-up-modal>
     <register-account-modal ng-switch-when="register-account"
@@ -17,9 +18,9 @@
     ></register-account-modal>
     <account-benefits-modal ng-switch-when="account-benefits"
       modal-title="$ctrl.modalTitle"
+      on-state-change="$ctrl.stateChanged(state)"
       on-success="$ctrl.onAccountBenefitsSuccess()"
       on-cancel="$ctrl.onCancel()"
-      on-state-change="$ctrl.stateChanged(state)"
     ></account-benefits-modal>
     <user-match-modal ng-switch-when="user-match"
       modal-title="$ctrl.modalTitle"


### PR DESCRIPTION
# Changes

* Replace the `onStateChange` binding with dedicated `onSignUp` and `onSignIn` bindings
* After sign up, use the order service to save the donor details to the user's account. If saving fails, show the contact info form with the fields from sign up pre-populated.

I made this a PR instead of committing directly so it's easier for you to see what changed and see if I'm going in the right direction with this.