### PR TITLE
[EP-2583] Cleanup event listeners in signUpModal destructor

### DIFF
--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -66,7 +66,11 @@ class SignUpModalController {
   }
 
   $onDestroy () {
-    this.oktaSignInWidget?.remove()
+    if (this.oktaSignInWidget) {
+      this.oktaSignInWidget.remove()
+      // Unsubscribe all event listeners
+      this.oktaSignInWidget.off()
+    }
     if (angular.isDefined(this.getDonorDetailsSubscription)) {
       this.getDonorDetailsSubscription.unsubscribe()
     }


### PR DESCRIPTION
## Bug

`this.oktaSignInWidget.remove()` does not unsubscribe from event listeners. When users advanced past step 1, then closed the form and reopened it, the `afterRender` function from the closed modal would run as well as the `afterRender` function from the current modal. That was causing the back button to show up on step 1 as well as other issues.

## Fix

Unsubscribe from all event listeners when the `signUpModal` component is unmounted.

### Steps to replicate:
1. Open up the modal and complete the form, getting to step 3.
2. Close the modal and re-open it.
3. Step through to step 2, then go back to the previous step.
4. The form will no longer load.

The reproduction for this bug was provided by @dr-bizz in #1191. This PR just fixes the underlying issue finally reproduced there.

EP-2583