### PR TITLE
EP-2562 - Filter invalid CVV

### DIFF
--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -41,6 +41,7 @@ class Step3Controller {
     this.sessionStorage = $window.sessionStorage
     this.selfReference = this
     this.isBranded = envService.read('isBrandedCheckout')
+    this.datadogRum = datadogRum
 
     this.$scope.$on(SignInEvent, () => {
       this.$onInit()
@@ -173,12 +174,23 @@ class Step3Controller {
         error.config.data['security-code'] = error.config.data['security-code'].replace(/./g, 'X') // Mask security-code
       }
       componentInstance.$log.error('Error submitting purchase:', error)
-      datadogRum.addError(new Error(`Error submitting purchase: ${JSON.stringify(error)}`), { context: 'Checkout Submission', errorCode: error.status }) // here in order to show up in Error Tracking in DD
+      componentInstance.logToDatadogRum(error)
       componentInstance.onSubmitted()
       componentInstance.submissionErrorStatus = error.status
       componentInstance.submissionError = isString(error && error.data) ? (error && error.data).replace(/[:].*$/, '') : 'generic error' // Keep prefix before first colon for easier ng-switch matching
       componentInstance.$window.scrollTo(0, 0)
     })
+  }
+
+  // Log error to Datadog in order to show up in Error Tracking (RUM)
+  logToDatadogRum (error) {
+    let errorMessage = `Error submitting purchase: ${JSON.stringify(error)}`
+    if (error?.data) {
+      if (error.data.includes('InvalidCVV2Exception')) {
+        errorMessage = 'Invalid CVV'
+      }
+    }
+    this.datadogRum.addError(new Error(errorMessage), { context: 'Checkout Submission', errorCode: error.status })
   }
 }
 

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -455,5 +455,40 @@ describe('checkout', () => {
         expect(self.controller.submitOrder).toHaveBeenCalled()
       })
     })
+
+    describe('logToDatadogRum', () => {
+      beforeEach(() => {
+        self.controller.datadogRum = {
+          addError: jest.fn()
+        }
+      })
+
+      it('should log a checkout error', () => {
+        const error = {
+          data: 'Server Error',
+          status: 500
+        }
+
+        self.controller.logToDatadogRum(error)
+        expect(self.controller.datadogRum.addError)
+          .toHaveBeenCalledWith(new Error(`Error submitting purchase: ${JSON.stringify(error)}`), { context: 'Checkout Submission', errorCode: error.status })
+      })
+
+      it('should log a checkout error without data', () => {
+        const error = 'Some error that is unstructured'
+        self.controller.logToDatadogRum(error)
+        expect(self.controller.datadogRum.addError)
+          .toHaveBeenCalledWith(new Error(`Error submitting purchase: ${JSON.stringify(error)}`), { context: 'Checkout Submission', errorCode: error.status })
+      })
+
+      it('should log InvalidCVV errors differently', () => {
+        const error = {
+          data: 'InvalidCVV2Exception: Invalid CVV',
+          status: 500
+        }
+        self.controller.logToDatadogRum(error)
+        expect(self.controller.datadogRum.addError).toHaveBeenCalledWith(new Error('Invalid CVV'), { context: 'Checkout Submission', errorCode: error.status })
+      })
+    })
   })
 })

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -8,7 +8,7 @@ import { cartUpdatedEvent } from 'common/components/nav/navCart/navCart.componen
 import { SignInEvent } from 'common/services/session/session.service'
 
 import module from './step-3.component'
-import { recaptchaFailedEvent, submitOrderEvent } from '../cart-summary/cart-summary.component'
+import { submitOrderEvent } from '../cart-summary/cart-summary.component'
 
 describe('checkout', () => {
   describe('step 3', () => {


### PR DESCRIPTION
In order to make the [Datadog Monitor](https://app.datadoghq.com/monitors/159980320) more effective in bringing up issues during checkout on the client side, we need to filter out user errors (such as entering the wrong cvv). If we want to filter out other user errors later, we can refactor the filtering logic.