### PR TITLE
[EP-2579] Prevent clicking outside the sign in modal from closing it

### DIFF
--- a/src/app/oktaAuthCallback/oktaAuthCallback.component.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.component.js
@@ -74,7 +74,7 @@ class OktaAuthCallbackController {
   }
 
   openContactInfoModalThenRedirect () {
-    this.sessionModalService.nonDismissibleRegisterAccount().then(() => {
+    this.sessionModalService.registerAccount({ dismissable: false }).then(() => {
       this.redirectToLocationPriorToLogin()
     })
   }

--- a/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
@@ -32,7 +32,7 @@ describe('oktaAuthCallback', function () {
     orderService = _orderService_
     verificationService = _verificationService_
     $ctrl = _$componentController_(module.name,
-      { 
+      {
         $log,
         $window: {
           location: '/okta-auth-callback.html',
@@ -44,7 +44,7 @@ describe('oktaAuthCallback', function () {
       }
     )
   }))
-  
+
   it('to be defined', function () {
     expect($ctrl).toBeDefined()
   })
@@ -71,7 +71,7 @@ describe('oktaAuthCallback', function () {
     })
   })
 
-  
+
   describe('onSignInFailure()', () => {
     it('should log error message', () => {
       jest.spyOn($log, 'error').mockImplementation(() => {})
@@ -148,14 +148,14 @@ describe('oktaAuthCallback', function () {
     beforeEach(inject((_$q_, _$rootScope_) => {
       deferred = _$q_.defer()
       $rootScope = _$rootScope_
-      jest.spyOn($ctrl.sessionModalService, 'nonDismissibleRegisterAccount').mockReturnValue(deferred.promise)
+      jest.spyOn($ctrl.sessionModalService, 'registerAccount').mockReturnValue(deferred.promise)
       jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
     }));
 
     it('should open contact info modal and upon completing redirect to the previous page', () => {
       $ctrl.openContactInfoModalThenRedirect()
 
-      expect($ctrl.sessionModalService.nonDismissibleRegisterAccount).toHaveBeenCalled()
+      expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ dismissable: false })
 
       deferred.resolve()
       $rootScope.$digest()
@@ -347,7 +347,7 @@ describe('oktaAuthCallback', function () {
   });
 
 
-  
+
 
   describe('onSignInSuccess', () => {
     let deferred, $rootScope
@@ -357,7 +357,7 @@ describe('oktaAuthCallback', function () {
       jest.spyOn($ctrl, 'openUserMatchModalThenRedirect').mockImplementation(() => Observable.of({}))
       jest.spyOn($ctrl, 'openContactInfoModalThenRedirect').mockImplementation(() => Observable.of({}))
       jest.spyOn($ctrl, 'postDonorMatches').mockImplementation(() => Observable.of({}))
-      jest.spyOn($ctrl.sessionModalService, 'nonDismissibleRegisterAccount').mockReturnValue(deferred.promise)
+      jest.spyOn($ctrl.sessionModalService, 'registerAccount').mockReturnValue(deferred.promise)
       jest.spyOn($ctrl.sessionModalService, 'userMatch').mockReturnValue(deferred.promise)
       jest.spyOn($ctrl, 'redirectToLocationPriorToLogin')
     }))

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -74,13 +74,9 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       dismissAnalyticsEvent: 'ga-registration-exit'
     }).result,
     accountBenefits: (lastPurchaseId) => openModal('account-benefits', { resolve: { lastPurchaseId: () => lastPurchaseId }, size: 'sm' }).result,
-    registerAccount: () => openModal('register-account', {
-      backdrop: 'static',
-      keyboard: false
-    }).result,
-    nonDismissibleRegisterAccount: () => openModal('register-account', {
+    registerAccount: ({ dismissable = true } = {}) => openModal('register-account', {
       resolve: {
-        hideCloseButton: () => true
+        hideCloseButton: () => !dismissable
       },
       backdrop: 'static',
       keyboard: false

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -63,6 +63,7 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       resolve: {
         lastPurchaseId: () => lastPurchaseId
       },
+      backdrop: 'static',
       keyboard: false,
       openAnalyticsEvent: 'ga-sign-in',
       dismissAnalyticsEvent: 'ga-sign-in-exit'


### PR DESCRIPTION
## Changes
* Prevent clicking outside the sign in modal from closing it.
* Cleaned up `sessionModalService` by merging `nonDismissibleRegisterAccount` into `registerAccount` by making it accept a `dismissable` option that defaults to `true`.
* Some trailing whitespace added in another PR was automatically removed.