### PR TITLE
EP-2566 Add Card Bin

### DIFF
--- a/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
+++ b/src/app/checkout/step-2/existingPaymentMethods/existingPaymentMethods.component.js
@@ -113,12 +113,16 @@ class ExistingPaymentMethodsController {
 
   selectPayment () {
     if (this.selectedPaymentMethod.chosen) {
-      this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri) // Unset the CVV unless the user has provided a CVV for the selected payment method this order
+      // Unset the CVV and CardBin unless the user has provided a CVV for the selected payment method this order
+      this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri)
+      this.orderService.storeCardBin(null, this.selectedPaymentMethod.self.uri)
       this.onPaymentFormStateChange({ $event: { state: 'loading' } })
     } else {
       this.orderService.selectPaymentMethod(this.selectedPaymentMethod.selectAction)
         .subscribe(() => {
-          this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri) // Unset the CVV unless the user has provided a CVV for the selected payment method this order
+          // Unset the CVV and CardBin unless the user has provided a CVV for the selected payment method this order
+          this.orderService.storeCardBin(null, this.selectedPaymentMethod.self.uri)
+          this.orderService.storeCardSecurityCode(null, this.selectedPaymentMethod.self.uri)
           this.onPaymentFormStateChange({ $event: { state: 'loading' } })
         },
         (error) => {

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -149,7 +149,8 @@ class Step3Controller {
       submitRequest = componentInstance.orderService.submit()
     } else if (componentInstance.creditCardPaymentDetails) {
       const cvv = componentInstance.orderService.retrieveCardSecurityCode()
-      submitRequest = componentInstance.orderService.submit(cvv)
+      const cardBin = componentInstance.orderService.retrieveCardBin()
+      submitRequest = componentInstance.orderService.submit(cvv, cardBin)
     } else {
       submitRequest = Observable.throw({ data: 'Current payment type is unknown' })
     }
@@ -158,6 +159,7 @@ class Step3Controller {
       componentInstance.submittingOrder = false
       componentInstance.onSubmittingOrder({ value: false })
       componentInstance.orderService.clearCardSecurityCodes()
+      componentInstance.orderService.clearCardBins()
       componentInstance.orderService.clearCoverFees()
       componentInstance.onSubmitted()
       componentInstance.$scope.$emit(cartUpdatedEvent)

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -158,6 +158,7 @@ class CreditCardController {
                 'expiry-month': this.creditCardPayment.expiryMonth,
                 'expiry-year': this.creditCardPayment.expiryYear,
                 'last-four-digits': tokenObj.maskedCardNumber,
+                'card-bin': this.creditCardPayment.cardNumber?.replace(/\s+/g, '').substring(0, 6) || null,
                 transactionId: tokenObj.transactionID,
                 cvv: this.creditCardPayment.securityCode
               }

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -154,6 +154,7 @@ describe('credit card form', () => {
           'expiry-month': 12,
           'expiry-year': 2019,
           'last-four-digits': '1111',
+          'card-bin': '411111',
           transactionId: '<transaction id>',
           cvv: '123'
         }
@@ -161,6 +162,28 @@ describe('credit card form', () => {
 
       expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ $event: { state: 'loading', payload: expectedData } })
       expect(self.outerScope.onPaymentFormStateChange).toHaveBeenCalledWith({ state: 'loading', payload: expectedData })
+    })
+
+    it('should correctly extract and store the card bin (first 6 digits) when card number is provided', () => {
+      self.controller.creditCardPayment = {
+        cardNumber: '4111 1111 1111 1111',
+      }
+      self.formController.$valid = true
+      self.controller.savePayment()
+
+      expect(self.controller.onPaymentFormStateChange).toHaveBeenCalledWith({ 
+        $event: { 
+          state: 'loading', payload: {
+            creditCard: {
+              'card-number': 'YfxWvtXJxjET5100',
+              'card-type': 'Visa',
+              'last-four-digits': '1111',
+              'card-bin': '411111',
+              transactionId: '<transaction id>',
+            }
+          } 
+        } 
+      })
     })
 
     it('should not send a billing address if the Same as Mailing Address box is checked as the api will use the mailing address there', () => {
@@ -188,6 +211,7 @@ describe('credit card form', () => {
           'expiry-month': 12,
           'expiry-year': 2019,
           'last-four-digits': '1111',
+          'card-bin': '411111',
           transactionId: '<transaction id>',
           cvv: '123'
         }
@@ -244,6 +268,7 @@ describe('credit card form', () => {
           'expiry-month': 12,
           'expiry-year': 2019,
           'last-four-digits': '4567',
+          'card-bin': null,
           transactionId: undefined,
           cvv: '123'
         }

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -123,6 +123,7 @@ class Order {
 
   addCreditCardPayment (paymentInfo, saveOnProfile) {
     const cvv = paymentInfo.cvv
+    const cardBin = paymentInfo['card-bin']
     paymentInfo = omit(paymentInfo, 'cvv')
 
     const dataToSend = {}
@@ -149,6 +150,7 @@ class Order {
           followLocation: true
         }).do(creditCard => {
           this.storeCardSecurityCode(cvv, creditCard.self.uri)
+          this.storeCardBin(cardBin, creditCard.self.uri)
         })
       })
   }
@@ -216,6 +218,7 @@ class Order {
     })
       .do(() => {
         this.storeCardSecurityCode(cvv, paymentMethod.self.uri)
+        this.storeCardBin(null, paymentMethod.self.uri)
       })
   }
 
@@ -301,10 +304,10 @@ class Order {
       .map(entry => entry?.messageIds)
   }
 
-  submit (cvv) {
+  submit (cvv, cardBin) {
     return this.getPurchaseForm()
       .mergeMap((data) => {
-        const postData = cvv ? { 'security-code': cvv } : {}
+        const postData = cvv && cardBin ? { 'security-code': cvv, 'card-bin': cardBin } : {}
         postData['cover-cc-fees'] = !!this.retrieveCoverFeeDecision()
         postData['radio-call-letters'] = this.retrieveRadioStationCallLetters()
         postData['tsys-device'] = this.tsysService.getDevice()
@@ -322,6 +325,37 @@ class Order {
         this.sessionStorage.removeItem('recaptchaToken')
         this.sessionStorage.removeItem('recaptchaAction')
       })
+  }
+
+  retrieveCardBin () {
+    return this.sessionStorage.getItem('cardBin')
+  }
+
+  clearCardBins () {
+    this.sessionStorage.removeItem('cardBin')
+    this.sessionStorage.removeItem('storedBins')
+  }
+
+  retrieveCardBins () {
+    const storedBins = this.sessionStorage.getItem('storedBins')
+    return storedBins && angular.fromJson(storedBins) || {} /* eslint-disable-line no-mixed-operators */
+  }
+
+  storeCardBin (cardBin, uri) {
+    const storedBins = this.retrieveCardBins()
+    if (!cardBin) {
+      cardBin = storedBins[uri] // Try looking up previously stored cardBin by payment method uri
+    } else {
+      // Save new cardBin in list of stored cardBins
+      storedBins[uri] = cardBin
+      this.sessionStorage.setItem('storedBins', angular.toJson(storedBins))
+    }
+
+    if (cardBin) {
+      this.sessionStorage.setItem('cardBin', cardBin)
+    } else {
+      this.sessionStorage.removeItem('cardBin')
+    }
   }
 
   storeCardSecurityCode (cvv, uri) {

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -867,13 +867,13 @@ describe('order service', () => {
       self.$httpBackend.flush()
     })
 
-    it('should send a request to finalize the purchase and with a CVV', (done) => {
+    it('should send a request to finalize the purchase with a CVV and cardBin', (done) => {
       self.$httpBackend.expectPOST(
         'https://give-stage2.cru.org/cortex/enhancedpurchases/orders/crugive/me3gkzrrmm4dillegq4tiljugmztillbmq4weljqga3wezrwmq3tozjwmu=?FollowLocation=true',
-        { 'security-code': '123', 'cover-cc-fees': false, 'radio-call-letters': null, 'tsys-device': '', 'recaptcha-token': null, 'recaptcha-action': null }
+        { 'security-code': '123', 'card-bin': '411111', 'cover-cc-fees': false, 'radio-call-letters': null, 'tsys-device': '', 'recaptcha-token': null, 'recaptcha-action': null }
       ).respond(200, purchaseResponse)
 
-      self.orderService.submit('123')
+      self.orderService.submit('123', '411111')
         .subscribe((data) => {
           expect(data).toEqual(purchaseResponse)
           done()


### PR DESCRIPTION
Include the first 6 digits of the credit card in the Google Recaptcha assessment. This is PCI-compliant and provides Google with more data to improve risk assessments.
https://jira.cru.org/browse/EP-2566

- When saving a Credit Card, pass the first 6 digits to the `addCreditCardPayment` method of `order.service`
- Add functions to store, retrieve and clear the card bin
- Include the card bin when submitting the gift