### PR TITLE
[HS-1332280] Expand designation editor input

### DIFF
--- a/src/app/designationEditor/designationEditor.scss
+++ b/src/app/designationEditor/designationEditor.scss
@@ -1,3 +1,7 @@
 .designation-editor-paragraph-text{
   min-height: 90px;
 }
+
+.ta-editor {
+  height: auto;
+}

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -31,3 +31,6 @@
 @import 'mobile';
 @import 'nav-cart';
 @import 'carousel';
+
+// TODO: Remove this manual import when we figure out why styles imported in components are not being added to the page
+@import '../../app/designationEditor/designationEditor';


### PR DESCRIPTION
Expand the designation editor input instead of letting it be set to `39px` by the `.form-control`.

The `import './designationEditor.scss'` wasn't doing anything. The `designationEditor.scss` styles weren't being included in the CSS bundle. I'm using a SCSS `@import` now instead.

Also, something is messed up with my staging account. I can't login with The Key locally and when I login with Okta in staging, I get a 403 Forbidden error when accessing the designation editor. I was only able to test by setting up local overrides pointing to the `give-web` `dist/` directory. Someone should probably test this in staging without overrides if possible.

https://secure.helpscout.net/conversation/2888678022/1332280