### PR TITLE
Revert modal-md size and adjust close button position

### DIFF
--- a/src/assets/crubrand/_overrides.scss
+++ b/src/assets/crubrand/_overrides.scss
@@ -569,7 +569,7 @@ $modal-header-border-color:           #e5e5e5;
 $modal-footer-border-color:           $modal-header-border-color;
 
 $modal-lg:                            900px;
-$modal-md:                            530px;
+$modal-md:                            600px;
 $modal-sm:                            300px;
 
 

--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -33,6 +33,13 @@
       }
     }
 
+    @media (min-width: 550px) and (max-width: 600px) {
+      button.close {
+        left: 10px;
+        right: 0px;
+      }
+    }
+
     @media (min-width: 992px) {
       button.close {
         background-image: url("/assets/img/close-icon.png");


### PR DESCRIPTION
Restore the modal-md size to 600px and reposition the close button for better accessibility on screens between 550-600px.