### PR TITLE
[no-Jira] Set up Stylelint extension to format on save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist
 .DS_STORE
 coverage
 *.iml
-.vscode
 
 *.log
 *.back.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.stylelint": "explicit"
+  },
+  "stylelint.validate": [
+    "css",
+    "scss"
+  ]
+}


### PR DESCRIPTION
Add VS Code configuration to make the Stylelint extension format SCSS files on save.