### PR TITLE
[no-Jira] Continue building styles with stylelint errors in development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,6 @@ const sharedConfig = {
             configFile: path.resolve(__dirname, 'stylelint.config.mjs'),
             context: 'src/assets/scss',
             files: '**/*.(css|scss)',
-            failOnError: true,
             quiet: false
           })
         ]),


### PR DESCRIPTION
This change lets the build proceed even if there are lint errors during development. We are running `stylelint` in CI, so we will catch any style lint errors before deploying. I think that devs should be able to add rules like `background-color: red` locally during development as long as they are removed before submitting a PR.