### PR TITLE
[EP-2362] Deduplicate sign in modals

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -108,7 +108,7 @@ class DesignationEditorController {
       this.updateCarousel()
     }, error => {
       if (error.status === 422 && !this.retried) {
-        return this.sessionModalService.open('sign-in', {
+        return this.sessionModalService.open('register-account', {
           backdrop: 'static',
           keyboard: false
         }).result.then(() => {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -88,6 +88,8 @@ class RegisterAccountModalController {
   }
 
   onIdentitySuccess () {
+    this.sessionService.removeOktaRedirectIndicator()
+
     // Success Sign-In/Up, Proceed to Step 2.
     this.getDonorDetails()
   }

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -187,6 +187,7 @@ export default angular
     bindings: {
       firstName: '=',
       modalTitle: '=',
+      lastPurchaseId: '<',
       onSuccess: '&',
       onCancel: '&',
       setLoading: '&'

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -83,6 +83,10 @@ class RegisterAccountModalController {
     }
   }
 
+  onSignUp () {
+    this.stateChanged('sign-up')
+  }
+
   onIdentitySuccess () {
     // Success Sign-In/Up, Proceed to Step 2.
     this.getDonorDetails()

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -146,10 +146,19 @@ class RegisterAccountModalController {
 
   stateChanged (state) {
     this.element.dataset.state = state
-    if (state === 'sign-up') {
+    if ((!this.welcomeBack && state === 'sign-in') || state === 'sign-up') {
+      // Use a small modal for sign in modals without a welcome back message and for sign up modals
+      // regardless of the screen size because they can't take advantage of the extra width
+      this.setModalSize('sm')
+    } else if (this.$window.innerWidth >= 1200) {
+      // Use a large modal on wide screens for other modals
+      this.setModalSize('lg')
+    } else if (state === 'contact-info') {
+      // Use a medium modal for contact info modals, even on narrow screens, because they need the extra width
       this.setModalSize('md')
     } else {
-      this.setModalSize(this.$window.screen.width >= 1200 ? 'lg' : state === 'contact-info' ? undefined : 'sm')
+      // Use a small modal for all other modals on narrow screens
+      this.setModalSize('sm')
     }
 
     this.state = state
@@ -163,9 +172,7 @@ class RegisterAccountModalController {
     // Modal size is unchangeable after initialization. This fetches the modal and changes the size classes.
     const modal = angular.element(document.getElementsByClassName('session-modal'))
     modal.removeClass('modal-sm modal-md modal-lg')
-    if (angular.isDefined(size)) {
-      modal.addClass(`modal-${size}`)
-    }
+    modal.addClass(`modal-${size}`)
   }
 }
 

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -187,6 +187,8 @@ export default angular
     bindings: {
       firstName: '=',
       modalTitle: '=',
+      // If true, show the "Welcome back!" message in the header/sidebar
+      welcomeBack: '<?',
       lastPurchaseId: '<',
       onSuccess: '&',
       onCancel: '&',

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -250,10 +250,18 @@ describe('registerAccountModal', function () {
   })
 
   describe('stateChanged( state )', () => {
+    let originalWidth
+
     beforeEach(() => {
+      originalWidth = $ctrl.$window.innerWidth
+
       $ctrl.state = 'unknown'
       jest.spyOn($ctrl, 'setModalSize').mockImplementation(() => {})
       jest.spyOn($ctrl, 'scrollModalToTop').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      $ctrl.$window.innerWidth = originalWidth
     })
 
     it('should scroll to the top of the modal', () => {
@@ -273,7 +281,7 @@ describe('registerAccountModal', function () {
     it('changes to \'sign-up\' state', () => {
       $ctrl.stateChanged('sign-up')
 
-      expect($ctrl.setModalSize).toHaveBeenCalledWith('md')
+      expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: false })
       expect($ctrl.state).toEqual('sign-up')
     })
@@ -281,7 +289,7 @@ describe('registerAccountModal', function () {
     it('changes to \'contact-info\' state', () => {
       $ctrl.stateChanged('contact-info')
 
-      expect($ctrl.setModalSize).toHaveBeenCalledWith(undefined)
+      expect($ctrl.setModalSize).toHaveBeenCalledWith('md')
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: false })
       expect($ctrl.state).toEqual('contact-info')
     })
@@ -292,6 +300,61 @@ describe('registerAccountModal', function () {
       expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: false })
       expect($ctrl.state).toEqual('failed-verification')
+    })
+
+    describe('when welcomeBack is true', () => {
+      beforeEach(() => {
+        $ctrl.welcomeBack = true
+      })
+
+      it('sets the sign-in modal size to large on wide screens', () => {
+        $ctrl.$window.innerWidth = 1200
+        $ctrl.stateChanged('sign-in')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('lg')
+      })
+
+      it('sets the sign-in modal size to small on narrow screens', () => {
+        $ctrl.stateChanged('sign-in')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
+      })
+
+      it('sets the sign-up modal size to small', () => {
+        $ctrl.stateChanged('sign-up')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
+      })
+
+      it('sets the contact-info modal size to medium', () => {
+        $ctrl.stateChanged('contact-info')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('md')
+      })
+    })
+
+    describe('when the screen is wide', () => {
+      beforeEach(() => {
+        $ctrl.$window.innerWidth = 1200
+      })
+
+      it('sets the sign-in modal size to small', () => {
+        $ctrl.stateChanged('sign-in')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
+      })
+
+      it('sets the sign-up modal size to small', () => {
+        $ctrl.stateChanged('sign-up')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('sm')
+      })
+
+      it('sets the contact-info modal size to large', () => {
+        $ctrl.stateChanged('contact-info')
+
+        expect($ctrl.setModalSize).toHaveBeenCalledWith('lg')
+      })
     })
   })
 
@@ -308,13 +371,6 @@ describe('registerAccountModal', function () {
 
       expect(modal.removeClass).toHaveBeenCalledWith('modal-sm modal-md modal-lg')
       expect(modal.addClass).toHaveBeenCalledWith('modal-sm')
-    })
-
-    it('sets size missing param', () => {
-      $ctrl.setModalSize()
-
-      expect(modal.removeClass).toHaveBeenCalledWith('modal-sm modal-md modal-lg')
-      expect(modal.addClass).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -24,7 +24,7 @@ describe('registerAccountModal', function () {
       $element: [{ dataset: {} }],
       orderService: { getDonorDetails: jest.fn() },
       verificationService: { postDonorMatches: jest.fn() },
-      sessionService: { 
+      sessionService: {
         getRole: jest.fn(),
         isOktaRedirecting: jest.fn(),
         removeOktaRedirectIndicator: jest.fn(),

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -24,6 +24,7 @@
   <sign-in-modal
     ng-switch-when="sign-in"
     modal-title="$ctrl.modalTitle"
+    last-purchase-id="$ctrl.lastPurchaseId"
     on-sign-up="$ctrl.onSignUp()"
     on-success="$ctrl.onIdentitySuccess()"
     on-failure="$ctrl.onIdentityFailure()"

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -24,7 +24,7 @@
   <sign-in-modal
     ng-switch-when="sign-in"
     modal-title="$ctrl.modalTitle"
-    on-state-change="$ctrl.stateChanged(state)"
+    on-sign-up="$ctrl.onSignUp()"
     on-success="$ctrl.onIdentitySuccess()"
     on-failure="$ctrl.onIdentityFailure()"
     is-inside-another-modal="true"

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -1,4 +1,4 @@
-<div class="modal-header {{$ctrl.state}}" >
+<div class="modal-header {{$ctrl.state}}" ng-if="$ctrl.state !== 'sign-in' || $ctrl.welcomeBack">
   <button type="button" class="close" aria-label="Close" ng-click="$ctrl.onCancel()">
     <span aria-hidden="true">×</span>
   </button>

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -42,7 +42,6 @@ export default angular
     bindings: {
       onSuccess: '&',
       onFailure: '&',
-      onStateChange: '&',
       lastPurchaseId: '<',
       onSignUpWithOkta: '&',
       onSignInPage: '<'

--- a/src/common/components/signInModal/signInModal.component.js
+++ b/src/common/components/signInModal/signInModal.component.js
@@ -25,10 +25,6 @@ class SignInModalController {
   getOktaUrl () {
     return this.sessionService.getOktaUrl()
   }
-
-  stateChanged (state) {
-    this.onStateChange({ state })
-  }
 }
 
 export default angular
@@ -43,7 +39,8 @@ export default angular
     bindings: {
       modalTitle: '=',
       lastPurchaseId: '<',
-      onStateChange: '&',
+      // Called when the user clicks the create account link
+      onSignUp: '&',
       onSuccess: '&',
       onFailure: '&',
       isInsideAnotherModal: '='

--- a/src/common/components/signInModal/signInModal.component.spec.js
+++ b/src/common/components/signInModal/signInModal.component.spec.js
@@ -58,11 +58,4 @@ describe('signInModal', function () {
       expect($ctrl.sessionService.getOktaUrl).toHaveBeenCalled()
     })
   })
-
-  describe('stateChanged', () => {
-    it('updates the state value', () => {
-      $ctrl.stateChanged('newState')
-      expect($ctrl.onStateChange).toHaveBeenCalledWith({state: 'newState'})
-    })
-  })
 })

--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -4,7 +4,6 @@
       on-success="$ctrl.onSuccess()"
       on-failure="$ctrl.onFailure()"
       last-purchase-id="$ctrl.lastPurchaseId"
-      on-state-change="$ctrl.stateChanged(state)"
       on-sign-up-with-okta="$ctrl.stateChanged('sign-up')"
     />
   </div>

--- a/src/common/components/signInModal/signInModal.tpl.html
+++ b/src/common/components/signInModal/signInModal.tpl.html
@@ -4,7 +4,7 @@
       on-success="$ctrl.onSuccess()"
       on-failure="$ctrl.onFailure()"
       last-purchase-id="$ctrl.lastPurchaseId"
-      on-sign-up-with-okta="$ctrl.stateChanged('sign-up')"
+      on-sign-up-with-okta="$ctrl.onSignUp()"
     />
   </div>
 </div>

--- a/src/common/services/session/sessionEnforcer.service.js
+++ b/src/common/services/session/sessionEnforcer.service.js
@@ -98,8 +98,7 @@ const SessionEnforcerService = /* @ngInject */ function ($window, orderService, 
       })
 
       if (angular.isUndefined(modal)) {
-        const modalType = find(enforced, { mode: EnforcerModes.donor }) ? 'register-account' : 'sign-in'
-        modal = sessionModalService.open(modalType, {
+        modal = sessionModalService.open('register-account', {
           backdrop: 'static',
           keyboard: false
         }).result

--- a/src/common/services/session/sessionEnforcer.service.spec.js
+++ b/src/common/services/session/sessionEnforcer.service.spec.js
@@ -70,9 +70,9 @@ describe('sessionEnforcerService Tests', () => {
             }, EnforcerModes.session)
           }))
 
-          it('opens sign-in modal and calls \'change\' callback', () => {
+          it('opens register-account modal and calls \'change\' callback', () => {
             expect(change).toHaveBeenCalledWith(Roles.public, 'NEW')
-            expect(sessionModalService.open).toHaveBeenCalledWith('sign-in', { backdrop: 'static', keyboard: false })
+            expect(sessionModalService.open).toHaveBeenCalledWith('register-account', { backdrop: 'static', keyboard: false })
           })
 
           describe('sign-in success', () => {
@@ -98,13 +98,13 @@ describe('sessionEnforcerService Tests', () => {
               sessionService.getRole.mockReturnValue(Roles.registered)
               jest.spyOn(sessionModalService, 'currentModal')
             })
-    
+
             it('should call \'signIn\' and sessionModalService.currentModal callback', () => {
               $rootScope.$digest()
               expect(signIn).toHaveBeenCalled()
               expect(sessionModalService.currentModal).toHaveBeenCalled()
             })
-    
+
             it('should close sessionModalService.currentModal', () => {
               let currentModalCloseMock = jest.fn()
               jest.spyOn(sessionModalService, 'currentModal').mockImplementation(() => {
@@ -128,13 +128,13 @@ describe('sessionEnforcerService Tests', () => {
             sessionEnforcerService([Roles.registered], {}, EnforcerModes.session)
           }))
 
-          it('opens sign-in modal and does not call \'change\' callback', () => {
+          it('opens register-account modal and does not call \'change\' callback', () => {
             expect(change).not.toHaveBeenCalled()
-            expect(sessionModalService.open).toHaveBeenCalledWith('sign-in', { backdrop: 'static', keyboard: false })
+            expect(sessionModalService.open).toHaveBeenCalledWith('register-account', { backdrop: 'static', keyboard: false })
           })
 
-          describe('sign-in success', () => {
-            it('does not call \'sign-in\' callback', () => {
+          describe('register-account success', () => {
+            it('does not call \'signIn\' callback', () => {
               deferred.resolve()
               $rootScope.$digest()
 
@@ -142,7 +142,7 @@ describe('sessionEnforcerService Tests', () => {
             })
           })
 
-          describe('sign-in canceled', () => {
+          describe('register-account canceled', () => {
             it('does not call \'cancel\' callback', () => {
               deferred.reject()
               $rootScope.$digest()

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -48,6 +48,10 @@ class SessionModalController {
     this.scrollModalToTop()
   }
 
+  onSignUp () {
+    this.stateChanged('sign-up')
+  }
+
   onSignInSuccess () {
     this.sessionService.removeOktaRedirectIndicator()
     const $injector = this.$injector

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -1,6 +1,5 @@
 import angular from 'angular'
 
-import signInModal from 'common/components/signInModal/signInModal.component'
 import signUpModal from 'common/components/signUpModal/signUpModal.component'
 import userMatchModal from 'common/components/userMatchModal/userMatchModal.component'
 import contactInfoModal from 'common/components/contactInfoModal/contactInfoModal.component'
@@ -36,6 +35,7 @@ class SessionModalController {
       this.firstName = session.first_name
     })
     this.stateChanged(this.resolve.state)
+    this.welcomeBack = this.resolve.welcomeBack
     this.lastPurchaseId = this.resolve.lastPurchaseId
   }
 
@@ -46,21 +46,6 @@ class SessionModalController {
   stateChanged (state) {
     this.state = state
     this.scrollModalToTop()
-  }
-
-  onSignUp () {
-    this.stateChanged('sign-up')
-  }
-
-  onSignInSuccess () {
-    this.sessionService.removeOktaRedirectIndicator()
-    const $injector = this.$injector
-    if (!$injector.has('sessionService')) {
-      $injector.loadNewModules(['sessionService'])
-    }
-    this.$document[0].body.dispatchEvent(
-      new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
-    this.close()
   }
 
   onSignUpSuccess () {
@@ -91,7 +76,6 @@ class SessionModalController {
 
 export default angular
   .module(componentName, [
-    signInModal.name,
     signUpModal.name,
     userMatchModal.name,
     contactInfoModal.name,

--- a/src/common/services/session/sessionModal.component.spec.js
+++ b/src/common/services/session/sessionModal.component.spec.js
@@ -80,31 +80,6 @@ describe('sessionModalController', function () {
     })
   })
 
-  describe('$ctrl.onSignInSuccess', () => {
-    it('should close modal', () => {
-      jest.spyOn($ctrl.sessionService, 'removeOktaRedirectIndicator').mockImplementation(() => {})
-      $ctrl.$injector.has.mockImplementation(() => true)
-      $ctrl.onSignInSuccess()
-      const $injector = $ctrl.$injector
-
-      expect($ctrl.close).toHaveBeenCalled()
-      expect($ctrl.sessionService.removeOktaRedirectIndicator).toHaveBeenCalled()
-      expect($ctrl.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
-        new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
-    })
-
-    it('should add the sessionService module', () => {
-      $ctrl.$injector.has.mockImplementation(() => false)
-      $ctrl.$injector.loadNewModules.mockImplementation(() => {})
-      $ctrl.onSignInSuccess()
-      const $injector = $ctrl.$injector
-
-      expect($injector.loadNewModules).toHaveBeenCalledWith(['sessionService'])
-      expect($ctrl.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
-        new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
-    })
-  })
-
   describe('$ctrl.onSignUpSuccess', () => {
     it('should close modal', () => {
       jest.spyOn($ctrl.sessionService, 'removeOktaRedirectIndicator').mockImplementation(() => {})

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -19,7 +19,7 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
         return false
       }
     }
-    type = angular.isDefined(type) ? type : 'sign-in'
+    type = angular.isDefined(type) ? type : 'register-account'
     options = angular.isObject(options) ? options : {}
     const modalOptions = angular.merge({}, {
       component: sessionModalComponent.name,
@@ -59,8 +59,10 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
   return {
     open: openModal,
     currentModal: () => currentModal,
-    signIn: (lastPurchaseId) => openModal('sign-in', {
-      resolve: { lastPurchaseId: () => lastPurchaseId },
+    signIn: (lastPurchaseId) => openModal('register-account', {
+      resolve: {
+        lastPurchaseId: () => lastPurchaseId
+      },
       openAnalyticsEvent: 'ga-sign-in',
       dismissAnalyticsEvent: 'ga-sign-in-exit'
     }).result,
@@ -70,7 +72,13 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       dismissAnalyticsEvent: 'ga-registration-exit'
     }).result,
     accountBenefits: (lastPurchaseId) => openModal('account-benefits', { resolve: { lastPurchaseId: () => lastPurchaseId }, size: 'sm' }).result,
-    registerAccount: () => openModal('register-account', { backdrop: 'static', keyboard: false }).result,
+    registerAccount: () => openModal('register-account', {
+      resolve: {
+        welcomeBack: () => true
+      },
+      backdrop: 'static',
+      keyboard: false
+    }).result,
     createAccount: () => openModal('sign-up', { backdrop: 'static', keyboard: false }).result
   }
 }

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -29,12 +29,12 @@ describe('sessionModalService', function () {
       expect(sessionModalService.open).toBeDefined()
     })
 
-    it('should open \'sign-in\' by default', () => {
+    it('should open \'register-account\' by default', () => {
       const modal = sessionModalService.open()
 
       expect($uibModal.open).toHaveBeenCalled()
       expect($uibModal.open.mock.calls.length).toEqual(1)
-      expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('sign-in')
+      expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('register-account')
       expect(modal).toEqual(sessionModalService.currentModal())
     })
 
@@ -65,8 +65,8 @@ describe('sessionModalService', function () {
         expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in')
       })
 
-      it('send analytics event for sign-in', () => {
-        sessionModalService.open('sign-in', {
+      it('send analytics event for register-account', () => {
+        sessionModalService.open('register-account', {
           openAnalyticsEvent: 'ga-sign-in'
         })
         deferred.resolve()
@@ -117,8 +117,8 @@ describe('sessionModalService', function () {
         expect(analyticsFactory.track).toHaveBeenCalledWith('ga-sign-in-exit')
       })
 
-      it('sends analytics event for sign-in', () => {
-        sessionModalService.open('sign-in', {
+      it('sends analytics event for register-account', () => {
+        sessionModalService.open('register-account', {
           dismissAnalyticsEvent: 'ga-sign-in-exit'
         })
         deferred.reject()
@@ -156,11 +156,11 @@ describe('sessionModalService', function () {
   })
 
   describe('signIn', () => {
-    it('should open signIn modal', () => {
+    it('should open registerAccount modal', () => {
       sessionModalService.signIn()
 
       expect($uibModal.open).toHaveBeenCalledTimes(1)
-      expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('sign-in')
+      expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('register-account')
     })
 
     it('should open signIn modal with last purchase id', () => {
@@ -186,6 +186,7 @@ describe('sessionModalService', function () {
 
       expect($uibModal.open).toHaveBeenCalledTimes(1)
       expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('register-account')
+      expect($uibModal.open.mock.calls[0][0].resolve.welcomeBack()).toBe(true)
     })
   })
 

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -3,7 +3,7 @@
     <sign-in-modal ng-switch-when="sign-in"
       modal-title="$ctrl.modalTitle"
       last-purchase-id="$ctrl.lastPurchaseId"
-      on-state-change="$ctrl.stateChanged(state)"
+      on-sign-up="$ctrl.onSignUp()"
       on-success="$ctrl.onSignInSuccess()"
     ></sign-in-modal>
     <sign-up-modal ng-switch-when="sign-up"
@@ -15,6 +15,7 @@
     <register-account-modal ng-switch-when="register-account"
       first-name="$ctrl.firstName"
       modal-title="$ctrl.modalTitle"
+      minimal="$ctrl.minimal"
       on-success="$ctrl.onSignUpSuccess()"
       on-cancel="$ctrl.onCancel()"
       set-loading="$ctrl.setLoading(loading)"

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -1,11 +1,5 @@
 <div class="loading-overlay-parent">
   <div ng-switch="$ctrl.state">
-    <sign-in-modal ng-switch-when="sign-in"
-      modal-title="$ctrl.modalTitle"
-      last-purchase-id="$ctrl.lastPurchaseId"
-      on-sign-up="$ctrl.onSignUp()"
-      on-success="$ctrl.onSignInSuccess()"
-    ></sign-in-modal>
     <sign-up-modal ng-switch-when="sign-up"
       modal-title="$ctrl.modalTitle"
       last-purchase-id="$ctrl.lastPurchaseId"
@@ -15,7 +9,8 @@
     <register-account-modal ng-switch-when="register-account"
       first-name="$ctrl.firstName"
       modal-title="$ctrl.modalTitle"
-      minimal="$ctrl.minimal"
+      welcome-back="$ctrl.welcomeBack"
+      last-purchase-id="$ctrl.lastPurchaseId"
       on-success="$ctrl.onSignUpSuccess()"
       on-cancel="$ctrl.onCancel()"
       set-loading="$ctrl.setLoading(loading)"


### PR DESCRIPTION
Previously, the sign in modal could be opened from the session modal directly or from the register account modal inside of the session modal. The main difference was that the direct sign in modal didn't have the "Welcome back!" header/sidebar.

This PR removes the sign in modal from the session modal so that it will always be displayed inside of the register account modal. I added the `minimal` binding that when set to true hides the Welcome back header/sidebar.

I also cleaned up the bindings of signInModal so that no longer directly changes the state of the parent modal.