### PR TITLE
EP-2561 fix modal width

### DIFF
--- a/src/assets/crubrand/_overrides.scss
+++ b/src/assets/crubrand/_overrides.scss
@@ -569,7 +569,7 @@ $modal-header-border-color:           #e5e5e5;
 $modal-footer-border-color:           $modal-header-border-color;
 
 $modal-lg:                            900px;
-$modal-md:                            530px;
+$modal-md:                            600px;
 $modal-sm:                            300px;
 
 


### PR DESCRIPTION
## Description
In this PR, I remove an edit previously made on the branch 2362-okta branch by another developer (a035561cfd8bbde8986e473ffde0ccd0a4ca0dba).

### History:
When the width was first changed, Bill asked for it to be reverted and styles to be added to the modal(s) that were affected instead of changing the width on all modals.

It was left added, and from briefly investigating, no styles were added to the modals that were affected. Though I could be wrong.
_This is most likely a result of different devs getting assigned to this project and small things like this falling through the cracks of ownership change._

### Changes
I have reverted the width change, which fixes the modals that had overflow issues.

Since the edit of the modal width, we have completely changed the design of the signup modal. Upon investigating, I don't see the issue of having the width as it originally was.