### PR TITLE
[EP-2362] Improvements to register account modal

### DIFF
--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -6,7 +6,7 @@ sign-up-modal {
   a {
     cursor: pointer;
   }
-  
+
   ul {
     padding-left: 1em;
   }
@@ -19,7 +19,7 @@ sign-up-modal {
     padding: 30px;
     background-color: #EBECEC;
   }
-  
+
   .signup-header {
     text-align: center;
   }
@@ -45,10 +45,10 @@ register-account-modal {
       width: auto;
     }
   }
-  
+
   .modal-dialog.modal-sm & {
     &[data-state=sign-in],
-    &[data-state=loading] {
+    &[data-state=loading-donor] {
       .modal-body {
         padding-top: 30px;
       }
@@ -57,7 +57,7 @@ register-account-modal {
 
   .modal-dialog.modal-lg & {
     &[data-state=sign-in],
-    &[data-state=loading] {  
+    &[data-state=loading-donor] {
       @media screen and (min-width: 550px) {
         sign-in-modal {
           padding: 50px;
@@ -70,7 +70,7 @@ register-account-modal {
         .modal-header {
           flex: 1
         }
-      }  
+      }
     }
     &[data-state=contact-info] {
 

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -155,6 +155,8 @@ class RegisterAccountModalController {
         // Workflow Complete if 'registration-state' is COMPLETED
         if (donorDetails['registration-state'] === 'COMPLETED') {
           this.onSuccess()
+        } else if (donorDetails['registration-state'] === 'MATCHED') {
+          this.onContactInfoSuccess()
         } else if (donorDetails['registration-state'] === 'FAILED') {
           this.stateChanged('failed-verification')
         } else {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -123,8 +123,7 @@ class RegisterAccountModalController {
 
   checkDonorDetails (signUpDonorDetails) {
     // Show loading state
-    this.modalTitle = this.gettext('Checking your donor account')
-    this.stateChanged('loading')
+    this.stateChanged('loading-donor')
 
     // Step 2. Fetch Donor Details
     if (angular.isDefined(this.getDonorDetailsSubscription)) {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -193,6 +193,17 @@ describe('registerAccountModal', function () {
       })
     })
 
+    describe('\'registration-state\' MATCHED', () => {
+      it('changes state to \'user-match\'', () => {
+        $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'MATCHED' }))
+        $ctrl.verificationService.postDonorMatches.mockImplementation(() => Observable.of({}))
+        $ctrl.checkDonorDetails()
+
+        expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()
+        expect($ctrl.stateChanged).toHaveBeenCalledWith('user-match')
+      })
+    })
+
     describe('\'registration-state\' NEW', () => {
       const signUpDonorDetails = {
         name: {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -61,6 +61,15 @@ describe('registerAccountModal', function () {
       expect($ctrl.checkDonorDetails).toHaveBeenCalled()
     })
 
+    it('should load donor details initially and reload when session changes', () => {
+      $ctrl.sessionService.getRole.mockReturnValue(Roles.registered)
+
+      $ctrl.$onInit()
+      expect($ctrl.checkDonorDetails).toHaveBeenCalledTimes(1)
+      $ctrl.sessionService.sessionSubject.next({})
+      expect($ctrl.checkDonorDetails).toHaveBeenCalledTimes(2)
+    })
+
     describe('with \'REGISTERED\' cortex-session', () => {
       beforeEach(() => {
         $ctrl.sessionService.getRole.mockReturnValue(Roles.registered)

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -193,8 +193,7 @@ describe('registerAccountModal', function () {
           $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({ 'registration-state': 'COMPLETED' }))
           $ctrl.checkDonorDetails()
 
-          expect($ctrl.modalTitle).toEqual('Checking your donor account')
-          expect($ctrl.stateChanged).toHaveBeenCalledWith('loading')
+          expect($ctrl.stateChanged).toHaveBeenCalledWith('loading-donor')
           expect($ctrl.stateChanged.mock.calls.length).toEqual(1)
           expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()
           expect($ctrl.onSuccess).toHaveBeenCalled()

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -2,7 +2,8 @@
   <button type="button" class="close" aria-label="Close" ng-click="$ctrl.onCancel()" ng-if="!$ctrl.hideCloseButton">
     <span aria-hidden="true">×</span>
   </button>
-  <div ng-if="$ctrl.state !== 'sign-up'">
+  <h3 ng-if="$ctrl.state === 'loading-donor'" translate>Checking your donor account</h3>
+  <div ng-if="$ctrl.state !== 'loading-donor' && $ctrl.state !== 'sign-up'">
     <h3 ng-if="$ctrl.firstName" translate>Welcome back, {{$ctrl.firstName}}!</h3>
     <h3 ng-if="!$ctrl.firstName" translate>Welcome back!</h3>
   </div>
@@ -36,7 +37,7 @@
     on-sign-in="$ctrl.onSignIn()"
     is-inside-another-modal="true"
   ></sign-up-modal>
-  <div ng-switch-when="loading">
+  <div ng-switch-when="loading-donor">
     <loading></loading>
   </div>
   <contact-info-modal


### PR DESCRIPTION
* Only call `checkDonorDetails` once in `$onInit`. Previously it was called twice in`$onInit`.
* Skip the contact info modal when `registration-state` is `MATCHED`.
* Show "Checking your donor account" in the modal title while `checkDonorDetails` is running and rename state from `loading` to `loading-donor` for clarity.