### PR TITLE
[EP-2573] Prevent escape key from closing the sign in modal

### DIFF
--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -63,6 +63,7 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       resolve: {
         lastPurchaseId: () => lastPurchaseId
       },
+      keyboard: false,
       openAnalyticsEvent: 'ga-sign-in',
       dismissAnalyticsEvent: 'ga-sign-in-exit'
     }).result,


### PR DESCRIPTION
Prevent the escape key from closing the sign in modal. This is to prevent confusion of users accidentally hitting escape (maybe when trying to close an autocomplete or dismiss an autofill suggestion), accidentally closing the sign in/sign up modal, and having to start over.

EP-2573