### PR TITLE
[EP-2576] Improve Okta info line on narrow screens

### DIFF
--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -78,7 +78,7 @@ register-account-modal:has(sign-in-modal, sign-up-modal) {
     .cru-info {
       display: flex;
       justify-content: space-between;
-      padding: 1rem 2rem;
+      padding: 1rem;
       border-bottom: 2px solid $colorCru-gold;
       background-color: white;
       gap: 2rem;

--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -134,7 +134,7 @@ register-account-modal:has(sign-in-modal, sign-up-modal) {
 
     .okta-info {
       display: flex;
-      align-items: end;
+      align-items: center;
 
       /* Makes it easier to align the baseline of the text with the bottom of the image */
       line-height: 1em;

--- a/src/assets/scss/components/_registerAccountModal.scss
+++ b/src/assets/scss/components/_registerAccountModal.scss
@@ -145,8 +145,12 @@ register-account-modal:has(sign-in-modal, sign-up-modal) {
         img {
           /* Override global Bootstrap image styles */
           display: unset;
-          height: 1rem;
+          height: 0.75rem;
         }
+      }
+
+      span {
+        vertical-align: middle;
       }
     }
 

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -20,8 +20,10 @@
               <span translate>Resources, Giving, and Events</span>
             </p>
             <p class="okta-info mobile">
-              <span translate>Powered by</span> &bull;
-              <img ng-src="{{$ctrl.imgDomain}}/assets/img/okta-logo.png" width="44" height="16" alt="Okta logo">
+              <span>
+                <span translate>Powered by</span>
+                <img ng-src="{{$ctrl.imgDomain}}/assets/img/okta-logo.png" width="33" height="12" alt="Okta logo">
+              </span>
               <span uib-tooltip="{{'Okta is our preferred partner for authentication. They help us keep your access to Cru&rsquo;s websites and software secure. You will be redirected to signon.okta.com next time you log in.' | translate}}">
                 <span translate>What does this mean?</span> <i class="fa fa-info-circle"></i>
               </span>


### PR DESCRIPTION
Changes:
* Reduce the x-axis padding to reduce the amount of line-wrapping
* Vertically align Okta info items when they are forced to wrap

I worked with @rguinee on this.

Before:
<img width="297" alt="Before" src="https://github.com/user-attachments/assets/f2933b53-e53e-4926-b2c8-bd08e94e29c7" />

After:
<img width="294" alt="After" src="https://github.com/user-attachments/assets/554ee54a-94cb-4c49-82b4-e6d2596ff38b" />

EP-2576