### PR TITLE
[HS-1354646] Remove Grouping and Sorting unless Featured

### DIFF
--- a/src/app/searchResults/searchResults.tpl.html
+++ b/src/app/searchResults/searchResults.tpl.html
@@ -113,7 +113,10 @@
                     </ul>
                   </section>
 
-                  <div ng-repeat-start="(k,hits) in hits | orderBy:$ctrl.featuredGroupBy:(facet === 'featured' && $ctrl.featuredGroupBy === 'startMonth') | groupBy:$ctrl.featuredGroupBy">
+                  <div ng-repeat-start="(k, hits) in (facet === 'featured' 
+                    ? (hits | orderBy:$ctrl.featuredGroupBy:($ctrl.featuredGroupBy === 'startMonth') 
+                      | groupBy:$ctrl.featuredGroupBy) 
+                    : { '': hits })">
                     <h4 class="is-results-divider" ng-if="facet === 'featured' && $ctrl.featuredGroupBy === 'startMonth'">
                       {{k | date:'LLLL yyyy'}}
                     </h4>


### PR DESCRIPTION
https://secure.helpscout.net/conversation/2924841982/1354646?viewId=7669074

Problem:
Results are being grouped and ordered by date on a default search. This should only happen when in the featured section.


Changes:
* Check if the facet === 'featured' before grouping and ordering the results