### PR TITLE
Fix deployment errors caused by PR #1154

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   push: 
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   lint:
+    name: 🧹 Lint Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,6 +40,7 @@ jobs:
         run: yarn lint:styles
 
   test:
+    name: ✅ Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -80,6 +82,7 @@ jobs:
 
 
   deploy:
+    name: 🚀 Deploy app
     runs-on: ubuntu-latest
     environment:
       name: ${{ (github.ref == 'refs/heads/master' && 'production') || 'staging' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,27 @@ jobs:
       
       - name: Upload Codecov Reports
         uses: codecov/codecov-action@v2 
-   
+
+  build:
+    name: 🏗️ Build app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+      
+      - name: Install Dependencies
+        run: yarn install --immutable --immutable-cache --ignore-optional
+      
+      - name: Build App
+        env:
+          S3_GIVE_DOMAIN: //${{ secrets.GIVE_WEB_HOSTNAME }}
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          DATADOG_RUM_CLIENT_TOKEN: ${{ secrets.DATADOG_RUM_CLIENT_TOKEN }}
+        run: yarn run build
+
+
   deploy:
     runs-on: ubuntu-latest
     environment:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^29.7.0",
     "jest-date-mock": "^1.0.7",
     "jest-environment-jsdom": "^29.4.2",
-    "mini-css-extract-plugin": "^1.6.2",
+    "mini-css-extract-plugin": "^0.8.2",
     "moment-locales-webpack-plugin": "^1.1.0",
     "ngtemplate-loader": "^2.0.1",
     "sass": "^1.49.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -194,13 +194,9 @@ module.exports = (env = {}) => [
       path: path.resolve(__dirname, 'dist')
     },
     plugins: [
-      ...(!isBuild
-        ? [
-            new MiniCssExtractPlugin({
-              filename: 'chunks/[name].[contenthash].min.css'
-            })
-          ]
-        : []),
+      new MiniCssExtractPlugin({
+        filename: 'chunks/[name].[contenthash].min.css'
+      }),
       ...sharedConfig.plugins,
       new BundleAnalyzerPlugin({
         analyzerMode: env.analyze ? 'static' : 'disabled'
@@ -242,13 +238,9 @@ module.exports = (env = {}) => [
       'branded-checkout': brandedComponents
     },
     plugins: [
-      ...(!isBuild
-        ? [
-            new MiniCssExtractPlugin({
-              filename: '[name].min.css'
-            })
-          ]
-        : []),
+      new MiniCssExtractPlugin({
+        filename: '[name].min.css'
+      }),
       ...sharedConfig.plugins,
       new BundleAnalyzerPlugin({
         analyzerMode: env.analyze ? 'static' : 'disabled'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,13 +60,17 @@ const sharedConfig = {
       ROLLBAR_ACCESS_TOKEN: JSON.stringify(process.env.ROLLBAR_ACCESS_TOKEN) || 'development-token',
       DATADOG_RUM_CLIENT_TOKEN: process.env.DATADOG_RUM_CLIENT_TOKEN || ''
     }),
-    new StyleLintPlugin({
-      configFile: path.resolve(__dirname, 'stylelint.config.mjs'),
-      context: 'src/assets/scss',
-      files: '**/*.(css|scss)',
-      failOnError: true,
-      quiet: false
-    }),
+    ...(isBuild
+      ? []
+      : [
+        new StyleLintPlugin({
+          configFile: path.resolve(__dirname, 'stylelint.config.mjs'),
+          context: 'src/assets/scss',
+          files: '**/*.(css|scss)',
+          failOnError: true,
+          quiet: false
+        }),
+      ]),
     // To strip all locales except “en”
     new MomentLocalesPlugin()
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,14 +63,14 @@ const sharedConfig = {
     ...(isBuild
       ? []
       : [
-        new StyleLintPlugin({
-          configFile: path.resolve(__dirname, 'stylelint.config.mjs'),
-          context: 'src/assets/scss',
-          files: '**/*.(css|scss)',
-          failOnError: true,
-          quiet: false
-        }),
-      ]),
+          new StyleLintPlugin({
+            configFile: path.resolve(__dirname, 'stylelint.config.mjs'),
+            context: 'src/assets/scss',
+            files: '**/*.(css|scss)',
+            failOnError: true,
+            quiet: false
+          })
+        ]),
     // To strip all locales except “en”
     new MomentLocalesPlugin()
   ],
@@ -199,7 +199,8 @@ module.exports = (env = {}) => [
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: 'chunks/[name].[contenthash].min.css'
+        filename: 'chunks/[name].[contenthash].min.css',
+        disable: !isBuild
       }),
       ...sharedConfig.plugins,
       new BundleAnalyzerPlugin({
@@ -243,7 +244,8 @@ module.exports = (env = {}) => [
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name].min.css'
+        filename: '[name].min.css',
+        disable: !isBuild
       }),
       ...sharedConfig.plugins,
       new BundleAnalyzerPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -6416,6 +6416,11 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -7660,13 +7665,14 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-css-extract-plugin@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz#83172b4fd812f8fc4a09d6f6d16f924f53990ca8"
-  integrity sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==
+mini-css-extract-plugin@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz#a875e169beb27c88af77dd962771c9eedc3da161"
+  integrity sha512-a3Y4of27Wz+mqK3qrcd3VhYz6cU0iW5x3Sgvqzbj+XmlrSizmvu8QQMl5oMYJjgHOC4iyt+w7l4umP+dQeW3bw==
   dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
+    loader-utils "^1.1.0"
+    normalize-url "1.9.1"
+    schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
@@ -7969,6 +7975,16 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-url@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
+  integrity sha512-A48My/mtCklowHBlI8Fq2jFWK4tX4lJ5E6ytFsSOq1fzpvT0SQSgKhSg7lN5c2uYFOrUAOQp6zhhJnpp1eMloQ==
+  dependencies:
+    object-assign "^4.0.1"
+    prepend-http "^1.0.0"
+    query-string "^4.1.0"
+    sort-keys "^1.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -7988,7 +8004,7 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8624,6 +8640,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prepend-http@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+  integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
+
 pretty-format@^27.0.2:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
@@ -8796,6 +8817,14 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+query-string@^4.1.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha512-O2XLNDBIg1DnTOa+2XrIwSiXEV8h2KImXUnjhhn2+UsvZ+Es2uyd5CCRTNQlDGbzUQOW3aYCBx9rVA6dzsiY7Q==
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -9797,6 +9826,13 @@ sockjs@^0.3.21:
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  integrity sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -10019,6 +10055,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
# Description
A previous PR https://github.com/CruGlobal/give-web/pull/1154 broke the deployment action. The error occurred during the build script. This wasn't caught before merging it into the `master` branch, causing the deployment to production to break.

The error was due to the `MiniCssExtractPlugin` not being included as a plugin when building the app - https://github.com/CruGlobal/give-web/actions/runs/13790159211/job/38567765240

### Changes
**MiniCssExtractPlugin**
Having updated `MiniCssExtractPlugin` package in the previous PR, the `disabled` property was no longer available, so in https://github.com/CruGlobal/give-web/pull/1154, I had meant to conditionally load `MiniCssExtractPlugin` when building the app. However, I must have got confused as I loaded the plugin during development instead.
In this PR, I have downgraded it, so it's back at the original version and added back the `disable` property.

**StyleLintPlugin**
I have also conditionally added the StyleLintPlugin to only run during `development`. This plugin lints the style files, so it shouldn't be running during the build, as we have a CI that tests the style lint before we build.

**Added build CI test**
I've added a build CI test to avoid this happening again. 


## Why this wasn't caught?
1. I missed it. I had checked that `build` was working, but then did a number of changes and didn't recheck it.
2. The PR was passing all its tests.
3. We don't have a CI test that tests the app can be built without errors.

