### PR TITLE
Fixing the sign up flow

### DIFF
--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -169,6 +169,7 @@ sign-up-modal {
 
       // We don't include password as it's the only field on it's step and has the password requirements below it.
       input[type=text]:not(.chzn-search input),
+      .o-form-input-error,
       .chzn-container a {
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;
@@ -181,6 +182,10 @@ sign-up-modal {
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;
       }
+    }
+
+    &[data-se="o-form-fieldset-credentials.passcode"] {
+      margin-bottom: 0;
     }
   }
 

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -391,24 +391,6 @@ class SignUpModalController {
   }
 
   postSubmit (response, onSuccess) {
-    const donorDetails = {
-      name: {
-        'given-name': this.$scope.firstName,
-        'family-name': this.$scope.lastName
-      },
-      'donor-type': this.$scope.accountType,
-      'organization-name': this.$scope.organizationName,
-      email: this.$scope.email,
-      phone: this.$scope.primaryPhone,
-      mailingAddress: {
-        streetAddress: this.$scope.streetAddress,
-        locality: this.$scope.city,
-        region: this.$scope.state,
-        postalCode: this.$scope.zipCode,
-        country: this.$scope.countryCode
-      }
-    }
-    this.$scope.$apply(() => this.onSignUp({ donorDetails }))
     onSuccess(response)
   }
 

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -412,25 +412,39 @@ class SignUpModalController {
       return
     }
 
+    // All steps
     this.updateSignUpButtonText()
     this.resetCurrentStepOnRegistrationComplete(context)
     this.redirectToSignInModalIfNeeded(context)
     this.injectErrorMessages()
     this.injectBackButton()
-    this.initializeFloatingLabels()
 
+    // Step 1: Identity
     if (this.loadingCountriesError && this.currentStep === 1) {
       this.injectCountryLoadError()
     }
+    // Step 2: Address
     if (this.loadingRegionsError && this.currentStep === 2) {
       this.injectRegionLoadError()
     }
+    // Step 3: Security
+    this.showVerificationCodeField()
+
+    // This needs to be last to ensure even the verification code field is styled correctly
+    this.initializeFloatingLabels()
   }
 
   ready () {
     this.$scope.$apply(() => {
       this.isLoading = false
     })
+  }
+
+  showVerificationCodeField () {
+    // The verification code field is only shown when the button link "Enter a verification code instead" is clicked.
+    // This makes the process of creating an account more streamlined as we remove that click.
+    const verificationCodeButtonLink = document.querySelector('.button-link.enter-auth-code-instead-link')
+    verificationCodeButtonLink?.click();
   }
 
   updateSignUpButtonText () {

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -984,6 +984,36 @@ describe('signUpForm', function () {
     });
   });
 
+  describe('showVerificationCodeField()', () => {
+    const handleClick = jest.fn();
+    window.handleClick = handleClick;
+    beforeEach(() => {
+      handleClick.mockClear();
+    })
+
+    it('should call handleClick when button link is rendered', () => {
+      document.body.innerHTML = `
+        <div>
+          <button class="button-link enter-auth-code-instead-link" onclick="handleClick()">
+            Enter authentication code instead
+          </button>
+        </div>
+      `;
+
+      $ctrl.showVerificationCodeField()
+      expect(handleClick).toHaveBeenCalled();
+    });
+
+    it("shouldn't call handleClick if button link is not rendered", () => {
+      document.body.innerHTML = `
+        <div>Something else</div>
+      `;
+
+      $ctrl.showVerificationCodeField()
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Injecting error messages', () => {
     const retryFieldSelector = '.cru-retry-button';
     const inputErrorFieldSelector = '.okta-form-input-error';

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -863,45 +863,11 @@ describe('signUpForm', function () {
   });
 
   describe('postSubmit()', () => {
-    it('should call onSignUp with details of donor', () => {
-      jest.spyOn($ctrl.$scope, '$apply').mockImplementation((callback) => callback());
-      jest.spyOn($ctrl, 'onSignUp').mockImplementation(() => {});
-
-      $ctrl.$scope.firstName = user.firstName
-      $ctrl.$scope.lastName = user.lastName
-      $ctrl.$scope.email = user.email
-      $ctrl.$scope.accountType = user.accountType
-      $ctrl.$scope.streetAddress = user.streetAddress
-      $ctrl.$scope.city = user.city
-      $ctrl.$scope.state = user.state
-      $ctrl.$scope.zipCode = user.zipCode
-      $ctrl.$scope.countryCode = user.countryCode
-      $ctrl.$scope.primaryPhone = user.primaryPhone
-      $ctrl.$scope.organizationName = user.organizationName
-
+    it('should call onSuccess', () => {
       const response = 'response'
       const onSuccess = jest.fn()
       $ctrl.postSubmit(response, onSuccess)
 
-      expect($ctrl.onSignUp).toHaveBeenCalledWith({
-        donorDetails: {
-          name: {
-            'given-name': user.firstName,
-            'family-name': user.lastName,
-          },
-          'donor-type': user.accountType,
-          'organization-name': user.organizationName,
-          email: user.email,
-          phone: user.primaryPhone,
-          mailingAddress: {
-            streetAddress: user.streetAddress,
-            locality: user.city,
-            region: user.state,
-            postalCode: user.zipCode,
-            country: user.countryCode,
-          }
-        }
-      });
       expect(onSuccess).toHaveBeenCalledWith(response)
     });
   });

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -476,7 +476,7 @@ describe('signUpForm', function () {
       $ctrl.loadCountries({initial: false}).subscribe({
         error: () => {
           expect($ctrl.loadingCountriesError).toBe(true);
-          expect($ctrl.$log.error).toHaveBeenCalledWith('Error loading countries.', error);
+          expect($ctrl.$log.error).toHaveBeenCalledWith('Okta Sign up: Error loading countries.', error);
           done();
         }
       });
@@ -608,7 +608,7 @@ describe('signUpForm', function () {
       $ctrl.refreshRegions('country').subscribe({
         error: () => {
           expect($ctrl.loadingRegionsError).toBe(true);
-          expect($ctrl.$log.error).toHaveBeenCalledWith('Error loading regions.', error);
+          expect($ctrl.$log.error).toHaveBeenCalledWith('Okta Sign up: Error loading regions.', error);
           done();
         }
       });
@@ -978,7 +978,7 @@ describe('signUpForm', function () {
       renderEl.mockImplementation((_, __, callback) => callback(error));
       $ctrl.reRenderWidget()
       setTimeout(() => {
-        expect($ctrl.$log.error).toHaveBeenCalledWith('Error rendering Okta sign up widget.', error);
+        expect($ctrl.$log.error).toHaveBeenCalledWith('Okta Sign up: Error rendering Okta sign up widget.', error);
         done();
       });
     });
@@ -1234,7 +1234,7 @@ describe('signUpForm', function () {
 
       $ctrl.signIn().then(() => {
         expect(handleLoginRedirect).not.toHaveBeenCalled()
-        expect($ctrl.$log.error).toHaveBeenCalledWith('Error showing Okta sign in widget.', error)
+        expect($ctrl.$log.error).toHaveBeenCalledWith('Okta Sign up: Error showing Okta sign in widget.', error)
         done()
       }, done)
     })
@@ -1295,7 +1295,7 @@ describe('signUpForm', function () {
       $ctrl.loadingDonorDetails = true
       $ctrl.loadDonorDetails().subscribe({
         error: () => {
-          expect($ctrl.$log.error).toHaveBeenCalledWith('Error loading donorDetails.', error)
+          expect($ctrl.$log.error).toHaveBeenCalledWith('Okta Sign up: Error loading donorDetails.', error)
         }
       })
 
@@ -1305,6 +1305,67 @@ describe('signUpForm', function () {
         expect($ctrl.loadingDonorDetails).toEqual(false)
         done()
       })
+    })
+  });
+
+  describe('saveDonorDetails()', () => {
+    const emailFormUri = '/emails/crugive'
+    const signUpDonorDetails = {
+      name: {
+        'given-name': user.firstName,
+        'family-name': user.lastName
+      },
+      'donor-type': user.accountType,
+      email: user.email,
+      'phone-number': user.primaryPhone,
+      mailingAddress: {
+        streetAddress: user.streetAddress,
+        locality: user.city,
+        region: user.state,
+        postalCode: '12345-678',
+        country: user.countryCode
+      }
+    }
+    beforeEach(() => {
+      $ctrl.$scope.firstName = user.firstName
+      $ctrl.$scope.lastName = user.lastName
+      $ctrl.$scope.email = user.email
+      $ctrl.$scope.accountType = user.accountType
+      $ctrl.$scope.streetAddress = user.streetAddress
+      $ctrl.$scope.city = user.city
+      $ctrl.$scope.state = user.state
+      $ctrl.$scope.zipCode = user.zipCode
+      $ctrl.$scope.countryCode = user.countryCode
+      $ctrl.$scope.primaryPhone = user.primaryPhone
+
+      jest.spyOn($ctrl.orderService, 'getDonorDetails').mockReturnValue(Observable.of({
+        'registration-state': 'NEW',
+        name: {
+          'given-name': 'Existing',
+          'family-name': 'Existing'
+        },
+        'donor-type': '',
+        email: 'existing.email@cru.org',
+        'phone-number': '',
+        mailingAddress: {
+          streetAddress: '',
+          locality: '',
+          region: '',
+          postalCode: '',
+          country: 'CANADA'
+        },
+        emailFormUri
+      }))
+      jest.spyOn($ctrl.orderService, 'updateDonorDetails').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl.orderService, 'addEmail').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'logIntoOkta').mockImplementation(() => Observable.of({}))
+    })
+
+    it("should update the user's data, updating email separately", () => {
+      $ctrl.saveDonorDetails()
+
+      expect($ctrl.orderService.updateDonorDetails).toHaveBeenCalledWith(expect.objectContaining(signUpDonorDetails))
+      expect($ctrl.orderService.addEmail).toHaveBeenCalledWith(signUpDonorDetails.email, emailFormUri)
     })
   });
 })


### PR DESCRIPTION
## Description 
In this PR, I update the Sign up form to allow the user to fully sign up to Okta, get redirected to Okta for sign in and update the user's details on the Give DB.

I've made some pretty big changes in this PR, but there is still quite a bit of work to be done around cleaning up the contact info logic and ensuring it shows when expected.
I haven't done it in this PR as I need to focus on updating the API next so we can create an endpoint that connects the Okta account to the Give account.


## Changes
**I first removed where we switched to the contact info modal.**
This should only take the user to the contact info modal if there is an error saving the user's data on the Give DB.
It must happen once the user returns from Okta after a successful sign-in. _I will need to configure this in a later PR._

**Enter the verification email code without an extra click**
When you get to the verification step, it says to click on the email, which if you do, it shows a code. 
I've added some code which clicks the button "Enter verify code instead", so it renders the verify code input field by default to avoid an unnecessary click from the user.

**Sign user into Okta by redirect**
The Okta sign-in widget allows users to sign in directly without redirecting them to the Okta website. While this enhances the user experience, we need to ensure users have the opportunity to save their credentials within the Okta sign-in form. This will allow their browser to remember their email and password for future visits.

Since we use the sign-in widget, the browser doesn't have a mechanism for saving users' credentials directly within the Okta context.


