### PR TITLE
[EP-2362] Rename street address label for consistency

### DIFF
--- a/src/common/components/signUpModal/signUpFormCustomFields.js
+++ b/src/common/components/signUpModal/signUpFormCustomFields.js
@@ -50,7 +50,7 @@ export const customFields = {
   streetAddressExtended: {
     name: 'userProfile.streetAddressExtended',
     type: 'text',
-    label: 'Street address line 2',
+    label: 'Address line 2',
     required: false,
     'label-top': true,
     multirowError: true,


### PR DESCRIPTION
This makes the first line "Street address" and the other lines "Address line 2/3/4". This looks better for international addresses, but do we need it to say "Street address line 2" for US addresses?