### PR TITLE
[EP-2572] Only augment error message box once

### DIFF
--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -566,7 +566,11 @@ class SignUpModalController {
       return
     }
 
+    // Remove the previous error fields
+    errorBox.querySelector('.error-fields')?.remove()
+
     const errorMessage = document.createElement('p')
+    errorMessage.className = 'error-fields'
     // The OKTA_SIGNUP_FIELDS_ERROR translation key is already loaded, so we can use
     // $translate.instant to synchronously interpolate our fields into it
     errorMessage.textContent = this.$translate.instant('OKTA_SIGNUP_FIELDS_ERROR', { fields: errorFields.join(', ') })

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -1250,6 +1250,13 @@ describe('signUpForm', function () {
 
           expect(errorBox.textContent).not.toContain('Please review the following fields')
         })
+
+        it('only creates error messages once', () => {
+          $ctrl.injectErrorMessages()
+          $ctrl.injectErrorMessages()
+
+          expect(errorBox.textContent.match(/Please review the following fields/g)?.length).toBe(1)
+        })
       })
     });
 


### PR DESCRIPTION
Once or twice, I've seen two lines of "Please review the following fields: email." `afterError` was being called twice by Okta for some reason. The issue resolved itself once I closed and reopened the modal.  It's likely a bug in Okta's widget.

To prevent this, we need to make sure that `injectErrorMessages` can be safely called multiple times.

EP-2572