### PR TITLE
[EP-2362] Improve styles and back button

### DIFF
--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -176,7 +176,7 @@ sign-up-modal {
     }
 
     // Allow the account type dropdown to have rounded corners if the organisation field is hidden
-    &:has(+ .o-form-fieldset[style="display: none;"]) .chzn-container a {
+    &:has([data-se="o-form-input-accountType"]):has(+ .o-form-fieldset[style="display: none;"] [data-se="o-form-input-organizationName"]) .chzn-container a {
       border-bottom-left-radius: 6px;
       border-bottom-right-radius: 6px;
     }

--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -125,7 +125,7 @@ sign-up-modal {
     }
 
     .chzn-container-single .chzn-drop {
-      border-radius: 0 0 6px 6px;
+      border-radius: 0;
     }
   }
 
@@ -176,9 +176,11 @@ sign-up-modal {
     }
 
     // Allow the account type dropdown to have rounded corners if the organisation field is hidden
-    &:has([data-se="o-form-input-accountType"]):has(+ .o-form-fieldset[style="display: none;"] [data-se="o-form-input-organizationName"]) .chzn-container a {
-      border-bottom-left-radius: 6px;
-      border-bottom-right-radius: 6px;
+    &:has([data-se="o-form-input-accountType"]):has(+ .o-form-fieldset[style="display: none;"] [data-se="o-form-input-organizationName"]) .chzn-container {
+      .chzn-drop, a {
+        border-bottom-left-radius: 6px;
+        border-bottom-right-radius: 6px;
+      }
     }
   }
 

--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -195,7 +195,6 @@ sign-up-modal {
       -webkit-appearance: none;
       appearance: none;
       border: 1px solid transparent;
-      height: auto;
       padding-bottom: 12px;
       padding-top: 20px;
 
@@ -203,6 +202,10 @@ sign-up-modal {
         border-color: $colorCru-gold;
         box-shadow: none;
       }
+    }
+
+    input[type=password] {
+      height: auto;
     }
   }
 

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -499,7 +499,7 @@ class SignUpModalController {
     const buttonBar = document.querySelector('.o-form-button-bar')
     // Ensure the button is only added once
     if (buttonBar && !buttonBar.querySelector(`#${backButtonId}`)) {
-      const backButton = angular.element(`<button id="${backButtonId}" class="btn btn-secondary">${backButtonText}</button>`)
+      const backButton = angular.element(`<button id="${backButtonId}" class="btn btn-secondary" type="button">${backButtonText}</button>`)
       // Add click behavior to go back a step
       backButton.on('click', (e) => {
         e.preventDefault()


### PR DESCRIPTION
## Description

* The first commit changes the selector to look for fields by their name and only applies the border radius changes to the account type field
* The second commit fixes the height of the zip code focus ring
* The third commit fixes the state dropdown having a bottom border radius instead of being a rectangle
* The fourth commit makes the enter advance to the next step instead of the previous step
  * `<button>` elements are unintuitively `type="submit"` by default, so the back button needed `type="button"`