### PR TITLE
[EP-2362] Remove session modal's signup modal

### DIFF
--- a/src/app/signIn/signIn.component.js
+++ b/src/app/signIn/signIn.component.js
@@ -78,10 +78,6 @@ class SignInController {
     })
   }
 
-  onSignUpWithOkta () {
-    this.sessionModalService.createAccount()
-  }
-
   closeRedirectingLoading () {
     this.showRedirectingLoadingIcon = false
   }

--- a/src/app/signIn/signIn.spec.js
+++ b/src/app/signIn/signIn.spec.js
@@ -22,7 +22,7 @@ describe('signIn', function () {
       }
     )
   }))
-  
+
   it('to be defined', function () {
     expect($ctrl).toBeDefined()
   })
@@ -174,16 +174,6 @@ describe('signIn', function () {
         $ctrl.checkoutAsGuest()
 
         expect($ctrl.$window.location).toEqual('/checkout.html')
-      })
-    })
-
-
-    describe('onSignUpWithOkta()', () => {
-      it('should call createAccount()', () => {
-        jest.spyOn($ctrl.sessionModalService, 'createAccount')
-        $ctrl.onSignUpWithOkta()
-
-        expect($ctrl.sessionModalService.createAccount).toHaveBeenCalled()
       })
     })
   })

--- a/src/app/signIn/signIn.tpl.html
+++ b/src/app/signIn/signIn.tpl.html
@@ -27,7 +27,7 @@
                 <h3 class="text-center" translate>Already have an account?</h3>
                 <p class="text-center section-description" translate>Sign in now for faster checkout by using saved contact and payment information.</p>
 
-                <sign-in-form on-sign-up-with-okta="$ctrl.onSignUpWithOkta()" on-sign-in-page="true"></sign-in-form>
+                <sign-in-form on-sign-in-page="true"></sign-in-form>
               </div>
             </div>
           </div>

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -43,7 +43,8 @@ export default angular
       onSuccess: '&',
       onFailure: '&',
       lastPurchaseId: '<',
-      onSignUpWithOkta: '&',
+      // Optional if on-sign-in-page is true
+      onSignUpWithOkta: '&?',
       onSignInPage: '<'
     }
   })

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -78,8 +78,7 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       },
       backdrop: 'static',
       keyboard: false
-    }).result,
-    createAccount: () => openModal('sign-up', { backdrop: 'static', keyboard: false }).result
+    }).result
   }
 }
 

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -190,15 +190,6 @@ describe('sessionModalService', function () {
     })
   })
 
-  describe('SignUp', () => {
-    it('should open signUp modal', () => {
-      sessionModalService.createAccount()
-
-      expect($uibModal.open).toHaveBeenCalledTimes(1)
-      expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('sign-up')
-    })
-  })
-
   describe('accountBenefits', () => {
     it('should open accountBenefits modal', () => {
       sessionModalService.accountBenefits('gxwpz=')


### PR DESCRIPTION
`sessionModalService.createAccount` was only being used in one place: `onSignUpWithOkta` in `signIn.component.js`. Upon careful review, that function is never callable because `sign-in-form` hides the create account link when `on-sign-in-page="true"`. I removed that prop from the component and then removed `createAccount` from the session modal because it is no longer being used.