### PR TITLE
Sets overflow-y of .modal to scroll

### DIFF
--- a/src/assets/scss/_gift-config.scss
+++ b/src/assets/scss/_gift-config.scss
@@ -146,6 +146,7 @@ label.btn.btn-default-form.active {
 .modal {
   display: none;
   overflow: hidden;
+  overflow-y: scroll;
   position: fixed;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Adding overflow-y attribute and setting it to `scroll` will override the current value `hidden` for overflow allowing the user to scroll to the "Add Payment Method" button.