### PR TITLE
EP-2600 - Add repeat passcode field to sign up

### DIFF
--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -394,7 +394,8 @@ export const appConfig = /* @ngInject */ function (envServiceProvider, $compileP
     OKTA_FIRST_NAME_FIELD: 'first name',
     OKTA_LAST_NAME_FIELD: 'last name',
     OKTA_EMAIL_FIELD: 'email',
-    OKTA_PASSWORD_FIELD: 'password'
+    OKTA_PASSWORD_FIELD: 'password',
+    PASSWORD_DOES_NOT_MATCH: 'Passwords do not match. Please try again.'
   })
 
   $translateProvider.translations('es', {
@@ -617,7 +618,8 @@ export const appConfig = /* @ngInject */ function (envServiceProvider, $compileP
     OKTA_FIRST_NAME_FIELD: 'first name',
     OKTA_LAST_NAME_FIELD: 'last name',
     OKTA_EMAIL_FIELD: 'email',
-    OKTA_PASSWORD_FIELD: 'password'
+    OKTA_PASSWORD_FIELD: 'password',
+    PASSWORD_DOES_NOT_MATCH: 'Passwords do not match. Please try again.'
   })
   $translateProvider.preferredLanguage('en')
 }

--- a/src/common/components/signUpModal/signUpFormCustomFields.js
+++ b/src/common/components/signUpModal/signUpFormCustomFields.js
@@ -127,5 +127,18 @@ export const customFields = {
     showWhen: {
       'userProfile.countryCode': 'US'
     }
-  }
+  },
+  repeatPasscode: {
+    name: 'passcodeVerification.repeatPasscode',
+    type: 'password',
+    label: 'Repeat password',
+    required: true,
+    secret: true,
+    'label-top': true,
+    multirowError: true,
+    'data-se': 'o-form-fieldset-passcodeVerification.repeatPasscode',
+    "params": {
+          "showPasswordToggle": true
+     }
+  },
 }

--- a/src/common/components/signUpModal/signUpFormCustomFields.js
+++ b/src/common/components/signUpModal/signUpFormCustomFields.js
@@ -137,8 +137,8 @@ export const customFields = {
     'label-top': true,
     multirowError: true,
     'data-se': 'o-form-fieldset-passcodeVerification.repeatPasscode',
-    "params": {
-          "showPasswordToggle": true
-     }
-  },
+    params: {
+      showPasswordToggle: true
+    }
+  }
 }

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -224,7 +224,7 @@ class SignUpModalController {
     ]
   }
 
-  getStep2Fields (schema) {
+  getStep2Fields () {
     // Retain the values entered by the user when navigating between steps.
     // Pre-populate the form fields with existing user details.
     return [

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -174,16 +174,16 @@ class SignUpModalController {
   }
 
   getSteps (schema) {
-    const passwordInput = schema.find(field => field.name === 'credentials.passcode')
+    const passcodeInput = schema.find(field => field.name === 'credentials.passcode')
     return {
       // Step 1: Name, email, account type and organization name (if applicable)
       1: this.getStep1Fields(schema),
       // Step 2: Address
-      2: this.getStep2Fields(schema),
+      2: this.getStep2Fields(),
       // Step 3: Password (We don't save the password for security reasons.
       // Which is why it's the last step)
       3: [
-        passwordInput,
+        passcodeInput,
         customFields.repeatPasscode
       ]
     }

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -428,7 +428,7 @@ class SignUpModalController {
 
     // Add the user profile to the postData object
     // Okta widget handles the password
-    delete postData.passcodeVerification;
+    delete postData.passcodeVerification
     postData.userProfile = {
       firstName: this.$scope.firstName,
       lastName: this.$scope.lastName,

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -832,28 +832,74 @@ describe('signUpForm', function () {
     });
 
 
-    it('submitFinalData()', () => {
-      const postData = {};
-      $ctrl.currentStep = 3;
-      $ctrl.$scope.firstName = user.firstName
-      $ctrl.$scope.lastName = user.lastName
-      $ctrl.$scope.email = user.email
-      $ctrl.$scope.accountType = user.accountType
-      $ctrl.$scope.streetAddress = user.streetAddress
-      $ctrl.$scope.city = user.city
-      $ctrl.$scope.state = user.state
-      $ctrl.$scope.zipCode = user.zipCode
-      $ctrl.$scope.countryCode = user.countryCode
-      $ctrl.$scope.organizationName = user.organizationName
-
-      $ctrl.preSubmit(postData, onSuccess);
-
-      expect(onSuccess).toHaveBeenCalledWith({
-        userProfile: {
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
+    describe('submitFinalData()', () => {
+      it('should error when passwords are not the same', () => {
+        const postData = {
+          credentials: {
+            passcode: 'passcode',
+          },
+          passcodeVerification: {
+            repeatPasscode: 'differentPassword'
+          }
+        };
+        $ctrl.currentStep = 3;
+        $ctrl.$scope.firstName = user.firstName
+        $ctrl.$scope.lastName = user.lastName
+        $ctrl.$scope.email = user.email
+        $ctrl.$scope.accountType = user.accountType
+        $ctrl.$scope.streetAddress = user.streetAddress
+        $ctrl.$scope.city = user.city
+        $ctrl.$scope.state = user.state
+        $ctrl.$scope.zipCode = user.zipCode
+        $ctrl.$scope.countryCode = user.countryCode
+        $ctrl.$scope.organizationName = user.organizationName
+        $ctrl.translations = {
+          passwordDoesNotMatch: 'Passwords do not match. Please try again.',
         }
+  
+        $ctrl.preSubmit(postData, onSuccess);
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect($ctrl.injectErrorMessages).toHaveBeenCalledWith([
+          {
+            errorSummary: $ctrl.translations.passwordDoesNotMatch,
+            property: 'passcodeVerification.repeatPasscode'
+          }
+        ])
+      });
+
+      it('should call onSuccess when passwords are the same', () => {
+        const postData = {
+          credentials: {
+            passcode: 'passcode',
+          },
+          passcodeVerification: {
+            repeatPasscode: 'passcode'
+          }
+        };
+        $ctrl.currentStep = 3;
+        $ctrl.$scope.firstName = user.firstName
+        $ctrl.$scope.lastName = user.lastName
+        $ctrl.$scope.email = user.email
+        $ctrl.$scope.accountType = user.accountType
+        $ctrl.$scope.streetAddress = user.streetAddress
+        $ctrl.$scope.city = user.city
+        $ctrl.$scope.state = user.state
+        $ctrl.$scope.zipCode = user.zipCode
+        $ctrl.$scope.countryCode = user.countryCode
+        $ctrl.$scope.organizationName = user.organizationName
+
+        $ctrl.preSubmit(postData, onSuccess);
+
+        expect(onSuccess).toHaveBeenCalledWith({
+          credentials: postData.credentials,
+          userProfile: {
+            firstName: user.firstName,
+            lastName: user.lastName,
+            email: user.email,
+          }
+        });
+        expect($ctrl.injectErrorMessages).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## Description
In this PR, I have added a repeat password/passcode field to the sign-up process. The reason for this change is that 1. DSG has been advocating for it, and we found that many people were forgetting their password when they accessed Okta.

I was initially opposed to adding the repeat passcode as it introduces another field, and I do not want to save the password anywhere. However, I have discovered a method to implement it without storing the password. If we later find the repeat passcode field to be annoying, we can remove it.