### PR TITLE
Updating Okta schema - Remove address and add primary phone.

### DIFF
--- a/src/common/components/signUpModal/signUpFormCustomFields.js
+++ b/src/common/components/signUpModal/signUpFormCustomFields.js
@@ -126,16 +126,5 @@ export const customFields = {
     showWhen: {
       'userProfile.countryCode': 'US'
     }
-  },
-  primaryPhone: {
-    name: 'userProfile.primaryPhone',
-    type: 'text',
-    label: 'Primary phone',
-    required: false,
-    maxLength: 100,
-    'label-top': true,
-    multirowError: true,
-    'data-se': 'o-form-fieldset-userProfile.primaryPhone',
-    sublabel: 'Optional'
   }
 }

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -147,7 +147,7 @@ class SignUpModalController {
       2: this.getStep2Fields(schema),
       // Step 3: Password (We don't save the password for security reasons.
       // Which is why it's the last step)
-      3: [schema[9]]
+      3: [schema[4]]
     }
   }
 
@@ -183,7 +183,7 @@ class SignUpModalController {
     ]
   }
 
-  getStep2Fields () {
+  getStep2Fields (schema) {
     // Retain the values entered by the user when navigating between steps.
     // Pre-populate the form fields with existing user details.
     return [
@@ -230,7 +230,7 @@ class SignUpModalController {
         value: this.$scope.zipCode || this.donorDetails?.mailingAddress?.postalCode || ''
       },
       {
-        ...customFields.primaryPhone,
+        ...schema[3],
         value: this.$scope.primaryPhone || this.donorDetails?.['phone-number'] || ''
       }
     ]


### PR DESCRIPTION
## Description
Updating Okta sign-up fields, as the schema from Okta has been updated. Jason and I removed the address fields.

### Changes
Since the address fields are removed from Okta's schema, it changed the order of the other fields. 
As Okta manages the primary phone field, we no longer need this as a custom field.