### PR TITLE
[EP-2362] Rearrange user match modal steps

### DIFF
--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -228,7 +228,6 @@ export default angular
     controller: RegisterAccountModalController,
     templateUrl: template,
     bindings: {
-      firstName: '=',
       modalTitle: '=',
       // If true, show the "Welcome back!" message in the header/sidebar
       welcomeBack: '<?',

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -6,6 +6,7 @@
   <div ng-if="$ctrl.state === 'sign-up'" class="signup-header">
     <h3 translate>Create Your Account</h3>
   </div>
+  <h3 ng-if="$ctrl.state === 'user-match'" translate>Access Your Account</h3>
   <div ng-if="$ctrl.state === 'sign-in'" class="section">
     <ul>
       <li translate>Give to thousands of opportunities.</li>

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -2,20 +2,20 @@
   <button type="button" class="close" aria-label="Close" ng-click="$ctrl.onCancel()" ng-if="!$ctrl.hideCloseButton">
     <span aria-hidden="true">×</span>
   </button>
-  <h3 ng-if="$ctrl.state === 'loading-donor'" translate>Checking your donor account</h3>
-  <div ng-if="$ctrl.state === 'sign-up'" class="signup-header">
-    <h3 translate>Create Your Account</h3>
-  </div>
-  <h3 ng-if="$ctrl.state === 'user-match'" translate>Access Your Account</h3>
-  <div ng-if="$ctrl.state === 'sign-in'" class="section">
-    <ul>
-      <li translate>Give to thousands of opportunities.</li>
-      <li translate>View giving history (online and offline).</li>
-      <li translate>Access your tax receipts and forms.</li>
-    </ul>
-  </div>
-  <div ng-if="$ctrl.state === 'contact-info'" class="section paragraph" translate>
-    Please fill in your information for your online account.
+  <div ng-switch="$ctrl.state">
+    <h3 ng-switch-when="loading-donor" translate>Checking your donor account</h3>
+    <h3 ng-switch-when="sign-up" class="signup-header" translate>Create Your Account</h3>
+    <h3 ng-switch-when="user-match" translate>Access Your Account</h3>
+    <div ng-switch-when="sign-in" class="section">
+      <ul>
+        <li translate>Give to thousands of opportunities.</li>
+        <li translate>View giving history (online and offline).</li>
+        <li translate>Access your tax receipts and forms.</li>
+      </ul>
+    </div>
+    <div ng-switch-when="contact-info" class="section paragraph" translate>
+      Please fill in your information for your online account.
+    </div>
   </div>
 </div>
 <div ng-switch="$ctrl.state">

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -3,10 +3,6 @@
     <span aria-hidden="true">×</span>
   </button>
   <h3 ng-if="$ctrl.state === 'loading-donor'" translate>Checking your donor account</h3>
-  <div ng-if="$ctrl.state !== 'loading-donor' && $ctrl.state !== 'sign-up'">
-    <h3 ng-if="$ctrl.firstName" translate>Welcome back, {{$ctrl.firstName}}!</h3>
-    <h3 ng-if="!$ctrl.firstName" translate>Welcome back!</h3>
-  </div>
   <div ng-if="$ctrl.state === 'sign-up'" class="signup-header">
     <h3 translate>Create Your Account</h3>
   </div>
@@ -52,7 +48,6 @@
   <user-match-modal
     ng-switch-when="user-match"
     cart-count="$ctrl.cartCount"
-    first-name="$ctrl.firstName"
     modal-title="$ctrl.modalTitle"
     on-success="$ctrl.onUserMatchSuccess()"
     set-loading="$ctrl.setLoading({loading: loading})"

--- a/src/common/components/userMatchModal/userMatchModal.component.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.js
@@ -20,7 +20,7 @@ class UserMatchModalController {
     this.profileService = profileService
     this.verificationService = verificationService
     this.analyticsFactory = analyticsFactory
-    this.stepCount = 8 // intro, name, 5 questions, and success
+    this.stepCount = 6 // 5 questions, and success
     this.identitySubmitted = false
     this.answerSubmitted = false
   }
@@ -53,14 +53,10 @@ class UserMatchModalController {
   }
 
   getCurrentStep () {
-    if (this.matchState === 'intro') {
-      return 0.1
-    } else if (this.matchState === 'identity') {
-      return 1
-    } else if (this.matchState === 'question') {
-      return this.questionIndex + 1 // questionIndex is 1-indexed, otherwise this would be + 2
+    if (this.matchState === 'question') {
+      return this.questionIndex - 1 // questionIndex is 1-indexed, otherwise this would be + 0
     } else if (this.matchState === 'success') {
-      return 7
+      return 5
     } else {
       return 0
     }

--- a/src/common/components/userMatchModal/userMatchModal.component.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.js
@@ -41,7 +41,7 @@ class UserMatchModalController {
         } else if (donorDetails['registration-state'] === 'FAILED') {
           this.changeMatchState('failure')
         } else {
-          this.changeMatchState('intro')
+          this.getContacts()
         }
       }
     },
@@ -69,7 +69,10 @@ class UserMatchModalController {
   postDonorMatch () {
     this.setLoading({ loading: true })
     this.verificationService.postDonorMatches().subscribe({
-      next: () => { this.changeMatchState('intro') }, // Donor match success, get contacts
+      next: () => {
+        // Donor match success, get contacts
+        this.getContacts()
+      },
       error: () => {
         // Donor Match failed, user match not required
         this.skippedQuestions = true
@@ -89,7 +92,7 @@ class UserMatchModalController {
     this.setLoading({ loading: true })
     this.verificationService.getContacts().subscribe((contacts) => {
       if (find(contacts, { selected: true })) {
-        this.onActivate()
+        this.changeMatchState('activate')
       } else {
         this.contacts = contacts
         this.changeMatchState('identity')
@@ -128,7 +131,7 @@ class UserMatchModalController {
     this.selectContactError = false
     if (angular.isDefined(contact)) {
       this.verificationService.selectContact(contact).subscribe(() => {
-        this.onActivate()
+        this.changeMatchState('activate')
         this.firstName = contact.name.includes(' ')
           ? contact.name.substring(0, contact.name.lastIndexOf(' '))
           : contact.name
@@ -165,7 +168,7 @@ class UserMatchModalController {
     this.answerSubmitted = true
   }
 
-  onActivate () {
+  loadQuestions () {
     this.setLoading({ loading: true })
     this.loadingQuestionsError = false
     this.verificationService.getQuestions().subscribe((questions) => {

--- a/src/common/components/userMatchModal/userMatchModal.component.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.js
@@ -132,9 +132,6 @@ class UserMatchModalController {
     if (angular.isDefined(contact)) {
       this.verificationService.selectContact(contact).subscribe(() => {
         this.changeMatchState('activate')
-        this.firstName = contact.name.includes(' ')
-          ? contact.name.substring(0, contact.name.lastIndexOf(' '))
-          : contact.name
       },
       error => {
         this.setLoading({ loading: false })
@@ -250,7 +247,6 @@ export default angular
     templateUrl: template,
     bindings: {
       cartCount: '<',
-      firstName: '=',
       modalTitle: '=',
       setLoading: '&',
       onStateChange: '&',

--- a/src/common/components/userMatchModal/userMatchModal.component.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.js
@@ -41,7 +41,7 @@ class UserMatchModalController {
         } else if (donorDetails['registration-state'] === 'FAILED') {
           this.changeMatchState('failure')
         } else {
-          this.getContacts()
+          this.loadContacts()
         }
       }
     },
@@ -71,7 +71,7 @@ class UserMatchModalController {
     this.verificationService.postDonorMatches().subscribe({
       next: () => {
         // Donor match success, get contacts
-        this.getContacts()
+        this.loadContacts()
       },
       error: () => {
         // Donor Match failed, user match not required
@@ -81,7 +81,7 @@ class UserMatchModalController {
     })
   }
 
-  getContacts () {
+  loadContacts () {
     if (this.contacts) {
       // The user picked a contact then went back, so don't load the contacts again because there
       // probably won't even be any

--- a/src/common/components/userMatchModal/userMatchModal.component.spec.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.spec.js
@@ -76,13 +76,13 @@ describe('userMatchModal', function () {
       })
 
       describe('getContacts has selected contact', () => {
-        it('initializes the component and proceeds to \'intro\'', () => {
+        it('initializes the component and proceeds to \'identity\'', () => {
           $ctrl.$onInit()
 
           expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
           expect($ctrl.modalTitle).toEqual('Activate Your Account')
           expect($ctrl.profileService.getDonorDetails).toHaveBeenCalled()
-          expect($ctrl.changeMatchState).toHaveBeenCalledWith('intro')
+          expect($ctrl.changeMatchState).toHaveBeenCalledWith('identity')
           expect($ctrl.loadingDonorDetailsError).toEqual(false)
         })
       })
@@ -107,16 +107,14 @@ describe('userMatchModal', function () {
       expect($ctrl.loadingDonorDetailsError).not.toEqual(true)
     })
 
-    it('initializes the component and proceeds to \'question\'', () => {
-      jest.spyOn($ctrl, 'onActivate')
+    it('initializes the component and proceeds to \'activate\'', () => {
       const contacts = [{ name: 'Charles Xavier', selected: true }]
       jest.spyOn($ctrl.verificationService, 'getQuestions').mockReturnValue(Observable.of([{ key: 'a' }, { key: 'b' }, { key: 'c' }]))
       $ctrl.verificationService.getContacts.mockImplementation(() => Observable.of(contacts))
       $ctrl.contacts = null
       $ctrl.getContacts()
       expect($ctrl.verificationService.getContacts).toHaveBeenCalled()
-      expect($ctrl.onActivate).toHaveBeenCalled()
-      expect($ctrl.changeMatchState).toHaveBeenCalledWith('question')
+      expect($ctrl.changeMatchState).toHaveBeenCalledWith('activate')
     })
 
     it('logs an error on failure', () => {
@@ -144,12 +142,13 @@ describe('userMatchModal', function () {
       jest.spyOn($ctrl, 'changeMatchState').mockImplementation(() => {})
     })
 
-    it('proceeds to intro on donor match success', () => {
+    it('loads contacts on donor match success', () => {
       jest.spyOn($ctrl.verificationService, 'postDonorMatches').mockReturnValue(Observable.of({}))
+      jest.spyOn($ctrl, 'getContacts').mockReturnValue(Observable.of({}))
       $ctrl.postDonorMatch()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
-      expect($ctrl.changeMatchState).toHaveBeenCalledWith('intro')
+      expect($ctrl.getContacts).toHaveBeenCalled()
     })
 
     it('proceeds to success on donor match failure', () => {
@@ -208,12 +207,11 @@ describe('userMatchModal', function () {
     describe('valid contact', () => {
       it('selects the contact', () => {
         jest.spyOn($ctrl.verificationService, 'selectContact').mockReturnValue(Observable.of({}))
-        jest.spyOn($ctrl, 'onActivate')
         $ctrl.onSelectContact(true, { name: 'Batman' })
 
         expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
         expect($ctrl.verificationService.selectContact).toHaveBeenCalledWith({ name: 'Batman' })
-        expect($ctrl.onActivate).toHaveBeenCalled()
+        expect($ctrl.changeMatchState).toHaveBeenCalledWith('activate')
         expect($ctrl.selectContactError).toEqual(false)
         expect($ctrl.firstName).toEqual('Batman')
       })
@@ -276,12 +274,12 @@ describe('userMatchModal', function () {
     })
   })
 
-  describe('onActivate()', () => {
+  describe('loadQuestions()', () => {
     it('load questions and changes state', () => {
       jest.spyOn($ctrl.verificationService, 'getQuestions').mockReturnValue(Observable.of([{ key: 'a' }, { key: 'b' }, { key: 'c' }]))
       jest.spyOn($ctrl, 'changeMatchState').mockImplementation(() => {})
 
-      $ctrl.onActivate()
+      $ctrl.loadQuestions()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
       expect($ctrl.questions).toEqual([{ key: 'a' }, { key: 'b' }, { key: 'c' }])
@@ -295,7 +293,7 @@ describe('userMatchModal', function () {
       jest.spyOn($ctrl.verificationService, 'getQuestions').mockReturnValue(Observable.throw('some error'))
       jest.spyOn($ctrl, 'changeMatchState').mockImplementation(() => {})
 
-      $ctrl.onActivate()
+      $ctrl.loadQuestions()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
       expect($ctrl.changeMatchState).not.toHaveBeenCalled()

--- a/src/common/components/userMatchModal/userMatchModal.component.spec.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.spec.js
@@ -89,7 +89,7 @@ describe('userMatchModal', function () {
     })
   })
 
-  describe('getContacts()', () => {
+  describe('loadContacts()', () => {
     beforeEach(() => {
       jest.spyOn($ctrl, 'changeMatchState')
       jest.spyOn($ctrl.verificationService, 'getContacts')
@@ -98,7 +98,7 @@ describe('userMatchModal', function () {
     it('initializes the component and proceeds to \'identity\'', () => {
       const contacts = [{ name: 'Charles Xavier', selected: false }, { name: 'Bruce Bannr', selected: false }]
       $ctrl.verificationService.getContacts.mockImplementation(() => Observable.of(contacts))
-      $ctrl.getContacts()
+      $ctrl.loadContacts()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
       expect($ctrl.verificationService.getContacts).toHaveBeenCalled()
@@ -112,14 +112,14 @@ describe('userMatchModal', function () {
       jest.spyOn($ctrl.verificationService, 'getQuestions').mockReturnValue(Observable.of([{ key: 'a' }, { key: 'b' }, { key: 'c' }]))
       $ctrl.verificationService.getContacts.mockImplementation(() => Observable.of(contacts))
       $ctrl.contacts = null
-      $ctrl.getContacts()
+      $ctrl.loadContacts()
       expect($ctrl.verificationService.getContacts).toHaveBeenCalled()
       expect($ctrl.changeMatchState).toHaveBeenCalledWith('activate')
     })
 
     it('logs an error on failure', () => {
       $ctrl.verificationService.getContacts.mockReturnValue(Observable.throw('another error'))
-      $ctrl.getContacts()
+      $ctrl.loadContacts()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
       expect($ctrl.verificationService.getContacts).toHaveBeenCalled()
@@ -130,7 +130,7 @@ describe('userMatchModal', function () {
 
     it('does not reload the contacts if they have already been loaded', () => {
       $ctrl.contacts = [{ name: 'Charles Xavier', selected: false }, { name: 'Bruce Bannr', selected: false }]
-      $ctrl.getContacts()
+      $ctrl.loadContacts()
 
       expect($ctrl.changeMatchState).toHaveBeenCalledWith('identity')
       expect($ctrl.verificationService.getContacts).not.toHaveBeenCalled()
@@ -144,11 +144,11 @@ describe('userMatchModal', function () {
 
     it('loads contacts on donor match success', () => {
       jest.spyOn($ctrl.verificationService, 'postDonorMatches').mockReturnValue(Observable.of({}))
-      jest.spyOn($ctrl, 'getContacts').mockReturnValue(Observable.of({}))
+      jest.spyOn($ctrl, 'loadContacts').mockReturnValue(Observable.of({}))
       $ctrl.postDonorMatch()
 
       expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: true })
-      expect($ctrl.getContacts).toHaveBeenCalled()
+      expect($ctrl.loadContacts).toHaveBeenCalled()
     })
 
     it('proceeds to success on donor match failure', () => {

--- a/src/common/components/userMatchModal/userMatchModal.component.spec.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.spec.js
@@ -213,7 +213,6 @@ describe('userMatchModal', function () {
         expect($ctrl.verificationService.selectContact).toHaveBeenCalledWith({ name: 'Batman' })
         expect($ctrl.changeMatchState).toHaveBeenCalledWith('activate')
         expect($ctrl.selectContactError).toEqual(false)
-        expect($ctrl.firstName).toEqual('Batman')
       })
 
       it('should log an error on failure', () => {
@@ -226,18 +225,6 @@ describe('userMatchModal', function () {
         expect($ctrl.selectContactError).toEqual(true)
         expect($ctrl.$log.error.logs[0]).toEqual(['Error selecting verification contact.', 'some error'])
         expect($ctrl.setLoading).toHaveBeenCalledWith({ loading: false })
-      })
-
-      it('should only return the first name', () => {
-        jest.spyOn($ctrl.verificationService, 'selectContact').mockReturnValue(Observable.of({}))
-        $ctrl.onSelectContact(true, { name: 'firstName lastName' })
-        expect($ctrl.firstName).toEqual('firstName')
-      })
-
-      it('should return the first two first names', () => {
-        jest.spyOn($ctrl.verificationService, 'selectContact').mockReturnValue(Observable.of({}))
-        $ctrl.onSelectContact(true, { name: 'firstName secondFirstName lastName' })
-        expect($ctrl.firstName).toEqual('firstName secondFirstName')
       })
     })
 

--- a/src/common/components/userMatchModal/userMatchModal.component.spec.js
+++ b/src/common/components/userMatchModal/userMatchModal.component.spec.js
@@ -377,22 +377,14 @@ describe('userMatchModal', function () {
   })
 
   describe('getCurrentStep()', () => {
-    it('returns intro step', () => {
-      $ctrl.matchState = 'intro'
-      expect($ctrl.getCurrentStep()).toEqual(0.1)
-    })
-    it('returns identity step', () => {
-      $ctrl.matchState = 'identity'
-      expect($ctrl.getCurrentStep()).toEqual(1)
-    })
     it('returns the next question step', () => {
       $ctrl.matchState = 'question'
       $ctrl.questionIndex = 2
-      expect($ctrl.getCurrentStep()).toEqual(3)
+      expect($ctrl.getCurrentStep()).toEqual(1)
     })
     it('returns success step', () => {
       $ctrl.matchState = 'success'
-      expect($ctrl.getCurrentStep()).toEqual(7)
+      expect($ctrl.getCurrentStep()).toEqual(5)
     })
     it('returns default step', () => {
       $ctrl.matchState = 'default'

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -9,7 +9,10 @@
       <p translate>There was an error saving your answer. Please try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     </div>
     <div class="activate-progress">
-      <h3 class="text-center" translate>Activate your account</h3>
+      <h3 class="text-center" translate>Access your account</h3>
+      <p ng-if="$ctrl.matchState === 'identity'" translate>
+        Has someone in your household donated before? We may already have an account for you.
+      </p>
       <div ng-if="$ctrl.matchState === 'question' || $ctrl.matchState === 'success'">
         <progress id="activation-progress" ng-attr-value="{{$ctrl.getCurrentStep()}}" ng-attr-max="{{$ctrl.stepCount - 1}}">Activation status</progress>
         <label for="activation-progress" class="step-label" ng-switch="$ctrl.matchState" style="--progress: {{$ctrl.getCurrentStep() / ($ctrl.stepCount - 1)}}">
@@ -18,10 +21,12 @@
         </label>
       </div>
     </div>
-    <div ng-switch-when="intro">
-      <h4 class="text-center" translate>According to our records, someone in your household has given to us before.</h4>
+    <div ng-switch-when="activate">
+      <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingQuestionsError">
+        <p class="text-center" translate>There was an error loading the verification questions. Please try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
+      </div>
       <p class="text-center" style="margin-bottom: 2em;" translate>
-        Please answer these questions to confirm this so that you can access your whole giving history from this account.
+        Please answer the following questions to confirm your identity so that you can access your account.
       </p>
     </div>
     <user-match-identity ng-switch-when="identity"
@@ -29,18 +34,6 @@
                          submitted="$ctrl.identitySubmitted"
                          on-submit="$ctrl.onSelectContact(success, contact)">
     </user-match-identity>
-    <div ng-switch-when="activate">
-      <div class="alert alert-danger" role="alert" ng-if="$ctrl.loadingQuestionsError">
-        <p translate>There was an error loading the verification questions. Please try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
-      </div>
-      <h4 class="text-center" translate>According to our records, someone in your household has given to us before.</h4>
-      <p class="text-center" translate>
-        Please answer these questions to confirm this so that you can access your whole giving history from this account.
-      </p>
-      <p ng-if="$ctrl.matchState !== 'success'">
-        <button type="button" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.onActivate()" translate>Next</button>
-      </p>
-    </div>
     <user-match-question ng-switch-when="question"
                          ng-init="$ctrl.analyticsFactory.track('ga-registration-match-security-question'+$ctrl.questionCount)"
                          question="$ctrl.getQuestion()"
@@ -70,11 +63,10 @@
     <div ng-switch-default style="height: 100px;" ng-if="!$ctrl.loadingDonorDetailsError"></div>
   </div>
 </div>
-<div class="modal-footer" ng-switch="$ctrl.matchState">
-  <button ng-switch-when="intro" type="button" class="btn btn-md btn-primary" ng-click="$ctrl.getContacts()" translate>Next</button>
-  <div ng-switch-when="identity">
-    <button type="button" class="btn btn-md back" ng-click="$ctrl.changeMatchState('intro')" translate>Back</button>
-    <button type="button" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.requestIdentitySubmit()" translate>Next</button>
+  <button ng-switch-when="identity" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.requestIdentitySubmit()" translate>Next</button>
+  <div ng-switch-when="activate">
+    <button type="button" class="btn btn-md back" ng-click="$ctrl.changeMatchState('identity')" translate>Back</button>
+    <button type="button" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.loadQuestions()" translate>Next</button>
   </div>
   <div ng-switch-when="question">
     <button type="button" class="btn btn-md back" ng-click="$ctrl.back()" translate>Back</button>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -9,7 +9,6 @@
       <p translate>There was an error saving your answer. Please try again. If you continue to see this message, contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.</p>
     </div>
     <div class="activate-progress">
-      <h3 class="text-center" translate>Access your account</h3>
       <p ng-if="$ctrl.matchState === 'identity'" translate>
         Has someone in your household donated before? We may already have an account for you.
       </p>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -10,12 +10,13 @@
     </div>
     <div class="activate-progress">
       <h3 class="text-center" translate>Activate your account</h3>
-      <progress id="activation-progress" ng-attr-value="{{$ctrl.getCurrentStep()}}" ng-attr-max="{{$ctrl.stepCount - 1}}" ng-if="$ctrl.matchState && $ctrl.matchState !== 'intro'">Activation status</progress>
-      <label for="activation-progress" class="step-label" ng-switch="$ctrl.matchState" style="--progress: {{$ctrl.getCurrentStep() / ($ctrl.stepCount - 1)}}" ng-if="$ctrl.matchState && $ctrl.matchState !== 'intro'">
-        <span ng-switch-when="identity" translate>Name</span>
-        <span ng-switch-when="question"><span translate>Question</span><br />{{$ctrl.questionIndex}} <span translate>of</span> {{$ctrl.questionCount}}</span>
-        <span ng-switch-when="success" translate>Activated</span>
-      </label>
+      <div ng-if="$ctrl.matchState === 'question' || $ctrl.matchState === 'success'">
+        <progress id="activation-progress" ng-attr-value="{{$ctrl.getCurrentStep()}}" ng-attr-max="{{$ctrl.stepCount - 1}}">Activation status</progress>
+        <label for="activation-progress" class="step-label" ng-switch="$ctrl.matchState" style="--progress: {{$ctrl.getCurrentStep() / ($ctrl.stepCount - 1)}}">
+          <span ng-switch-when="question"><span translate>Question</span><br />{{$ctrl.questionIndex}} <span translate>of</span> {{$ctrl.questionCount}}</span>
+          <span ng-switch-when="success" translate>Activated</span>
+        </label>
+      </div>
     </div>
     <div ng-switch-when="intro">
       <h4 class="text-center" translate>According to our records, someone in your household has given to us before.</h4>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -63,6 +63,7 @@
     <div ng-switch-default style="height: 100px;" ng-if="!$ctrl.loadingDonorDetailsError"></div>
   </div>
 </div>
+<div class="modal-footer" ng-switch="$ctrl.matchState" ng-if="$ctrl.matchState">
   <button ng-switch-when="identity" class="btn btn-md btn-block btn-primary" ng-click="$ctrl.requestIdentitySubmit()" translate>Next</button>
   <div ng-switch-when="activate">
     <button type="button" class="btn btn-md back" ng-click="$ctrl.changeMatchState('identity')" translate>Back</button>

--- a/src/common/components/userMatchModal/userMatchModal.tpl.html
+++ b/src/common/components/userMatchModal/userMatchModal.tpl.html
@@ -14,7 +14,7 @@
         Has someone in your household donated before? We may already have an account for you.
       </p>
       <div ng-if="$ctrl.matchState === 'question' || $ctrl.matchState === 'success'">
-        <progress id="activation-progress" ng-attr-value="{{$ctrl.getCurrentStep()}}" ng-attr-max="{{$ctrl.stepCount - 1}}">Activation status</progress>
+        <progress id="activation-progress" ng-attr-value="{{$ctrl.getCurrentStep()}}" ng-attr-max="{{$ctrl.stepCount - 1}}"></progress>
         <label for="activation-progress" class="step-label" ng-switch="$ctrl.matchState" style="--progress: {{$ctrl.getCurrentStep() / ($ctrl.stepCount - 1)}}">
           <span ng-switch-when="question"><span translate>Question</span><br />{{$ctrl.questionIndex}} <span translate>of</span> {{$ctrl.questionCount}}</span>
           <span ng-switch-when="success" translate>Activated</span>

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -31,17 +31,10 @@ class SessionModalController {
     this.$rootScope.$on(LoginOktaOnlyEvent, (_, state) => {
       this.stateChanged(state)
     })
-    this.subscription = this.sessionService.sessionSubject.subscribe((session) => {
-      this.firstName = session.first_name
-    })
     this.stateChanged(this.resolve.state)
     this.welcomeBack = this.resolve.welcomeBack
     this.hideCloseButton = this.resolve.hideCloseButton
     this.lastPurchaseId = this.resolve.lastPurchaseId
-  }
-
-  $onDestroy () {
-    this.subscription.unsubscribe()
   }
 
   stateChanged (state) {

--- a/src/common/services/session/sessionModal.component.spec.js
+++ b/src/common/services/session/sessionModal.component.spec.js
@@ -56,15 +56,6 @@ describe('sessionModalController', function () {
     })
   })
 
-  describe('$ctrl.$onDestroy', () => {
-    it('should remove sessionSubject subscription', () => {
-      $ctrl.$onInit()
-      expect($ctrl.subscription.closed).toEqual(false)
-      $ctrl.$onDestroy()
-      expect($ctrl.subscription.closed).toEqual(true)
-    })
-  })
-
   describe('$ctrl.stateChanged', () => {
     it('should scroll to the top of the modal', () => {
       jest.spyOn($ctrl, 'scrollModalToTop').mockImplementation(() => {})

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -8,7 +8,6 @@
       on-cancel="$ctrl.close()"
     ></sign-up-modal>
     <register-account-modal ng-switch-when="register-account"
-      first-name="$ctrl.firstName"
       modal-title="$ctrl.modalTitle"
       welcome-back="$ctrl.welcomeBack"
       hide-close-button="$ctrl.hideCloseButton"


### PR DESCRIPTION
Changes requested by Mike Nelson:

* Make the identity step the first step
* Remove progress bar from the identity and activate steps
* Remove "Welcome back" message
* Change title from "Activate your account" to "Access your account"
* Update some labels

This PR also includes a few cleanup changes to the user match modal template.