### PR TITLE
[EP-2585] Upgrade style-loader to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "sass": "^1.49.0",
     "sass-loader": "^10",
     "standard": "^16.0.4",
-    "style-loader": "^1.0.0",
+    "style-loader": "^2.0.0",
     "stylelint": "^16.14.1",
     "stylelint-config-idiomatic-order": "^10.0.0",
     "stylelint-config-standard": "^37.0.0",

--- a/src/app/designationEditor/designationEditor.scss
+++ b/src/app/designationEditor/designationEditor.scss
@@ -1,7 +1,3 @@
 .designation-editor-paragraph-text{
   min-height: 90px;
 }
-
-.ta-editor {
-  height: auto;
-}

--- a/src/assets/scss/styles.scss
+++ b/src/assets/scss/styles.scss
@@ -32,6 +32,3 @@
 @import 'nav-cart';
 @import 'carousel';
 @import 'directives/creditCardCvv';
-
-// TODO: Remove this manual import when we figure out why styles imported in components are not being added to the page
-@import '../../app/designationEditor/designationEditor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9370,14 +9370,6 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.1.0.tgz#940363b6b1ec407800a22951bdcc23363c039393"
-  integrity sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
-
 schema-utils@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
@@ -10143,13 +10135,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.0.0.tgz#1d5296f9165e8e2c85d24eee0b7caf9ec8ca1f82"
-  integrity sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==
+style-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-2.0.0.tgz#9669602fd4690740eaaec137799a03addbbc393c"
+  integrity sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==
   dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.0.1"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Description

When #1171 upgraded `mini-css-extract-plugin`, it neglected to also update `style-loader` to v2, as recommended in the [release notes](https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/CHANGELOG.md#-notice). The result was that stylesheets imported from JS files were not being injected into the DOM.

## Testing

* On `master`
  * Go to https://localhost.cru.org:9000/cart.html
  * See that the loading component for "Loading your gifts..." renders as unstyled text.
* On this branch
  * Go to https://localhost.cru.org:9000/cart.html
  * See that the loading component is correctly styled. The text should be centered and have animated bars.

EP-2585