### PR TITLE
[no-Jira] Only collect test coverage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn install --immutable --immutable-cache
       
       - name: Run Tests
-        run: yarn test
+        run: yarn test --coverage=true
       
       - name: Upload Codecov Reports
         uses: codecov/codecov-action@v2 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn install --immutable --immutable-cache
       
       - name: Run Tests
-        run: yarn test --coverage=true
+        run: yarn test:coverage
       
       - name: Upload Codecov Reports
         uses: codecov/codecov-action@v2 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  collectCoverage: true,
   collectCoverageFrom: [
     'src/**/*.js',
     'src/**/*.{ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "build": "webpack -p",
     "build:analyze": "webpack -p --env.analyze",
     "test": "jest",
+    "test:coverage": "jest --coverage=true",
     "test:log": "jest --silent=false",
     "lint": "standard",
     "lint:write": "standard --fix",


### PR DESCRIPTION
Currently, give-web always runs tests with test coverage enabled. This prints the code coverage results, which means I always have to scroll up many lines to see which tests succeeded or failed. It also makes the tests take a little longer to run.

This change makes tests default to not having test coverage enabled, while still enabling test coverage in CI. If developers want to see code coverage info locally, they can always run `yarn test --coverage=true`.