### PR TITLE
EP-2598 - Add option to send email address to Okta on login

### DIFF
--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -808,7 +808,7 @@ class SignUpModalController {
   }
 
   redirectToOktaForLogin () {
-    this.sessionService.signIn(this.lastPurchaseId).subscribe(() => {})
+    this.sessionService.signIn(this.lastPurchaseId, this.$scope.email).subscribe(() => {})
   }
 }
 

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -1590,8 +1590,9 @@ describe('signUpForm', function () {
 
   describe('redirectToOktaForLogin', () => {
     it('should call sessionService.signIn', () => {
+      $ctrl.$scope.email = user.email
       $ctrl.redirectToOktaForLogin()
-      expect($ctrl.sessionService.signIn).toHaveBeenCalledWith($ctrl.lastPurchaseId)
+      expect($ctrl.sessionService.signIn).toHaveBeenCalledWith($ctrl.lastPurchaseId, user.email)
     })
   })
 })

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -123,10 +123,10 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
     }
   }
 
-  function signIn (lastPurchaseId) {
+  function signIn (lastPurchaseId, emailAddress) {
     session.isOktaRedirecting = true
     return new Observable(observer => {
-      internalSignIn(lastPurchaseId)
+      internalSignIn(lastPurchaseId, emailAddress)
         .finally(() => {
           $rootScope.$broadcast(SignInEvent)
         })
@@ -148,13 +148,13 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
     })
   }
 
-  function internalSignIn (lastPurchaseId) {
+  function internalSignIn (lastPurchaseId, emailAddress) {
     return new Observable(observer => {
       authClient.isAuthenticated()
         .then(isAuthenticated => {
           if (!isAuthenticated) {
             setRedirectingOnLogin()
-            return authClient.token.getWithRedirect()
+            return authClient.token.getWithRedirect(emailAddress ? { loginHint: emailAddress } : undefined)
           }
           return authClient.tokenManager.getTokens()
         })

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -267,13 +267,16 @@ describe('session service', function () {
       jest.spyOn($rootScope, '$broadcast')
       jest.spyOn(sessionService.authClient, 'isAuthenticated').mockResolvedValueOnce(false)
       jest.spyOn(sessionService.authClient.token, 'getWithRedirect').mockResolvedValue(undefined)
-
-      sessionService.signIn('lastPurchaseId-SignInEvent').subscribe();
+      const loginHint = 'test@cru.org';
+      sessionService.signIn('lastPurchaseId-SignInEvent', loginHint).subscribe();
 
       // Observable.finally is fired after the test, this defers until it's called.
       // eslint-disable-next-line angular/timeout-service
       setTimeout(() => {
         expect($rootScope.$broadcast).toHaveBeenCalledWith(SignInEvent)
+        expect(sessionService.authClient.token.getWithRedirect).toHaveBeenCalledWith({
+          loginHint
+        })
         done()
       })
     })


### PR DESCRIPTION
## Description
Add an option to allow an email address to be sent to Okta during login.

The reason for this is to eliminate a step in the sign-up process where we require users to re-enter their email address. We found that people were entering their email incorrectly and getting stuck, as the password field does not provide much guidance when an incorrect email or password is entered.
