### PR TITLE
EP-2568 - Ensure Okta redirects back to Give after logout

### DIFF
--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -203,12 +203,13 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
         $window.sessionStorage.setItem(locationOnLogin, $window.location.href)
       }
 
-      return authClient.signOut({
-        postLogoutRedirectUri: redirectHome ? null : `${envService.read('oktaReferrer')}/sign-out.html`
-      }).catch(() => {
-        // If Okta sign out fails, redirect to Okta sign out page
-        $window.location.href = `${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}`
-      })
+      // We no longer use the below code because it doesn't redirect the user back to the Give site
+      // Instead, it redirects to the Okta sign in page.
+      // return authClient.signOut({
+      //   postLogoutRedirectUri: redirectHome ? null : `${envService.read('oktaReferrer')}/sign-out.html`
+      // })
+
+      $window.location.href = `${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}/sign-out.html`
     }
 
     return Observable.from($http({

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -203,12 +203,7 @@ const session = /* @ngInject */ function ($cookies, $rootScope, $http, $timeout,
         $window.sessionStorage.setItem(locationOnLogin, $window.location.href)
       }
 
-      // We no longer use the below code because it doesn't redirect the user back to the Give site
-      // Instead, it redirects to the Okta sign in page.
-      // return authClient.signOut({
-      //   postLogoutRedirectUri: redirectHome ? null : `${envService.read('oktaReferrer')}/sign-out.html`
-      // })
-
+      // Don't use authClient.signOut() as it doesn't redirect back to the Give site.
       $window.location.href = `${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}/sign-out.html`
     }
 

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -200,7 +200,7 @@ describe('session service', function () {
           .respond(200, {})
       })
 
-      it('makes a DELETE request to Cortex & sets postLogoutRedirectUri', done => {
+      it('makes a DELETE request to Cortex & redirects to Okta to sign out', done => {
         sessionService
           .signOut(false)
           .subscribe(() => {
@@ -210,7 +210,7 @@ describe('session service', function () {
         $httpBackend.flush()
       })
 
-      it('should revoke all tokens & run signOut returning the user home', done => {
+      it('should revoke all tokens & run redirect to Okta to sign out', done => {
         sessionService
           .signOut(true)
           .subscribe(() => {

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -210,7 +210,7 @@ describe('session service', function () {
         $httpBackend.flush()
       })
 
-      it('should revoke all tokens & run redirect to Okta to sign out', done => {
+      it('should revoke all tokens & redirect to Okta to sign out', done => {
         sessionService
           .signOut(true)
           .subscribe(() => {

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -203,11 +203,8 @@ describe('session service', function () {
       it('makes a DELETE request to Cortex & sets postLogoutRedirectUri', done => {
         sessionService
           .signOut(false)
-          .subscribe((response) => {
-            expect(response.data).toEqual({})
-            expect(sessionService.authClient.signOut).toHaveBeenCalledWith({
-              postLogoutRedirectUri: `https://localhost.cru.org:9000/sign-out.html`
-            })
+          .subscribe(() => {
+            expect($window.location.href).toEqual(`${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}/sign-out.html`)
             done()
           }, done)
         $httpBackend.flush()
@@ -219,23 +216,7 @@ describe('session service', function () {
           .subscribe(() => {
             expect(sessionService.authClient.revokeAccessToken).toHaveBeenCalled()
             expect(sessionService.authClient.revokeRefreshToken).toHaveBeenCalled()
-            expect(sessionService.authClient.signOut).toHaveBeenCalledWith({
-              postLogoutRedirectUri: null
-            })
-            done()
-          }, done)
-        $httpBackend.flush()
-      })
-
-      it('should still sign user out if error during signout', done => {
-        sessionService.authClient.signOut.mockRejectedValue()
-
-        sessionService
-          .signOut()
-          .subscribe(() => {
-            expect(sessionService.authClient.revokeAccessToken).toHaveBeenCalled()
-            expect(sessionService.authClient.revokeRefreshToken).toHaveBeenCalled()
-            expect(sessionService.authClient.signOut).toHaveBeenCalled()
+            expect($window.location.href).toEqual(`${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}/sign-out.html`)
             done()
           }, done)
         $httpBackend.flush()
@@ -263,18 +244,6 @@ describe('session service', function () {
           .signOut(false)
           .subscribe(() => {
             expect($window.sessionStorage.getItem(forcedUserToLogout)).toEqual('true')
-            done()
-          }, done)
-        $httpBackend.flush()
-      })
-
-      it('should redirect the user to okta if all else fails', done => {
-        sessionService.authClient.signOut.mockRejectedValue()
-
-        sessionService
-          .signOut()
-          .subscribe(() => {
-            expect($window.location.href).toEqual(`${envService.read('oktaUrl')}/login/signout?fromURI=${envService.read('oktaReferrer')}`)
             done()
           }, done)
         $httpBackend.flush()


### PR DESCRIPTION
## Description
In this PR, I fix the redirection after signing out. Previously, the user would be kept on the Okta site when signing out. This fix ensures the user is redirected back to the Give site.

We are using the same link to sign out as we do on other applications like MPDX, so I know this will log them out of all instances of their Okta account on the browser before returning them to the Give site.

Jira Task: [EP-2568](https://jira.cru.org/browse/EP-2568)