### PR TITLE
Remove Existing Payment Methods box when loading

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -159,6 +159,7 @@ export default angular
       brandedCheckoutItem: '<',
       onPaymentFormStateChange: '&',
       onPaymentChange: '&',
-      onLoad: '&'
+      onLoad: '&',
+      useV3: '<'
     }
   })

--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.tpl.html
@@ -1,4 +1,4 @@
-<div class="panel panel-default tab-toggle mb0">
+<div ng-if="$ctrl.useV3 !== 'true'" class="panel panel-default tab-toggle mb0">
   <div class="panel-title panel-heading">
     <span translate>Your Payment Methods</span>
     <i class="fas fa-lock u-floatRight mt--"></i>

--- a/src/app/checkout/step-2/step-2.component.js
+++ b/src/app/checkout/step-2/step-2.component.js
@@ -151,6 +151,7 @@ export default angular
       cartData: '<',
       brandedCheckoutItem: '<',
       changeStep: '&',
-      onStateChange: '&'
+      onStateChange: '&',
+      useV3: '<'
     }
   })

--- a/src/app/checkout/step-2/step-2.tpl.html
+++ b/src/app/checkout/step-2/step-2.tpl.html
@@ -7,7 +7,7 @@
 </div>
 <div class="loading-overlay-parent">
   <loading type="overlay" ng-if="$ctrl.loadingPaymentMethods || $ctrl.paymentFormState === 'loading' || $ctrl.paymentFormState === 'encrypting'"></loading>
-  <div ng-if="!$ctrl.existingPaymentMethods">
+  <div ng-if="!$ctrl.existingPaymentMethods || $ctrl.useV3==='true'">
     <payment-method-form
       payment-form-state="$ctrl.paymentFormState"
       payment-form-error="$ctrl.paymentFormError"
@@ -31,7 +31,8 @@
       default-payment-type="$ctrl.defaultPaymentType"
       hide-payment-type-options="$ctrl.hidePaymentTypeOptions"
       cart-data="$ctrl.cartData"
-      branded-checkout-item="$ctrl.brandedCheckoutItem">
+      branded-checkout-item="$ctrl.brandedCheckoutItem"
+      use-v3="$ctrl.useV3">
     </checkout-existing-payment-methods>
   </div>
 </div>


### PR DESCRIPTION
## Description
https://jira.cru.org/browse/EP-2518

- Hide Existing Payment Methods box for `useV3`
- Always show `payment-method-form` when using `useV3`

