### PR TITLE
[EP-2362] Retry signIn once to mitigate ephemeral fetch errors

### DIFF
--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -539,7 +539,7 @@ class SignUpModalController {
     // Render the widget again to show new step
     // Unfortunately, this removes the error messages, which is why we inject them after rendering
     this.oktaSignInWidget.remove()
-    this.oktaSignInWidget.renderEl(
+    return this.oktaSignInWidget.renderEl(
       { el: '#osw-container' },
       null,
       (error) => {
@@ -550,12 +550,17 @@ class SignUpModalController {
     )
   }
 
-  signIn () {
+  signIn (retrying = false) {
     return this.oktaSignInWidget.showSignInAndRedirect({
       el: '#osw-container'
     }).then(tokens => {
       this.oktaSignInWidget.authClient.handleLoginRedirect(tokens)
     }).catch(error => {
+      if (!retrying) {
+        // Retry once
+        return this.reRenderWidget().then(() => this.signIn(true))
+      }
+
       this.$log.error('Error showing Okta sign in widget.', error)
     })
   }

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -1222,11 +1222,12 @@ describe('signUpForm', function () {
       });
     });
 
-    it('should handle an error with $log', (done) => {
-      const error = new Error('Error signing in');
-      jest.spyOn($ctrl.$log, 'error').mockImplementation(() => {});
-      const showSignInAndRedirect = jest.fn().mockRejectedValue(error);
-      const handleLoginRedirect = jest.fn();
+    it('should handle an error with $log and retry once', (done) => {
+      const error = new Error('Error signing in')
+      jest.spyOn($ctrl.$log, 'error').mockImplementation(() => {})
+      jest.spyOn($ctrl, 'reRenderWidget').mockResolvedValue()
+      const showSignInAndRedirect = jest.fn().mockRejectedValue(error)
+      const handleLoginRedirect = jest.fn()
       $ctrl.oktaSignInWidget = {
         showSignInAndRedirect,
         authClient: {
@@ -1235,12 +1236,14 @@ describe('signUpForm', function () {
       }
 
       $ctrl.signIn().then(() => {
-      expect(handleLoginRedirect).not.toHaveBeenCalled()
-      expect($ctrl.$log.error).toHaveBeenCalledWith('Error showing Okta sign in widget.', error)
-      done()
-      });
-    });
-  });
+        expect(handleLoginRedirect).not.toHaveBeenCalled()
+        expect($ctrl.reRenderWidget).toHaveBeenCalledTimes(1)
+        expect($ctrl.$log.error).toHaveBeenCalledTimes(1)
+        expect($ctrl.$log.error).toHaveBeenCalledWith('Error showing Okta sign in widget.', error)
+        done()
+      })
+    })
+  })
 
   describe('loadDonorDetails()', () => {
     const signUpFormData = {


### PR DESCRIPTION
## Description

Sometimes `this.oktaSignInWidget.showSignInAndRedirect` throws because of a `fetch` error. We are current unsure of why the request sometimes fails. In the meantime, to mitigate this, we are automatically re-rendering the widget and retrying the sign in once. We only retry once to avoid getting stuck in an infinite loop.

## Testing

* Open the sign in modal
* Set network throttling to Offline in DevTools
* Click the create account button
* Verify that the requests to set up the sign up form happen exactly twice
