### PR TITLE
2362 okta optional mfa click

### DIFF
--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -459,6 +459,18 @@ class SignUpModalController {
       this.showVerificationCodeField()
     }
 
+    // Step 5: Optional MFA setup
+    if (context.formName === 'select-authenticator-enroll') {
+      // As Okta enforces the MFA screen to be shown during sign up, we need to skip it.
+      // This step does not have good UX as it's long, causing users to scroll to see the continue button.
+      // We are okay with skipping this step as users can set up MFA later.
+      this.$scope.$apply(() => {
+        this.isLoading = true
+        this.currentStep = 5
+      })
+      this.skipOptionalMFAOptions()
+    }
+
     // All steps
     this.updateSignUpButtonText()
     this.resetCurrentStepOnRegistrationComplete(context)
@@ -489,6 +501,13 @@ class SignUpModalController {
     // This makes the process of creating an account more streamlined as we remove that click.
     const verificationCodeButtonLink = document.querySelector('.button-link.enter-auth-code-instead-link')
     verificationCodeButtonLink?.click()
+  }
+
+  skipOptionalMFAOptions () {
+    // As Okta enforces the MFA screen to be shown during sign up, we need to skip it to streamline the process.
+    // The user can setup MFA at a later date in their account settings.
+    const skipMFAButton = document.querySelector('.authenticator-enroll-list-container .button.skip-all')
+    skipMFAButton?.click()
   }
 
   updateSignUpButtonText () {

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -468,7 +468,7 @@ class SignUpModalController {
         this.isLoading = true
         this.currentStep = 5
       })
-      this.skipOptionalMFAOptions()
+      this.skipOptionalMFAEnrollment()
     }
 
     // All steps
@@ -503,11 +503,17 @@ class SignUpModalController {
     verificationCodeButtonLink?.click()
   }
 
-  skipOptionalMFAOptions () {
-    // As Okta enforces the MFA screen to be shown during sign up, we need to skip it to streamline the process.
-    // The user can setup MFA at a later date in their account settings.
-    const skipMFAButton = document.querySelector('.authenticator-enroll-list-container .button.skip-all')
-    skipMFAButton?.click()
+  skipOptionalMFAEnrollment () {
+    // Hide MFA options while we wait for the redirect to happen.
+    // The loading icon will be shown, so the user will know something is happening.
+    const mfaOptions = document.querySelector('.select-authenticator-enroll')
+    if (mfaOptions) {
+      mfaOptions.style.display = 'none'
+      // As Okta enforces the MFA screen to be shown during sign up, we need to skip it to streamline the process.
+      // The user can setup MFA at a later date in their account settings.
+      const skipMFAButton = mfaOptions.querySelector('.button.skip-all')
+      skipMFAButton?.click()
+    }
   }
 
   updateSignUpButtonText () {

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -909,6 +909,7 @@ describe('signUpForm', function () {
         jest.spyOn($ctrl, 'injectErrorMessages').mockImplementation(() => {});
         jest.spyOn($ctrl, 'injectBackButton').mockImplementation(() => {});
         jest.spyOn($ctrl, 'showVerificationCodeField').mockImplementation(() => {});
+        jest.spyOn($ctrl, 'skipOptionalMFAEnrollment').mockImplementation(() => {});
 
         $ctrl.$onInit()
       })
@@ -928,6 +929,14 @@ describe('signUpForm', function () {
 
         expect($ctrl.currentStep).toBe(4)
         expect($ctrl.showVerificationCodeField).toHaveBeenCalled()
+      })
+
+      it('shows the loading screen and skips the MFA enroll', () => {
+        $ctrl.afterRender({ formName: 'select-authenticator-enroll' })
+
+        expect($ctrl.currentStep).toBe(5)
+        expect($ctrl.isLoading).toBeTruthy()
+        expect($ctrl.skipOptionalMFAEnrollment).toHaveBeenCalled()
       })
     });
 
@@ -1034,33 +1043,59 @@ describe('signUpForm', function () {
     });
   });
 
-  describe('showVerificationCodeField()', () => {
+  describe('AfterRender JS Triggers', () => {
     const handleClick = jest.fn();
     window.handleClick = handleClick;
     beforeEach(() => {
       handleClick.mockClear();
     })
 
-    it('should call handleClick when button link is rendered', () => {
-      document.body.innerHTML = `
-        <div>
-          <button class="button-link enter-auth-code-instead-link" onclick="handleClick()">
-            Enter authentication code instead
-          </button>
-        </div>
-      `;
+    describe('showVerificationCodeField()', () => {
+      it('should call handleClick when button link is rendered', () => {
+        document.body.innerHTML = `
+          <div>
+            <button class="button-link enter-auth-code-instead-link" onclick="handleClick()">
+              Enter authentication code instead
+            </button>
+          </div>
+        `;
 
-      $ctrl.showVerificationCodeField()
-      expect(handleClick).toHaveBeenCalled();
+        $ctrl.showVerificationCodeField()
+        expect(handleClick).toHaveBeenCalled();
+      });
+
+      it("shouldn't call handleClick if button link is not rendered", () => {
+        document.body.innerHTML = `
+          <div>Something else</div>
+        `;
+
+        $ctrl.showVerificationCodeField()
+        expect(handleClick).not.toHaveBeenCalled();
+      });
     });
 
-    it("shouldn't call handleClick if button link is not rendered", () => {
-      document.body.innerHTML = `
-        <div>Something else</div>
-      `;
+    describe('skipOptionalMFAEnrollment()', () => {
+      it('should call handleClick when button link is rendered', () => {
+        document.body.innerHTML = `
+          <div class="select-authenticator-enroll">
+            <a class="button skip-all" onclick="handleClick()">
+              Continue
+            </a>
+          </div>
+        `;
 
-      $ctrl.showVerificationCodeField()
-      expect(handleClick).not.toHaveBeenCalled();
+        $ctrl.skipOptionalMFAEnrollment()
+        expect(handleClick).toHaveBeenCalled();
+      });
+
+      it("shouldn't call handleClick if button link is not rendered", () => {
+        document.body.innerHTML = `
+          <div>Something else</div>
+        `;
+
+        $ctrl.skipOptionalMFAEnrollment()
+        expect(handleClick).not.toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
## Description
Currently, Okta requires us to show you the MFA options during sign-up. Jason Buckner is trying to remove them, but in the meantime, I have made it so we can skip past this step, so the user doesn't get caught in this step while signing up.

We skip the Optional MFA enroll step by clicking the "Continue" button via JS and then hiding the MFA enroll HTML to not confuse the user.

### Testing
- Sign up as usual, entering your verification code.
- When you click "Submit", a loading screen will show, and then you will be taken to Okta to log in.