### PR TITLE
EP-2583 - Prevent Okta from concealing the form.

### DIFF
--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -49,6 +49,8 @@ sign-up-modal {
   }
 
   &.main-container {
+    // Fix to prevent Okta hiding form - EP-2583
+    display: block !important;    
     box-shadow: none;
   }
 


### PR DESCRIPTION
## Description
Prevent Okta from concealing the form. Initially, I believed the form was not loading or that an error had occurred. However, it turned out that Okta was hiding the form instead.

Jira: [EP-2583](https://jira.cru.org/browse/EP-2583)
### Steps to replicate:
1. Open up the modal and complete the form, getting to step 3.
2. Close the modal and re-open it.
3. Step through to step 2, then go back to the previous step.
4. The form will no longer load.

### Changes
Added a style which ensures the form is displayed.