### PR TITLE
Returns spouse info to V3, adds a toggle to add/remove spouse, adds tooltip to explain spouse info

### DIFF
--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -18,6 +18,7 @@ import sessionService, { SignInEvent, Roles } from 'common/services/session/sess
 import analyticsFactory from 'app/analytics/analytics.factory'
 
 import template from './contactInfo.tpl.html'
+import uibTooltip from 'angular-ui-bootstrap/src/tooltip'
 
 const componentName = 'contactInfo'
 
@@ -188,7 +189,8 @@ export default angular
     orderService.name,
     radioStationsService.name,
     sessionService.name,
-    analyticsFactory.name
+    analyticsFactory.name,
+    uibTooltip
   ])
   .component(componentName, {
     controller: Step1Controller,

--- a/src/common/components/contactInfo/contactInfo.component.js
+++ b/src/common/components/contactInfo/contactInfo.component.js
@@ -31,6 +31,7 @@ class Step1Controller {
     this.radioStationsService = radioStationsService
     this.sessionService = sessionService
     this.analyticsFactory = analyticsFactory
+    this.showSpouseDetails = false
   }
 
   $onInit () {
@@ -116,6 +117,10 @@ class Step1Controller {
         this.loadingDonorDetailsError = true
         this.$log.error('Error loading donorDetails.', error)
       })
+  }
+
+  toggleSpouseDetails () {
+    this.showSpouseDetails = !this.showSpouseDetails
   }
 
   loadRadioStations () {

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -126,7 +126,7 @@
               <label class="mb0 hidden-xs hidden-sm">
                 <span class="invisible mb0"></span>
               </label>
-              <button type="button" class="btn btn-primary btn-block" ng-click="$ctrl.toggleSpouseDetails()">
+              <button type="button" class="btn btn-primary btn-block" ng-click="$ctrl.toggleSpouseDetails()" uib-tooltip="{{'By adding your spouse\'s name, we can ensure that both of your contributions are linked together, providing a clearer and more accurate record of your household\'s giving.' | translate}}">
                   <span ng-if="!$ctrl.showSpouseDetails">Add Spouse</span>
                   <span ng-if="$ctrl.showSpouseDetails">Remove Spouse</span>
               </button>

--- a/src/common/components/contactInfo/contactInfo.tpl.html
+++ b/src/common/components/contactInfo/contactInfo.tpl.html
@@ -48,7 +48,7 @@
       <h4 ng-if="$ctrl.useV3 !== 'true'" class="panel-title  border-bottom-small  visible" translate>{{'YOUR_INFORMATION'}}</h4>
       <h4 ng-if="$ctrl.useV3 === 'true'" class="panel-title  border-bottom-small  visible" translate>{{'CONTACT_INFO'}}</h4>
       <div class="row">
-        <div ng-class="{'col-sm-4': $ctrl.useV3 !== 'true', 'col-sm-6': $ctrl.useV3 === 'true'}">
+        <div ng-class="{'col-md-5 col-sm-6' : $ctrl.useV3, 'col-sm-4' : !$ctrl.useV3}">
           <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.nameGivenName | showErrors)}">
             <label>
               <span translate>{{'FIRST_NAME'}}</span>
@@ -83,7 +83,7 @@
             </div>
           </div>
         </div>
-        <div ng-class="{'col-sm-4': $ctrl.useV3 !== 'true', 'col-sm-6': $ctrl.useV3 === 'true'}">
+        <div ng-class="{'col-md-5 col-sm-6' : $ctrl.useV3, 'col-sm-4' : !$ctrl.useV3}">
           <div class="form-group is-required" ng-class="{'has-error': ($ctrl.detailsForm.nameFamilyName | showErrors)}">
             <label>
               <span translate>{{'LAST_NAME'}}</span>
@@ -120,10 +120,23 @@
             </label>
           </div>
         </div>
+        <div ng-if="$ctrl.donorDetails['donor-type'] === 'Household' && $ctrl.useV3 === 'true'">
+          <div class="col-sm-12 col-md-2">
+            <div class="form-group">
+              <label class="mb0 hidden-xs hidden-sm">
+                <span class="invisible mb0"></span>
+              </label>
+              <button type="button" class="btn btn-primary btn-block" ng-click="$ctrl.toggleSpouseDetails()">
+                  <span ng-if="!$ctrl.showSpouseDetails">Add Spouse</span>
+                  <span ng-if="$ctrl.showSpouseDetails">Remove Spouse</span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
 
-      <div class="row" ng-if="$ctrl.donorDetails['donor-type'] === 'Household' && $ctrl.useV3 !== 'true'">
-        <div class="col-sm-4">
+      <div class="row" ng-if="$ctrl.donorDetails['donor-type'] === 'Household' && $ctrl.showSpouseDetails" >
+        <div ng-class="$ctrl.useV3 ? 'col-sm-6' : 'col-sm-4'">
           <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseGivenName | showErrors)}">
             <label>
               <span translate>{{'SPOUSE_FIRST_NAME'}}</span>
@@ -140,7 +153,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2" ng-if="$ctrl.useV3 !== 'true'">
           <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseMiddleInitial | showErrors)}">
             <label>
               <span translate>{{'MIDDLE_ABBREV'}}</span>
@@ -156,7 +169,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-4">
+        <div ng-class="$ctrl.useV3 ? 'col-sm-6' : 'col-sm-4'">
           <div class="form-group" ng-class="{'has-error': ($ctrl.detailsForm.spouseFamilyName | showErrors)}">
             <label>
               <span translate>{{'SPOUSE_LAST_NAME'}}</span>
@@ -173,7 +186,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2" ng-if="$ctrl.useV3 !== 'true'">
           <div class="form-group">
             <label>
               <span translate>{{'SUFFIX'}}</span>


### PR DESCRIPTION
This new PR fixes a lint issue that was identified

Spouse Contact Info
- "Add Spouse" button next to primary contact fields, see attachment for UI moc up (always present, optional)
- Button should have hover text that states "By adding your spouse's name, we can ensure that both of your contributions are linked together, providing a clearer and more accurate record of your household's giving."
- When clicked display the following spouse fields and convert the button text to "Remove Spouse":
- Spouse First Name (present when "Add Spouse" button clicked, optional, removed when "Remove Spouse" button clicked)
- Spouse Last Name (present when "Add Spouse" button clicked, optional, removed when "Remove Spouse" button clicked)
- 
NOTE: these fields look required in the moc up attached but they should just be optional.