### PR TITLE
2362 okta account creation flow

### DIFF
--- a/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
@@ -4,15 +4,33 @@ import module, { unknownErrorMessage } from './oktaAuthCallback.component'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/observable/throw'
+import { user } from '../../common/components/signUpModal/signUpModal.component.mock'
+
+const mockDonorDetails = {
+  name: {
+    'given-name': user.firstName,
+    'family-name': user.lastName
+  },
+  'donor-type': user.accountType,
+  email: user.email,
+  mailingAddress: {
+    streetAddress: user.streetAddress,
+    locality: user.city,
+    region: user.state,
+    postalCode: user.zipCode,
+    country: user.countryCode
+  },
+}
 
 describe('oktaAuthCallback', function () {
   beforeEach(angular.mock.module(module.name))
-  let $ctrl, $rootScope, $log, orderService
+  let $ctrl, $rootScope, $log, orderService, verificationService
 
-  beforeEach(inject(function (_$componentController_, _$rootScope_, _$log_, _orderService_) {
+  beforeEach(inject(function (_$componentController_, _$rootScope_, _$log_, _orderService_, _verificationService_) {
     $rootScope = _$rootScope_
     $log = _$log_
     orderService = _orderService_
+    verificationService = _verificationService_
     $ctrl = _$componentController_(module.name,
       { 
         $log,
@@ -105,11 +123,240 @@ describe('oktaAuthCallback', function () {
     })
   })
 
+  describe('openUserMatchModalThenRedirect', () => {
+    let deferred, $rootScope
+    beforeEach(inject((_$q_, _$rootScope_) => {
+      deferred = _$q_.defer()
+      $rootScope = _$rootScope_
+      jest.spyOn($ctrl.sessionModalService, 'userMatch').mockReturnValue(deferred.promise)
+      jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
+    }));
+
+    it('should open user matching modal and upon completing redirect to the previous page', () => {
+      $ctrl.openUserMatchModalThenRedirect()
+
+      expect($ctrl.sessionModalService.userMatch).toHaveBeenCalled()
+
+      deferred.resolve()
+      $rootScope.$digest()
+      expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
+    });
+  });
+
+  describe('openContactInfoModalThenRedirect', () => {
+    let deferred, $rootScope
+    beforeEach(inject((_$q_, _$rootScope_) => {
+      deferred = _$q_.defer()
+      $rootScope = _$rootScope_
+      jest.spyOn($ctrl.sessionModalService, 'nonDismissibleRegisterAccount').mockReturnValue(deferred.promise)
+      jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
+    }));
+
+    it('should open contact info modal and upon completing redirect to the previous page', () => {
+      $ctrl.openContactInfoModalThenRedirect()
+
+      expect($ctrl.sessionModalService.nonDismissibleRegisterAccount).toHaveBeenCalled()
+
+      deferred.resolve()
+      $rootScope.$digest()
+      expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
+    });
+  });
+
+  describe('postDonorMatches', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl, 'openUserMatchModalThenRedirect').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'openContactInfoModalThenRedirect').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
+    });
+
+    it('should run post donor matches and on success open the user matching modal', () => {
+      jest.spyOn(verificationService, 'postDonorMatches').mockImplementation(() => Observable.of({}))
+      $ctrl.postDonorMatches()
+
+      expect(verificationService.postDonorMatches).toHaveBeenCalled()
+      expect($ctrl.openUserMatchModalThenRedirect).toHaveBeenCalled()
+      expect($ctrl.openContactInfoModalThenRedirect).not.toHaveBeenCalled()
+    });
+
+    it('should run post donor matches and on failure open the contact info modal', () => {
+      jest.spyOn(verificationService, 'postDonorMatches').mockReturnValue(Observable.throw({}))
+      $ctrl.postDonorMatches()
+
+      expect(verificationService.postDonorMatches).toHaveBeenCalled()
+      expect($ctrl.openUserMatchModalThenRedirect).not.toHaveBeenCalled()
+      expect($ctrl.openContactInfoModalThenRedirect).toHaveBeenCalled()
+    });
+  });
+
+  describe('areRequiredFieldsFilled', () => {
+    it('should validate given name field', () => {
+      const testCases = [
+        { givenName: '', expected: false },
+        { givenName: 'Test', expected: true }
+      ];
+
+      testCases.forEach(({ givenName, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          name: {
+            ...mockDonorDetails.name,
+            'given-name': givenName,
+          }
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate family name field', () => {
+      const testCases = [
+        { familyName: '', expected: false },
+        { familyName: 'Test', expected: true }
+      ];
+
+      testCases.forEach(({ familyName, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          name: {
+            ...mockDonorDetails.name,
+            'family-name': familyName,
+          }
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate email field', () => {
+      const testCases = [
+        { email: '', expected: false },
+        { email: user.email, expected: true }
+      ];
+
+      testCases.forEach(({ email, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          email
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate donor-type field', () => {
+      const testCases = [
+        { donorType: '', expected: false },
+        { donorType: user.accountType, expected: true }
+      ];
+
+      testCases.forEach(({ donorType, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          'donor-type': donorType
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate country field', () => {
+      const testCases = [
+        { country: '', expected: false },
+        { country: 'US', expected: true }
+      ];
+
+      testCases.forEach(({ country, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          mailingAddress: {
+            ...mockDonorDetails.mailingAddress,
+            country,
+          }
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate street address field', () => {
+      const testCases = [
+        { streetAddress: '', expected: false },
+        { streetAddress: '123 Test lane', expected: true }
+      ];
+
+      testCases.forEach(({ streetAddress, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          mailingAddress: {
+            ...mockDonorDetails.mailingAddress,
+            streetAddress,
+          }
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it("should validate organization-name field when organization account", () => {
+      const testCases = [
+        { organizationName: '', expected: false },
+        { organizationName: '12345', expected: true }
+      ];
+
+      testCases.forEach(({ organizationName, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          'donor-type': 'Organization',
+          'organization-name': organizationName
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate US address', () => {
+      const testCases = [
+        { locality: '', region: '', postalCode: '', expected: false },
+        { locality: 'city', region: '', postalCode: '', expected: false },
+        { locality: 'city', region: 'GA', postalCode: '', expected: false },
+        { locality: 'city', region: 'GA', postalCode: '12345', expected: true }
+      ];
+
+      testCases.forEach(({ locality, region, postalCode, expected }) => {
+        const isValid = $ctrl.areRequiredFieldsFilled({
+          ...mockDonorDetails,
+          mailingAddress: {
+            ...mockDonorDetails.mailingAddress,
+            country: 'US',
+            locality,
+            region,
+            postalCode
+          }
+        });
+        expect(isValid).toBe(expected);
+      });
+    });
+
+    it('should validate International address', () => {
+      const isValid = $ctrl.areRequiredFieldsFilled({
+        ...mockDonorDetails,
+        mailingAddress: {
+          ...mockDonorDetails.mailingAddress,
+          country: 'UK',
+          locality: '',
+          region: '',
+          postalCode: ''
+        }
+      });
+      expect(isValid).toBe(true);
+    });
+  });
+
+
+  
+
   describe('onSignInSuccess', () => {
     let deferred, $rootScope
     beforeEach(inject((_$q_, _$rootScope_) => {
       deferred = _$q_.defer()
       $rootScope = _$rootScope_
+      jest.spyOn($ctrl, 'openUserMatchModalThenRedirect').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'openContactInfoModalThenRedirect').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'postDonorMatches').mockImplementation(() => Observable.of({}))
       jest.spyOn($ctrl.sessionModalService, 'nonDismissibleRegisterAccount').mockReturnValue(deferred.promise)
       jest.spyOn($ctrl.sessionModalService, 'userMatch').mockReturnValue(deferred.promise)
       jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
@@ -133,40 +380,85 @@ describe('oktaAuthCallback', function () {
       expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
     })
 
-    it('opens the register account modal when the user is NEW', () => {
-      jest.spyOn($ctrl, 'onSignInFailure')
-      jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({ 'registration-state': 'NEW' }))
-      $ctrl.onSignInSuccess('data')
-      expect($ctrl.sessionModalService.nonDismissibleRegisterAccount).toHaveBeenCalled()
-      expect($ctrl.sessionModalService.userMatch).not.toHaveBeenCalled()
+    describe('Registration state is NEW', () => {
+      it('opens the contact info modal if Cortex sign up fields are missing', () => {
+        jest.spyOn($ctrl, 'onSignInFailure')
+        jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({
+          ...mockDonorDetails,
+          'registration-state': 'NEW',
+          mailingAddress: {
+            ...mockDonorDetails.mailingAddress,
+            streetAddress: undefined
+          }
+        }))
+        $ctrl.onSignInSuccess('data')
 
-      deferred.resolve()
-      $rootScope.$digest()
-      expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
+        expect($ctrl.openContactInfoModalThenRedirect).toHaveBeenCalled()
+        expect($ctrl.openUserMatchModalThenRedirect).not.toHaveBeenCalled()
+        expect($ctrl.postDonorMatches).not.toHaveBeenCalled()
+
+        deferred.resolve()
+        $rootScope.$digest()
+      })
+
+      it('runs post donor matching when all required Cortex fields are filled', () => {
+        jest.spyOn($ctrl, 'onSignInFailure')
+        jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({
+          ...mockDonorDetails,
+          'registration-state': 'NEW'
+        }))
+        $ctrl.onSignInSuccess('data')
+        expect($ctrl.postDonorMatches).toHaveBeenCalled()
+        expect($ctrl.openContactInfoModalThenRedirect).not.toHaveBeenCalled()
+        expect($ctrl.openUserMatchModalThenRedirect).not.toHaveBeenCalled()
+
+        deferred.resolve()
+        $rootScope.$digest()
+      })
+
+      it('opens the user matching modal with an international address', () => {
+        jest.spyOn($ctrl, 'onSignInFailure')
+        jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({
+          ...mockDonorDetails,
+          'registration-state': 'NEW',
+          mailingAddress: {
+            ...mockDonorDetails.mailingAddress,
+            country: 'UK',
+            locality: undefined,
+            region: undefined,
+            postalCode: undefined,
+          }
+        }))
+        $ctrl.onSignInSuccess('data')
+
+        expect($ctrl.postDonorMatches).toHaveBeenCalled()
+        expect($ctrl.openContactInfoModalThenRedirect).not.toHaveBeenCalled()
+        expect($ctrl.openUserMatchModalThenRedirect).not.toHaveBeenCalled()
+
+        deferred.resolve()
+        $rootScope.$digest()
+      })
     })
 
     it('opens the user match modal when the user is MATCHED', () => {
       jest.spyOn($ctrl, 'onSignInFailure')
       jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({ 'registration-state': 'MATCHED' }))
       $ctrl.onSignInSuccess('data')
-      expect($ctrl.sessionModalService.nonDismissibleRegisterAccount).not.toHaveBeenCalled()
-      expect($ctrl.sessionModalService.userMatch).toHaveBeenCalled()
+      expect($ctrl.openUserMatchModalThenRedirect).toHaveBeenCalled()
 
-        deferred.resolve()
+      deferred.resolve()
       $rootScope.$digest()
-      expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
     })
 
     it('does not open a modal and redirects user to prior page when the user is REGISTERED', () => {
       jest.spyOn($ctrl, 'onSignInFailure')
       jest.spyOn(orderService, 'getDonorDetails').mockImplementation(() => Observable.of({ 'registration-state': 'REGISTERED' }))
       $ctrl.onSignInSuccess('data')
-      expect($ctrl.sessionModalService.nonDismissibleRegisterAccount).not.toHaveBeenCalled()
-      expect($ctrl.sessionModalService.userMatch).not.toHaveBeenCalled()
-
-      deferred.resolve()
-      $rootScope.$digest()
       expect($ctrl.redirectToLocationPriorToLogin).toHaveBeenCalled()
+
+      expect($ctrl.postDonorMatches).not.toHaveBeenCalled()
+      expect($ctrl.openContactInfoModalThenRedirect).not.toHaveBeenCalled()
+      expect($ctrl.openUserMatchModalThenRedirect).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -13,14 +13,6 @@ import userMatchModal from 'common/components/userMatchModal/userMatchModal.comp
 import contactInfoModal from 'common/components/contactInfoModal/contactInfoModal.component'
 import failedVerificationModal from 'common/components/failedVerificationModal/failedVerificationModal.component'
 
-import { Observable } from 'rxjs/Observable'
-import 'rxjs/add/observable/forkJoin'
-import 'rxjs/add/observable/of'
-import 'rxjs/add/operator/do'
-import 'rxjs/add/operator/map'
-import 'rxjs/add/operator/switchMap'
-import merge from 'lodash/merge'
-
 const componentName = 'registerAccountModal'
 
 class RegisterAccountModalController {
@@ -133,7 +125,7 @@ class RegisterAccountModalController {
     this.onSuccess()
   }
 
-  checkDonorDetails (signUpDonorDetails) {
+  checkDonorDetails () {
     // Show loading state
     this.stateChanged('loading-donor')
 
@@ -141,27 +133,7 @@ class RegisterAccountModalController {
     if (angular.isDefined(this.getDonorDetailsSubscription)) {
       this.getDonorDetailsSubscription.unsubscribe()
     }
-    this.getDonorDetailsSubscription = this.orderService.getDonorDetails().switchMap((donorDetails) => {
-      if (signUpDonorDetails && donorDetails['registration-state'] === 'NEW') {
-        // Save the contact info from signup
-        merge(donorDetails, signUpDonorDetails)
-
-        // Send each of the requests and pass donorDetails to the next step after the requests complete
-        return Observable.forkJoin([
-          this.orderService.updateDonorDetails(donorDetails),
-          this.orderService.addEmail(donorDetails.email, donorDetails.emailFormUri)
-        ]).map(() => donorDetails).do({
-          error: () => {
-            // If there was an error, save the donor details from sign up so that they will be added
-            // to the contact info form. The error handler below will change the step to contact-info.
-            this.signUpDonorDetails = signUpDonorDetails
-          }
-        })
-      }
-
-      // Pass donorDetails to the next step
-      return Observable.of(donorDetails)
-    }).subscribe({
+    this.getDonorDetailsSubscription = this.orderService.getDonorDetails().subscribe({
       next: (donorDetails) => {
         // Workflow Complete if 'registration-state' is COMPLETED
         if (donorDetails['registration-state'] === 'COMPLETED') {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -197,10 +197,6 @@ class RegisterAccountModalController {
   redirectToOktaForLogin () {
     this.sessionService.signIn(this.lastPurchaseId).subscribe(() => {
       const $injector = angular.injector()
-      if (!$injector.has('sessionService')) {
-        $injector.loadNewModules(['sessionService'])
-      }
-
       this.$document[0].body.dispatchEvent(
         new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } })
       )

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -27,11 +27,11 @@ class RegisterAccountModalController {
   // 5. Complete User Match
 
   /* @ngInject */
-  constructor ($element, $rootScope, $window, $document, cartService, orderService, sessionService, verificationService, envService, gettext) {
+  constructor ($document, $element, $rootScope, $window, cartService, orderService, sessionService, verificationService, envService, gettext) {
+    this.$document = $document
     this.element = $element[0]
     this.$rootScope = $rootScope
     this.$window = $window
-    this.$document = $document
     this.cartService = cartService
     this.orderService = orderService
     this.sessionService = sessionService
@@ -40,7 +40,6 @@ class RegisterAccountModalController {
     this.scrollModalToTop = scrollModalToTop
     this.imgDomain = envService.read('imgDomain')
     this.newUser = sessionService.getRole() === Roles.public
-    this.$injector = angular.injector()
   }
 
   $onInit () {
@@ -182,7 +181,7 @@ class RegisterAccountModalController {
 
   redirectToOktaForLogin () {
     this.sessionService.signIn(this.lastPurchaseId).subscribe(() => {
-      const $injector = this.$injector
+      const $injector = angular.injector()
       if (!$injector.has('sessionService')) {
         $injector.loadNewModules(['sessionService'])
       }

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -16,15 +16,30 @@ import failedVerificationModal from 'common/components/failedVerificationModal/f
 const componentName = 'registerAccountModal'
 
 class RegisterAccountModalController {
-  // Register Account Modal is a multi-step process.
+  // --------------------------------------
+  // Registration process.
+  // It's a multi-step process, handled by
+  // this component and sub-components.
+  // --------------------------------------
   // 1. Sign In/Up
-  //  1.1 Sign in or Sign Up
-  //  1.2 Verify Email
-  //  1.3 Sign In
+  //  1.1 Sign in - redirect to Okta
+  //  1.2 Sign Up - shown the sign up modal
   // 2. Fetch Donor Details
   // 3. Collect Contact Info
-  // 4. Post to Donor Matches
-  // 5. Complete User Match
+  // 4. Register for Okta account
+  //   4.1 Verify email via Okta
+  // 5. Register for Cortex/Give account
+  //   5.1 Upon success, redirect to Okta
+  //   5.2 Upon failure, shown the contact info modal for manual entry.
+  //     5.2.1 Upon success, redirect to Okta
+  // 6. User authenticates on Okta
+  //     (Redirect to allow user's credentials to be stored by browser.)
+  // 7. Upon returning to the site, we check the user's donor details.
+  //   7.1 If MATCHED, we show the user match modal.
+  //   7.2 if NEW, we determine if the user has already registered.
+  //     7.2.1 If registered, we run post donor matching and show the user match modal.
+  //     7.2.2 If not fully registered, we show the contact info modal and then run post donor matches.
+  // 8. Upon registration completion, we redirect the user back to their previous page
 
   /* @ngInject */
   constructor ($document, $element, $rootScope, $window, cartService, orderService, sessionService, verificationService, envService, gettext) {

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -263,67 +263,10 @@ describe('registerAccountModal', function () {
     })
 
     describe('\'registration-state\' NEW', () => {
-      const signUpDonorDetails = {
-        name: {
-          'given-name': 'First',
-          'family-name': 'Last'
-        },
-        'donor-type': 'Household',
-        email: 'first.last@cru.org',
-        phone: '111-222-3333',
-        mailingAddress: {
-          streetAddress: '123 First St',
-          locality: 'Orlando',
-          region: 'FL',
-          postalCode: '12345',
-          country: 'US'
-        }
-      }
-
-      const emailFormUri = '/emails/crugive'
-
-      beforeEach(() => {
+      it('changes state to \'contact-info\'', () => {
         $ctrl.orderService.getDonorDetails.mockImplementation(() => Observable.of({
           'registration-state': 'NEW',
-          name: {
-            'given-name': 'Existing',
-            'family-name': 'Existing'
-          },
-          'donor-type': '',
-          email: 'existing.email@cru.org',
-          phone: '',
-          mailingAddress: {
-            streetAddress: '',
-            locality: '',
-            region: '',
-            postalCode: '',
-            country: 'CANADA'
-          },
-          emailFormUri
         }))
-        $ctrl.orderService.addEmail.mockImplementation(() => Observable.of({}))
-      })
-
-      describe('with sign up details', () => {
-        it('saves sign up contact info merged with existing contact info', () => {
-          $ctrl.checkDonorDetails(signUpDonorDetails)
-
-          expect($ctrl.orderService.updateDonorDetails).toHaveBeenCalledWith(expect.objectContaining(signUpDonorDetails))
-          expect($ctrl.orderService.addEmail).toHaveBeenCalledWith(signUpDonorDetails.email, emailFormUri)
-          expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')
-        })
-
-        it('remembers contact info after error', () => {
-          $ctrl.orderService.addEmail.mockImplementation(() => Observable.throw(new Error('Error adding email')))
-
-          $ctrl.checkDonorDetails(signUpDonorDetails)
-
-          expect($ctrl.signUpDonorDetails).toBe(signUpDonorDetails)
-          expect($ctrl.stateChanged).toHaveBeenCalledWith('contact-info')
-        })
-      })
-
-      it('changes state to \'contact-info\'', () => {
         $ctrl.checkDonorDetails()
 
         expect($ctrl.orderService.getDonorDetails).toHaveBeenCalled()

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -24,10 +24,6 @@ describe('registerAccountModal', function () {
           dispatchEvent: jest.fn()
         }
       }],
-      $injector: {
-        has: jest.fn(),
-        loadNewModules: jest.fn()
-      }
     }
     locals = {
       $element: [{ dataset: {} }],
@@ -410,33 +406,21 @@ describe('registerAccountModal', function () {
     })
   })
 
-  describe('redirectToOktaForLogin', () => {
-    let dispatchEventSpy
-    beforeEach(() => {
-      jest.spyOn($ctrl.sessionService, 'signIn').mockReturnValue(Observable.of({}))
-      dispatchEventSpy = jest.spyOn($ctrl.$document[0].body, 'dispatchEvent')
-    })
-
+  describe('redirectToOktaForLogin', () => {   
     it('should call sessionService.signIn and dispatch giveSignInSuccess event', () => {
-      expect($ctrl.sessionService.signIn).not.toHaveBeenCalled()
+      const $injector = { get: jest.fn() }
+      jest.spyOn(angular, 'injector').mockReturnValue($injector)
+      jest.spyOn($ctrl.sessionService, 'signIn').mockReturnValue(Observable.of({}))
+      const dispatchEventSpy = jest.spyOn($ctrl.$document[0].body, 'dispatchEvent')
 
+      expect($ctrl.sessionService.signIn).not.toHaveBeenCalled()
       $ctrl.redirectToOktaForLogin()
 
       expect($ctrl.sessionService.signIn).toHaveBeenCalledWith($ctrl.lastPurchaseId)
-      expect($ctrl.$injector.has).toHaveBeenCalledWith('sessionService')
-      expect($ctrl.$injector.loadNewModules).toHaveBeenCalledWith(['sessionService'])
       expect(dispatchEventSpy).toHaveBeenCalledWith(expect.objectContaining({
         type: 'giveSignInSuccess',
-        detail: { $injector: $ctrl.$injector }
+        detail: { $injector }
       }))
-    })
-
-    it('should not load new modules if sessionService is already available', () => {
-      $ctrl.$injector.has.mockReturnValue(true)
-
-      $ctrl.redirectToOktaForLogin()
-
-      expect($ctrl.$injector.loadNewModules).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -70,9 +70,10 @@
     ></sign-in-modal>
     <sign-up-modal
       ng-switch-when="sign-up"
-      on-sign-up="$ctrl.onSignUpSuccess(donorDetails)"
+      on-sign-up-error="$ctrl.onSignUpError(donorDetails)"
       on-sign-in="$ctrl.onSignIn()"
       is-inside-another-modal="true"
+      redirect-to-okta-for-login="$ctrl.redirectToOktaForLogin()"
     ></sign-up-modal>
     <div ng-switch-when="loading-donor" class="modal-body">
       <loading></loading>

--- a/src/common/components/signInForm/signInButton/signInButton.component.js
+++ b/src/common/components/signInForm/signInButton/signInButton.component.js
@@ -13,7 +13,6 @@ class SignInButtonController {
     this.$rootScope = $rootScope
     this.$document = $document
     this.$timeout = $timeout
-    this.$injector = angular.injector()
     this.sessionService = sessionService
     this.gettext = gettext
     this.imgDomain = envService.read('imgDomain')
@@ -44,10 +43,7 @@ class SignInButtonController {
     this.watchSigningIn()
     this.sessionService.signIn(this.lastPurchaseId).subscribe(() => {
       this.isSigningIn = false
-      const $injector = this.$injector
-      if (!$injector.has('sessionService')) {
-        $injector.loadNewModules(['sessionService'])
-      }
+      const $injector = angular.injector()
       this.$document[0].body.dispatchEvent(
         new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } })
       )

--- a/src/common/components/signInForm/signInButton/signInButton.component.spec.js
+++ b/src/common/components/signInForm/signInButton/signInButton.component.spec.js
@@ -20,10 +20,6 @@ describe('signInButton', function () {
           dispatchEvent: jest.fn()
         }
       }],
-      $injector: {
-        has: jest.fn(),
-        loadNewModules: jest.fn()
-      }
     }
 
     const scope = { $apply: jest.fn() }
@@ -88,13 +84,10 @@ describe('signInButton', function () {
     it('adds the sessionService module', () => {
       deferred.resolve({})
       $rootScope.$digest()
-      bindings.$injector.has.mockImplementation(() => false)
-      bindings.$injector.loadNewModules.mockImplementation(() => {})
+      const $injector = { get: jest.fn() }
+      jest.spyOn(angular, 'injector').mockReturnValue($injector)
 
       expect(bindings.$document[0].body.dispatchEvent).toHaveBeenCalled();
-      const $injector = bindings.$injector
-
-      expect($injector.loadNewModules).toHaveBeenCalledWith(['sessionService'])
       expect(bindings.$document[0].body.dispatchEvent).toHaveBeenCalledWith(
         new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } }))
     })

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -41,7 +41,6 @@ class SignUpModalController {
     this.geographiesService = geographiesService
     this.imgDomain = envService.read('imgDomain')
     this.publicCru = envService.read('publicCru')
-    this.$injector = angular.injector()
   }
 
   $onInit () {
@@ -662,9 +661,9 @@ class SignUpModalController {
       'phone-number': this.$scope.primaryPhone,
       mailingAddress: {
         streetAddress: this.$scope.streetAddress,
-        streetAddressExtended: this.$scope.streetAddressExtended,
-        internationalAddressLine3: this.$scope.internationalAddressLine3,
-        internationalAddressLine4: this.$scope.internationalAddressLine4,
+        extendedAddress: this.$scope.streetAddressExtended,
+        intAddressLine3: this.$scope.internationalAddressLine3,
+        intAddressLine4: this.$scope.internationalAddressLine4,
         locality: this.$scope.city,
         region: this.$scope.state,
         postalCode: this.$scope.zipCode,
@@ -683,21 +682,8 @@ class SignUpModalController {
         this.orderService.addEmail(donorDetails.email, donorDetails.emailFormUri)
       ]).map(() => donorDetails)
     }).subscribe({
-      next: () => this.logIntoOkta(),
-      error: () => this.logIntoOkta()
-    })
-  }
-
-  logIntoOkta () {
-    this.sessionService.signIn(this.lastPurchaseId).subscribe(() => {
-      const $injector = this.$injector
-      if (!$injector.has('sessionService')) {
-        $injector.loadNewModules(['sessionService'])
-      }
-
-      this.$document[0].body.dispatchEvent(
-        new window.CustomEvent('giveSignInSuccess', { bubbles: true, detail: { $injector } })
-      )
+      next: () => this.redirectToOktaForLogin(),
+      error: (donorDetails) => this.onSignUpError({ donorDetails })
     })
   }
 }
@@ -713,12 +699,14 @@ export default angular
     controller: SignUpModalController,
     templateUrl: template,
     bindings: {
-      // Called with `donorDetails` after the user creates an account with Okta
-      onSignUp: '&',
+      // Called with `donorDetails` if there is an error while signing up to the Cortex DB
+      onSignUpError: '&',
       // Called when the user clicks back to sign in link
       onSignIn: '&',
       // Called with the user dismisses the modal via the close button
       onCancel: '&',
+      // Called when user successfully signs up and we redirect them to Okta to login
+      redirectToOktaForLogin: '&',
       isInsideAnotherModal: '='
     }
   })

--- a/src/common/components/signUpModal/signUpModal.component.mock.js
+++ b/src/common/components/signUpModal/signUpModal.component.mock.js
@@ -4,12 +4,12 @@ export const user = {
   email: 'email',
   accountType: 'Household',
   streetAddress: 'streetAddress',
-  streetAddressExtended: 'streetAddressExtended',
+  extendedAddress: 'streetAddressExtended',
   city: 'city',
   state: 'state',
   zipCode: '11111',
   countryCode: 'US',
-  primaryPhone: 'primaryPhone',
+  'phone-number': 'primaryPhone',
   organizationName: 'organizationName'
 }
 

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -19,7 +19,8 @@ describe('signUpForm', function () {
     $rootScope = _$rootScope_
     bindings = {
       onSignIn: jest.fn(),
-      onSignUp: jest.fn(),
+      onSignUpError: jest.fn(),
+      redirectToOktaForLogin: jest.fn(),
       signUpForm: {
         $valid: false,
         $setSubmitted: jest.fn()
@@ -344,13 +345,13 @@ describe('signUpForm', function () {
       it('should use saved data from $scope', () => {
         $ctrl.$scope.countryCode = 'UK';
         $ctrl.$scope.streetAddress = user.streetAddress;
-        $ctrl.$scope.streetAddressExtended = user.streetAddressExtended;
+        $ctrl.$scope.streetAddressExtended = 'Extended';
         $ctrl.$scope.internationalAddressLine3 = 'internationalAddressLine3';
         $ctrl.$scope.internationalAddressLine4 = 'internationalAddressLine4';
         $ctrl.$scope.city = user.city;
         $ctrl.$scope.state = user.state;
         $ctrl.$scope.zipCode = user.zipCode;
-        $ctrl.$scope.primaryPhone = user.primaryPhone;
+        $ctrl.$scope.primaryPhone = user['phone-number'];
 
         $ctrl.parseSchema(schema, onSuccess);
 
@@ -1316,10 +1317,14 @@ describe('signUpForm', function () {
         'family-name': user.lastName
       },
       'donor-type': user.accountType,
+      'organization-name': 'Organization Name',
       email: user.email,
-      'phone-number': user.primaryPhone,
+      'phone-number': "",
       mailingAddress: {
         streetAddress: user.streetAddress,
+        extendedAddress: 'extendedAddress',
+        intAddressLine3: 'intAddressLine3',
+        intAddressLine4: 'intAddressLine4',
         locality: user.city,
         region: user.state,
         postalCode: '12345-678',
@@ -1331,7 +1336,11 @@ describe('signUpForm', function () {
       $ctrl.$scope.lastName = user.lastName
       $ctrl.$scope.email = user.email
       $ctrl.$scope.accountType = user.accountType
+      $ctrl.$scope.organizationName = 'Organization Name'
       $ctrl.$scope.streetAddress = user.streetAddress
+      $ctrl.$scope.streetAddressExtended = 'extendedAddress'
+      $ctrl.$scope.internationalAddressLine3 = 'intAddressLine3'
+      $ctrl.$scope.internationalAddressLine4 = 'intAddressLine4'
       $ctrl.$scope.city = user.city
       $ctrl.$scope.state = user.state
       $ctrl.$scope.zipCode = user.zipCode
@@ -1356,16 +1365,28 @@ describe('signUpForm', function () {
         },
         emailFormUri
       }))
-      jest.spyOn($ctrl.orderService, 'updateDonorDetails').mockImplementation(() => Observable.of({}))
       jest.spyOn($ctrl.orderService, 'addEmail').mockImplementation(() => Observable.of({}))
-      jest.spyOn($ctrl, 'logIntoOkta').mockImplementation(() => Observable.of({}))
+      jest.spyOn($ctrl, 'redirectToOktaForLogin')
+      jest.spyOn($ctrl, 'onSignUpError')
     })
 
-    it("should update the user's data, updating email separately", () => {
+    it("should succeed updating the user's data, redirecting to Okta", () => {
+      jest.spyOn($ctrl.orderService, 'updateDonorDetails').mockImplementation(() => Observable.of({}))
+
       $ctrl.saveDonorDetails()
 
       expect($ctrl.orderService.updateDonorDetails).toHaveBeenCalledWith(expect.objectContaining(signUpDonorDetails))
       expect($ctrl.orderService.addEmail).toHaveBeenCalledWith(signUpDonorDetails.email, emailFormUri)
+      expect($ctrl.redirectToOktaForLogin).toHaveBeenCalled()
+      expect($ctrl.onSignUpError).not.toHaveBeenCalled()
+    })
+
+    it("should fail while updating the user's data, opening the contact info modal", () => {
+      jest.spyOn($ctrl.orderService, 'updateDonorDetails').mockImplementation(() => Observable.throw({}))
+      $ctrl.saveDonorDetails()
+
+      expect($ctrl.redirectToOktaForLogin).not.toHaveBeenCalled()
+      expect($ctrl.onSignUpError).toHaveBeenCalled()
     })
   });
 })


### PR DESCRIPTION
# Description
In this PR, I finish the coding for the sign up process. Up to now, we have the Okta form done, but in this PR, I handle saving the user data to the Give information, redirecting to Okta to ensure the user logs in to the browser, and, upon returning, handle the user matching.

You will also see that I've cleaned up some code in the registerAccountModal files.

## Sign up flows

_When testing, use your email address, but change it by adding the `+` symbol. such as `daniel.bisgrove+testEmail236@cru.org`_

### Error while saving data to Give DB (Cortex)
If there is an error saving the data on the sign-up form (Before redirecting to Okta), we send users to the contact-info modal. Once they fix the details and click save, we redirect the user to Okta to complete the registration.

**To Test:**
1. Change line 660 to `email: '111'` to cause an error while saving the email.
2. Sign up as a user (Entering your details)
3. After you enter the verification code and MFA options, you should be redirected to the contact info modal.
4. After fixing your email, you will be redirected to Okta to authentication.
5. Upon returning to the Give site, you will go through the user matching modal or be redirected to your previous page.
6. Revert changes to line 660.


### Catch user that has Okta account but no Give account
If there is an error saving the Give DB data on the sign-up form (Before redirecting to Okta), but the Okta account has been created, then the session is lost due to the user vanishing. We need to ensure when they log back in; we continue to finish off the signup process.

**To Test:**
1. Change line 660 to `email: '111'` to cause an error while saving the email.
2. Sign up as a user (Entering your details)
3. After you enter the verification code and MFA options, you should be redirected to the contact info modal.
4. Close your tab/session.
5. Open a new session on an incognito window and log into Okta with the account you just created.
6. Upon returning to the Give site, you should be sent to the contact info modal to fix errors with the account.
7. After this, you will be sent through the user-matching modals


### Go through user matching
If you enter data for the sign-up form, similar to another account's, it will show the user modal after being redirected from Okta in the registration process.

**To Test:**
1. Sign up as a new user, entering details similar to an existing account
3. Go through the email verification and MFA steps.
4. You will be redirected ti Okta. Login with your new account.
5. Upon returning to the Give site, you will go through the user matching modal.


## Tests
I have added tests to each function to ensure they work as expected.

## Loading and error pages
I still need to add error pages and better loading pages
- Show Error while loading contact info modal when there was an error saving the Cortex account.
- Show better loading when switching from the Signup modal to directing to Okta for login.
- Add error when Okta and Cortex doesn't work and we need to instruct the user to contact Cru.