### PR TITLE
[EP-2362] Okta sign in modal redesign

### DIFF
--- a/src/assets/img/okta-aura.svg
+++ b/src/assets/img/okta-aura.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="800px" height="800px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none"><path fill="#007DC1" d="M8 1C4.143 1 1 4.12 1 8s3.121 7 7 7 7-3.121 7-7-3.143-7-7-7zm0 10.5c-1.94 0-3.5-1.56-3.5-3.5S6.06 4.5 8 4.5s3.5 1.56 3.5 3.5-1.56 3.5-3.5 3.5z"/></svg>

--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -110,9 +110,4 @@ register-account-modal {
     }
   }
 
-  sign-in-button {
-    .okta-button:not(.normal-padding) {
-      width: 100%;
-    }
-  }
 }

--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -110,12 +110,6 @@ register-account-modal {
     }
   }
 
-  sign-in-form {
-    hr {
-      width: 65%;
-    }
-  }
-
   sign-in-button {
     .okta-button:not(.normal-padding) {
       width: 100%;

--- a/src/assets/scss/components/_signInForm.scss
+++ b/src/assets/scss/components/_signInForm.scss
@@ -14,16 +14,8 @@ sign-in-form {
     cursor: pointer;
   }
 
-  .sign-in-info {
+  > p {
     margin-bottom: 0;
-
-    .sup {
-      font-size: 12px;
-
-      i {
-        color: #333333;
-      }
-    }
   }
 
   .need-help {

--- a/src/assets/scss/components/_signInForm.scss
+++ b/src/assets/scss/components/_signInForm.scss
@@ -62,6 +62,10 @@ sign-in-button {
   .okta-button {
     width: 100%;
 
+    .fa {
+      padding-left: 0.25rem;
+    }
+
     &:not(.normal-padding) {
       width: 70%;
       padding: 1em 0.5em;

--- a/src/assets/scss/components/_signInForm.scss
+++ b/src/assets/scss/components/_signInForm.scss
@@ -14,6 +14,30 @@ sign-in-form {
     cursor: pointer;
   }
 
+  .details-wrapper {
+    display: flex;
+    flex-wrap: wrap; // Keep the summaries on the first line and wrap the description to the next line
+
+    details:first-of-type summary {
+      flex: 1; // Push the second summary to the right edge
+      min-width: 150px; // Ensure that the summaries are wide enough that the description is forced to wrap to the next line
+    }
+  }
+
+  // The goal is to have two <details> on one line that display their descriptions in the same
+  // location on the page on the line before
+  details {
+    display: contents; // Make the descriptions participate in the .details-wrapper flexbox layout
+    text-align: left;
+  }
+
+  summary {
+    display: list-item;
+    order: -1; // Make both summaries appear before the descriptions
+    margin: 1rem 0;
+    cursor: pointer;
+  }
+
   > p {
     margin-bottom: 0;
   }
@@ -41,33 +65,6 @@ sign-in-form {
 
     img {
       display: inline;
-    }
-  }
-
-  .need-help {
-    &--header {
-      cursor: pointer;
-
-      i {
-        font-size: 11px;
-        margin-right: 3px;
-      }
-    }
-
-    &--content {
-      max-height: 0px;
-      overflow: hidden;
-      transition: max-height 0.3s ease 0s;;
-    }
-
-    &.open {
-      i {
-        transform: rotate(90deg);
-      }
-
-      .need-help--content {
-        max-height: 140px;
-      }
     }
   }
 

--- a/src/assets/scss/components/_signInForm.scss
+++ b/src/assets/scss/components/_signInForm.scss
@@ -18,6 +18,32 @@ sign-in-form {
     margin-bottom: 0;
   }
 
+  .okta-signup-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    padding-block: 20px;
+    width: 100%;
+    font-size: 1.2rem;
+    font-weight: bold;
+    background-color: white;
+    color: #1371b4;
+    border: 2px solid #1371b4;
+    border-radius: 4px;
+
+    &:hover {
+      background-color: darken(white, 5%);
+    }
+    &:focus {
+      background-color: darken(white, 10%);
+    }
+
+    img {
+      display: inline;
+    }
+  }
+
   .need-help {
     &--header {
       cursor: pointer;
@@ -53,14 +79,9 @@ sign-in-form {
 sign-in-button {
   .okta-button {
     width: 100%;
+  }
 
-    .fa {
-      padding-left: 0.25rem;
-    }
-
-    &:not(.normal-padding) {
-      width: 70%;
-      padding: 1em 0.5em;
-    }
+  .fa {
+    padding-left: 0.25rem;
   }
 }

--- a/src/assets/scss/components/_signInModal.scss
+++ b/src/assets/scss/components/_signInModal.scss
@@ -1,6 +1,6 @@
 sign-in-modal {
   display: block;
-  
+
   h4 {
     font-size: 1.3em;
     line-height: 1.5em;
@@ -12,5 +12,9 @@ sign-in-modal {
     hr {
       width: 45%;
     }
+  }
+
+  sign-in-button .btn-primary {
+    @include button-variant(black, $btn-primary-bg, $btn-primary-border);
   }
 }

--- a/src/assets/scss/components/_signInModal.scss
+++ b/src/assets/scss/components/_signInModal.scss
@@ -19,4 +19,8 @@ sign-in-modal {
   sign-in-button .btn-primary {
     @include button-variant(black, $btn-primary-bg, $btn-primary-border);
   }
+
+  .okta-button {
+    padding-block: 1.25em;
+  }
 }

--- a/src/assets/scss/components/_signInModal.scss
+++ b/src/assets/scss/components/_signInModal.scss
@@ -9,8 +9,10 @@ sign-in-modal {
   sign-in-form {
     margin-top: 0;
 
-    hr {
-      width: 45%;
+    @media (min-width: 768px) {
+      hr {
+        width: 100%;
+      }
     }
   }
 

--- a/src/common/components/signInForm/signInButton/signInButton.component.js
+++ b/src/common/components/signInForm/signInButton/signInButton.component.js
@@ -21,7 +21,6 @@ class SignInButtonController {
 
   $onInit () {
     this.isSigningIn = false
-    this.onSignInPage = this.onSignInPage || false
 
     this.sessionService.handleOktaRedirect()
       .subscribe((data) => {
@@ -94,7 +93,6 @@ export default angular
       onSuccess: '&',
       onFailure: '&',
       lastPurchaseId: '<',
-      errorMessage: '=',
-      onSignInPage: '<'
+      errorMessage: '='
     }
   })

--- a/src/common/components/signInForm/signInButton/signInButton.tpl.html
+++ b/src/common/components/signInForm/signInButton/signInButton.tpl.html
@@ -3,6 +3,7 @@
         ng-disabled="$ctrl.isSigningIn"
         ng-class="{'normal-padding': $ctrl.onSignInPage}">
   <strong translate>Sign in to your account</strong>
+  <i class="fa fa-external-link"></i>
 </button>
 <loading type="overlay" ng-if="$ctrl.isSigningIn">
   <translate translate>Signing you in...</translate>

--- a/src/common/components/signInForm/signInButton/signInButton.tpl.html
+++ b/src/common/components/signInForm/signInButton/signInButton.tpl.html
@@ -1,7 +1,6 @@
 <button class="okta-button btn btn-primary"
         ng-click="$ctrl.signInWithOkta()"
-        ng-disabled="$ctrl.isSigningIn"
-        ng-class="{'normal-padding': $ctrl.onSignInPage}">
+        ng-disabled="$ctrl.isSigningIn">
   <strong translate>Sign in to your account</strong>
   <i class="fa fa-external-link"></i>
 </button>

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -13,16 +13,11 @@ class SignInFormController {
     this.$injector = angular.injector()
     this.sessionService = sessionService
     this.gettext = gettext
-    this.needHelpAccordionOpened = false
   }
 
   $onInit () {
     this.onSignInPage = this.onSignInPage || false
   }
-
-  toggleNeedHelpAccordion () {
-    this.needHelpAccordionOpened = !this.needHelpAccordionOpened
-  };
 
   getOktaUrl () {
     return this.sessionService.getOktaUrl()

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -6,32 +6,25 @@
     {{$ctrl.errorMessage | translate}}
   </span>
 </div>
-<div ng-if="!$ctrl.onSignInPage">
-  <h2 translate>Sign in</h2>
-</div>
-<div>
-  <sign-in-button
-    on-success="$ctrl.onSuccess()"
-    on-failure="$ctrl.onFailure()"
-    last-purchase-id="$ctrl.lastPurchaseId"
-    error-message="$ctrl.errorMessage"
-    on-sign-in-page="$ctrl.onSignInPage"
-  ></sign-in-button>
-</div>
+<sign-in-button
+  on-success="$ctrl.onSuccess()"
+  on-failure="$ctrl.onFailure()"
+  last-purchase-id="$ctrl.lastPurchaseId"
+  error-message="$ctrl.errorMessage"
+  on-sign-in-page="$ctrl.onSignInPage"
+></sign-in-button>
 
-<div>
-  <p class="sign-in-info" ng-if="!$ctrl.onSignInPage">
-    <span translate>You will be taken to Okta </span>
-    <span class="sup">
-      <i
-        class="fa fa-info-circle text-info"
-        uib-tooltip="{{'Okta is a trusted 3rd party security tool used by Cru to protect your personal information associated with your donor account.' | translate}}"
-      ></i>
-    </span>
-    <span translate>, then back to this site.</span>
-  </p>
-  <p ng-if="$ctrl.onSignInPage" translate>You will briefly be taken away from this site to login, then brought back right where you left off.</p>
-</div>
+<p class="sign-in-info" ng-if="!$ctrl.onSignInPage">
+  <span translate>You will be taken to Okta </span>
+  <span class="sup">
+    <i
+      class="fa fa-info-circle text-info"
+      uib-tooltip="{{'Okta is a trusted 3rd party security tool used by Cru to protect your personal information associated with your donor account.' | translate}}"
+    ></i>
+  </span>
+  <span translate>, then back to this site.</span>
+</p>
+<p ng-if="$ctrl.onSignInPage" translate>You will briefly be taken away from this site to login, then brought back right where you left off.</p>
 <hr />
 <div ng-if="!$ctrl.onSignInPage">
   <h4 translate>Don&rsquo;t have an account?</h4>

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -23,13 +23,14 @@
     <span translate>Sign up with Okta</span>
   </button>
 </div>
-<div class="need-help" ng-class="{'open': $ctrl.needHelpAccordionOpened}">
-  <div class="need-help--header" ng-click="$ctrl.toggleNeedHelpAccordion()" onKeyPress>
-    <i class="fa fa-caret-right"></i>
-    <span translate>Need help?</span>
-  </div>
-  <div class="need-help--content">
+<div class="details-wrapper">
+  <details name="okta-help">
+    <summary translate>Need help?</summary>
     <p><a ng-href="{{$ctrl.getOktaUrl()}}/signin/forgot-password" target="_blank" translate>Forgot your password?</a></p>
-    <p>Call <a href="tel:+18882787233">(888) 278-7233</a> opt. 1, then 1.<br />9:00 a.m. to 5:00 p.m. ET, Monday-Friday,<br /> or email us at <a href="mailto:eGift@cru.org">eGift@cru.org</a>.</p>
-  </div>
+    <p>Call <a href="tel:+18882787233">(888) 278-7233</a> opt. 1, then 1.<br />9:00 a.m. to 5:00 p.m. ET, Monday-Friday,<br />or email us at <a href="mailto:eGift@cru.org">eGift@cru.org</a>.</p>
+  </details>
+  <details name="okta-help">
+    <summary translate>What is Okta?</summary>
+    <p translate>Okta is a trusted 3rd party security tool used by Cru to protect your personal information associated with your donor account.</p>
+  </details>
 </div>

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -11,7 +11,6 @@
   on-failure="$ctrl.onFailure()"
   last-purchase-id="$ctrl.lastPurchaseId"
   error-message="$ctrl.errorMessage"
-  on-sign-in-page="$ctrl.onSignInPage"
 ></sign-in-button>
 
 <p ng-if="!$ctrl.onSignInPage" translate>You will be taken to Okta, then back to this site.</p>
@@ -19,7 +18,10 @@
 <hr />
 <div ng-if="!$ctrl.onSignInPage">
   <h4 translate>Don&rsquo;t have an account?</h4>
-  <a class="okta-signup-button" ng-click="$ctrl.onSignUpWithOkta()">Create an account</a>
+  <button class="okta-signup-button" ng-click="$ctrl.onSignUpWithOkta()">
+    <img src="/assets/img/okta-aura.svg" alt="Okta logo" width="24" height="24"></img>
+    <span translate>Sign up with Okta</span>
+  </button>
 </div>
 <div class="need-help" ng-class="{'open': $ctrl.needHelpAccordionOpened}">
   <div class="need-help--header" ng-click="$ctrl.toggleNeedHelpAccordion()" onKeyPress>

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -14,16 +14,7 @@
   on-sign-in-page="$ctrl.onSignInPage"
 ></sign-in-button>
 
-<p class="sign-in-info" ng-if="!$ctrl.onSignInPage">
-  <span translate>You will be taken to Okta </span>
-  <span class="sup">
-    <i
-      class="fa fa-info-circle text-info"
-      uib-tooltip="{{'Okta is a trusted 3rd party security tool used by Cru to protect your personal information associated with your donor account.' | translate}}"
-    ></i>
-  </span>
-  <span translate>, then back to this site.</span>
-</p>
+<p ng-if="!$ctrl.onSignInPage" translate>You will be taken to Okta, then back to this site.</p>
 <p ng-if="$ctrl.onSignInPage" translate>You will briefly be taken away from this site to login, then brought back right where you left off.</p>
 <hr />
 <div ng-if="!$ctrl.onSignInPage">


### PR DESCRIPTION
@dr-bizz I only implemented the mobile styles, not the desktop styles with the second panel on the left. I wanted to coordinate with you first since that panel is present on the sign up modal also.

The most complex part is the CSS to get the two details elements to show their contents in the same location on the page when opened. I like using `<details>` to get accessibility for free, but if you think it's too complex, I can go back to the drawing board with a JS-based solution.