### PR TITLE
[EP-2362] Add label to loading indicator before redirecting

### DIFF
--- a/src/assets/scss/components/_signUpModal.scss
+++ b/src/assets/scss/components/_signUpModal.scss
@@ -35,6 +35,10 @@ sign-up-modal {
 
   .okta-signup-loading {
     padding: 153px 0;
+
+    .loading-message {
+      padding-bottom: 0.5rem;
+    }
   }
 
   form {

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -394,7 +394,8 @@ export const appConfig = /* @ngInject */ function (envServiceProvider, $compileP
     OKTA_FIRST_NAME_FIELD: 'first name',
     OKTA_LAST_NAME_FIELD: 'last name',
     OKTA_EMAIL_FIELD: 'email',
-    OKTA_PASSWORD_FIELD: 'password'
+    OKTA_PASSWORD_FIELD: 'password',
+    OKTA_REGISTERING: 'Creating your Okta account and preparing to redirect you to Okta to log in...'
   })
 
   $translateProvider.translations('es', {
@@ -617,7 +618,8 @@ export const appConfig = /* @ngInject */ function (envServiceProvider, $compileP
     OKTA_FIRST_NAME_FIELD: 'first name',
     OKTA_LAST_NAME_FIELD: 'last name',
     OKTA_EMAIL_FIELD: 'email',
-    OKTA_PASSWORD_FIELD: 'password'
+    OKTA_PASSWORD_FIELD: 'password',
+    OKTA_REGISTERING: 'Creating your Okta account and preparing to redirect you to Okta to log in...'
   })
   $translateProvider.preferredLanguage('en')
 }

--- a/src/common/components/signUpModal/signUpModal.tpl.html
+++ b/src/common/components/signUpModal/signUpModal.tpl.html
@@ -54,8 +54,10 @@
         />
       </div>
     </div>
-    
-    <loading ng-if="$ctrl.isLoading" class="okta-signup-loading"></loading>
+
+    <loading ng-if="$ctrl.isLoading" class="okta-signup-loading">
+      <div ng-if="$ctrl.currentStep === 5" class="loading-message" translate>OKTA_REGISTERING</div>
+    </loading>
 
     <div id="osw-container"></div>
   </div>


### PR DESCRIPTION
After the user submits the verification code, a loading indicator appears for a few seconds before redirecting to Okta. This PR adds a label to that loading indicator so that the user is aware of what is loading and is less confused when they are redirected.

@rguinee Do you have thoughts on the message I used?