### PR TITLE
[EP-2603] Use register account modal on thank you page

### DIFF
--- a/src/app/thankYou/accountBenefits/accountBenefits.component.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.js
@@ -40,7 +40,7 @@ class AccountBenefitsController {
     this.sessionService.oktaIsUserAuthenticated().subscribe((isAuthenticated) => {
       const registrationState = this.donorDetails['registration-state']
       if (isAuthenticated && registrationState === 'NEW') {
-        return this.sessionModalService.registerAccount(lastPurchaseId).then(() => {
+        return this.sessionModalService.registerAccount({ lastPurchaseId }).then(() => {
           this.isVisible = false
         }, angular.noop)
       } else if (isAuthenticated && registrationState === 'MATCHED') {
@@ -62,7 +62,7 @@ class AccountBenefitsController {
     if (this.sessionService.getRole() === Roles.registered) {
       this.sessionModalService.userMatch()
     } else {
-      this.sessionModalService.registerAccount(this.getLastPurchaseId()).then(() => {
+      this.sessionModalService.registerAccount({ lastPurchaseId: this.getLastPurchaseId() }).then(() => {
         this.sessionModalService.userMatch().then(() => {
           // Hide component after successful user match
           this.isVisible = false

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.js
@@ -35,7 +35,7 @@ class AccountBenefitsController {
     const lastPurchaseId = this.getLastPurchaseId()
     return this.sessionService.oktaIsUserAuthenticated().subscribe((isAuthenticated) => {
       const registrationState = this.donorDetails['registration-state']
-      if (lastPurchaseId && registrationState !== 'COMPLETED') {
+      if (lastPurchaseId) {
         if (isAuthenticated && registrationState === 'NEW') {
           return this.sessionModalService.registerAccount(lastPurchaseId).then(() => {
             this.isVisible = false

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.js
@@ -33,22 +33,24 @@ class AccountBenefitsController {
 
   openAccountBenefitsModal () {
     const lastPurchaseId = this.getLastPurchaseId()
-    return this.sessionService.oktaIsUserAuthenticated().subscribe((isAuthenticated) => {
+    if (!lastPurchaseId) {
+      return
+    }
+
+    this.sessionService.oktaIsUserAuthenticated().subscribe((isAuthenticated) => {
       const registrationState = this.donorDetails['registration-state']
-      if (lastPurchaseId) {
-        if (isAuthenticated && registrationState === 'NEW') {
-          return this.sessionModalService.registerAccount(lastPurchaseId).then(() => {
-            this.isVisible = false
-          }, angular.noop)
-        } else if (isAuthenticated && registrationState === 'MATCHED') {
-          return this.sessionModalService.userMatch(lastPurchaseId).then(() => {
-            this.isVisible = false
-          }, angular.noop)
-        } else {
-          return this.sessionModalService.accountBenefits(lastPurchaseId).then(() => {
-            this.isVisible = false
-          }, angular.noop)
-        }
+      if (isAuthenticated && registrationState === 'NEW') {
+        return this.sessionModalService.registerAccount(lastPurchaseId).then(() => {
+          this.isVisible = false
+        }, angular.noop)
+      } else if (isAuthenticated && registrationState === 'MATCHED') {
+        return this.sessionModalService.userMatch(lastPurchaseId).then(() => {
+          this.isVisible = false
+        }, angular.noop)
+      } else {
+        return this.sessionModalService.accountBenefits(lastPurchaseId).then(() => {
+          this.isVisible = false
+        }, angular.noop)
       }
     },
     error => {

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
@@ -4,7 +4,6 @@ import module from './accountBenefits.component'
 import { Observable } from 'rxjs/Observable'
 import 'rxjs/add/observable/from'
 import 'rxjs/add/observable/throw'
-import { Roles } from 'common/services/session/session.service'
 
 describe('thank you', function () {
   describe('accountBenefits', function () {
@@ -36,25 +35,25 @@ describe('thank you', function () {
 
     describe('$onChanges', () => {
       beforeEach(() => {
-        jest.spyOn($ctrl, 'openAccountBenefitsModal').mockImplementation(() => {})
+        jest.spyOn($ctrl, 'openModal').mockImplementation(() => {})
       })
 
       it('is visible when registration-state is \'MATCHED\'', () => {
         $ctrl.$onChanges({ donorDetails: { currentValue: { 'registration-state': 'MATCHED' } } })
 
         expect($ctrl.isVisible).toEqual(true)
-        expect($ctrl.openAccountBenefitsModal).toHaveBeenCalled()
+        expect($ctrl.openModal).toHaveBeenCalled()
       })
 
       it('is not visible when registration-state is \'COMPLETED\'', () => {
         $ctrl.$onChanges({ donorDetails: { currentValue: { 'registration-state': 'COMPLETED' } } })
 
         expect($ctrl.isVisible).toEqual(false)
-        expect($ctrl.openAccountBenefitsModal).not.toHaveBeenCalled()
+        expect($ctrl.openModal).not.toHaveBeenCalled()
       })
     })
 
-    describe('openAccountBenefitsModal', () => {
+    describe('openModal', () => {
       let deferred, $rootScope, userMatch
       beforeEach(inject((_$q_, _$rootScope_) => {
         deferred = _$q_.defer()
@@ -70,7 +69,7 @@ describe('thank you', function () {
       it('shows userMatch modal to users who are authenticated but need to complete donor matching', (done) => {
         $ctrl.sessionService.oktaIsUserAuthenticated.mockReturnValue(Observable.from([true]))
         $ctrl.donorDetails = { 'registration-state': 'MATCHED' }
-        $ctrl.openAccountBenefitsModal()
+        $ctrl.openModal()
 
         expect($ctrl.sessionModalService.userMatch).toHaveBeenCalledWith(lastPurchaseId)
         deferred.resolve()
@@ -82,7 +81,7 @@ describe('thank you', function () {
       it('shows registerAccount modal to users who are authenticated but need to register for a donor account', () => {
         $ctrl.sessionService.oktaIsUserAuthenticated.mockReturnValue(Observable.from([true]))
         $ctrl.donorDetails = { 'registration-state': 'NEW' }
-        $ctrl.openAccountBenefitsModal()
+        $ctrl.openModal()
 
         expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ lastPurchaseId })
         deferred.resolve()
@@ -90,10 +89,22 @@ describe('thank you', function () {
         expect($ctrl.isVisible).toEqual(false)
       })
 
-      it('shows accountBenefits modal to users who aren\'t authenticated', () => {
+      it('shows registerAccount modal to users who aren\'t authenticated', () => {
         $ctrl.sessionService.oktaIsUserAuthenticated.mockReturnValue(Observable.from([false]))
         $ctrl.donorDetails = { 'registration-state': 'NEW' }
-        $ctrl.openAccountBenefitsModal()
+        $ctrl.openModal()
+
+        expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ lastPurchaseId, signUp: true })
+        deferred.resolve()
+        $rootScope.$digest()
+
+        expect($ctrl.isVisible).toEqual(false)
+      })
+
+      it('shows accountBenefits modal to users who aren\'t authenticated when defaultToAccountBenefits is true', () => {
+        $ctrl.sessionService.oktaIsUserAuthenticated.mockReturnValue(Observable.from([false]))
+        $ctrl.donorDetails = { 'registration-state': 'NEW' }
+        $ctrl.openModal(true)
 
         expect($ctrl.sessionModalService.accountBenefits).toHaveBeenCalledWith(lastPurchaseId)
         deferred.resolve()
@@ -105,7 +116,7 @@ describe('thank you', function () {
       it('should not show accountBenefits modal if purchase link is missing', () => {
         $ctrl.orderService.retrieveLastPurchaseLink.mockReturnValue(undefined)
         $ctrl.donorDetails = { 'registration-state': 'NEW' }
-        $ctrl.openAccountBenefitsModal()
+        $ctrl.openModal()
 
         expect($ctrl.sessionModalService.accountBenefits).not.toHaveBeenCalled()
       })
@@ -113,39 +124,9 @@ describe('thank you', function () {
       it('should log an error', () => {
         const error = 'Unknown error'
         $ctrl.sessionService.oktaIsUserAuthenticated.mockReturnValue(Observable.throw(error))
-        $ctrl.openAccountBenefitsModal()
+        $ctrl.openModal()
 
         expect($ctrl.$log.error.logs[0]).toEqual(['Failed checking if user is authenticated', error])
-      })
-    })
-
-    describe('doUserMatch()', () => {
-      let deferred, $rootScope
-        beforeEach(inject((_$q_, _$rootScope_) => {
-          deferred = _$q_.defer()
-          $rootScope = _$rootScope_
-          jest.spyOn($ctrl.sessionModalService, 'registerAccount').mockReturnValue(deferred.promise)
-          jest.spyOn($ctrl.sessionModalService, 'userMatch').mockReturnValue(deferred.promise)
-          $ctrl.isVisible = true
-        }))
-
-      it('shows registerAccount modal if role is \'REGISTERED\'', () => {
-        jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.registered)
-        $ctrl.doUserMatch()
-        expect($ctrl.sessionModalService.userMatch).toHaveBeenCalled()
-      })
-
-
-      describe('\'PUBLIC\' role', () => {
-        it('shows sign in modal, followed by registerAccount', () => {
-          $ctrl.doUserMatch()
-
-          expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ lastPurchaseId })
-          deferred.resolve()
-          $rootScope.$digest()
-
-          expect($ctrl.isVisible).toEqual(false)
-        })
       })
     })
 

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
@@ -84,7 +84,7 @@ describe('thank you', function () {
         $ctrl.donorDetails = { 'registration-state': 'NEW' }
         $ctrl.openAccountBenefitsModal()
 
-        expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith(lastPurchaseId)
+        expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ lastPurchaseId })
         deferred.resolve()
         $rootScope.$digest()
         expect($ctrl.isVisible).toEqual(false)
@@ -140,7 +140,7 @@ describe('thank you', function () {
         it('shows sign in modal, followed by registerAccount', () => {
           $ctrl.doUserMatch()
 
-          expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalled()
+          expect($ctrl.sessionModalService.registerAccount).toHaveBeenCalledWith({ lastPurchaseId })
           deferred.resolve()
           $rootScope.$digest()
 

--- a/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
+++ b/src/app/thankYou/accountBenefits/accountBenefits.component.spec.js
@@ -102,13 +102,6 @@ describe('thank you', function () {
         expect($ctrl.isVisible).toEqual(false)
       })
 
-      it('should not show accountBenefits modal to users who have completed donor matching', () => {
-        $ctrl.donorDetails = { 'registration-state': 'COMPLETED' }
-        $ctrl.openAccountBenefitsModal()
-
-        expect($ctrl.sessionModalService.accountBenefits).not.toHaveBeenCalled()
-      })
-
       it('should not show accountBenefits modal if purchase link is missing', () => {
         $ctrl.orderService.retrieveLastPurchaseLink.mockReturnValue(undefined)
         $ctrl.donorDetails = { 'registration-state': 'NEW' }

--- a/src/app/thankYou/accountBenefits/accountBenefits.tpl.html
+++ b/src/app/thankYou/accountBenefits/accountBenefits.tpl.html
@@ -9,6 +9,6 @@
       <li translate>Manage your recurring gifts</li>
       <li translate>Change your bank account or credit card information</li>
     </ul>
-    <button id="registerYourAccountButton" class="btn btn-primary btn-block" ng-click="$ctrl.doUserMatch()" translate>Register Your Account</button>
+    <button id="registerYourAccountButton" class="btn btn-primary btn-block" ng-click="$ctrl.openModal()" translate>Register Your Account</button>
   </div>
 </div>

--- a/src/common/components/accountBenefitsModal/accountBenefitsModal.component.js
+++ b/src/common/components/accountBenefitsModal/accountBenefitsModal.component.js
@@ -8,18 +8,13 @@ const componentName = 'accountBenefitsModal'
 
 class AccountBenefitsModalController {
   /* @ngInject */
-  constructor ($location, gettext, sessionService) {
-    this.$location = $location
+  constructor (gettext, sessionService) {
     this.gettext = gettext
     this.sessionService = sessionService
   }
 
   $onInit () {
     this.modalTitle = this.gettext('Register Your Account for Online Access')
-    const shouldShowRegisterAccountModal = !!this.$location.search()?.code && !!this.$location.search()?.state
-    if (shouldShowRegisterAccountModal) {
-      this.onStateChange({ state: 'register-account' })
-    }
   }
 
   registerAccount () {

--- a/src/common/components/accountBenefitsModal/accountBenefitsModal.component.js
+++ b/src/common/components/accountBenefitsModal/accountBenefitsModal.component.js
@@ -22,7 +22,7 @@ class AccountBenefitsModalController {
       // No need to sign in if we already are
       this.onSuccess()
     } else {
-      this.onStateChange({ state: 'sign-up' })
+      this.onRegister()
     }
   }
 
@@ -42,7 +42,7 @@ export default angular
     templateUrl: template,
     bindings: {
       modalTitle: '=',
-      onStateChange: '&',
+      onRegister: '&',
       onSuccess: '&',
       onCancel: '&'
     }

--- a/src/common/components/accountBenefitsModal/accountBenefitsModal.component.spec.js
+++ b/src/common/components/accountBenefitsModal/accountBenefitsModal.component.spec.js
@@ -11,7 +11,7 @@ describe('accountBenefitsModal', function () {
     $location = _$location_
     bindings = {
       modalTitle: '',
-      onStateChange: jest.fn(),
+      onRegister: jest.fn(),
       onSuccess: jest.fn()
     }
     $ctrl = _$componentController_(module.name, {}, bindings)
@@ -37,9 +37,11 @@ describe('accountBenefitsModal', function () {
       expect($ctrl.onSuccess).toHaveBeenCalled()
     })
 
-    it('changes state to \'sign-up\'', () => {
+    it('calls onRegister if role is not registered', () => {
+      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public)
       $ctrl.registerAccount()
-      expect($ctrl.onStateChange).toHaveBeenCalledWith({ state: 'sign-up' })
+
+      expect($ctrl.onRegister).toHaveBeenCalled()
     })
   })
 

--- a/src/common/components/accountBenefitsModal/accountBenefitsModal.component.spec.js
+++ b/src/common/components/accountBenefitsModal/accountBenefitsModal.component.spec.js
@@ -26,14 +26,6 @@ describe('accountBenefitsModal', function () {
       $ctrl.$onInit()
 
       expect($ctrl.modalTitle).toEqual('Register Your Account for Online Access')
-      expect($ctrl.onStateChange).not.toHaveBeenCalled()
-    })
-
-    it('initializes component', () => {
-      jest.spyOn($location, 'search').mockReturnValue({ code: 'code', state: 'state '})
-      $ctrl.$onInit()
-
-      expect($ctrl.onStateChange).toHaveBeenCalledWith({ state: 'register-account' })
     })
   })
 

--- a/src/common/components/registerAccountModal/registerAccountModal.component.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.js
@@ -74,7 +74,7 @@ class RegisterAccountModalController {
         this.checkDonorDetails()
       } else {
         // Proceed to Step 1.
-        this.stateChanged('sign-in')
+        this.stateChanged(this.showSignUp ? 'sign-up' : 'sign-in')
       }
     })
     this.cortexSignUpError = false
@@ -213,6 +213,9 @@ export default angular
     bindings: {
       modalTitle: '=',
       lastPurchaseId: '<',
+      // If true, then the modal will open in the "Create Your Account" section as if the user had
+      // manually clicked "Sign up with Okta"
+      showSignUp: '<?',
       onSuccess: '&',
       onCancel: '&',
       setLoading: '&',

--- a/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
+++ b/src/common/components/registerAccountModal/registerAccountModal.component.spec.js
@@ -84,15 +84,24 @@ describe('registerAccountModal', function () {
     describe('with \'PUBLIC\' cortex-session', () => {
       beforeEach(() => {
         $ctrl.sessionService.getRole.mockReturnValue(Roles.public)
-        $ctrl.$onInit()
       })
 
       it('proceeds to sign-in', () => {
+        $ctrl.$onInit()
+
         expect($ctrl.checkDonorDetails).not.toHaveBeenCalled()
         expect($ctrl.stateChanged).toHaveBeenCalledWith('sign-in')
       })
 
+      it('proceeds to sign-up if showSignUp is true', () => {
+        $ctrl.showSignUp = true
+        $ctrl.$onInit()
+
+        expect($ctrl.stateChanged).toHaveBeenCalledWith('sign-up')
+      })
+
       it('proceeds to contact-info', () => {
+        $ctrl.$onInit()
         $ctrl.sessionService.sessionSubject.next({
           firstName: 'Daniel'
         })

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -59,7 +59,6 @@
       on-sign-up="$ctrl.onSignUp()"
       on-success="$ctrl.onIdentitySuccess()"
       on-failure="$ctrl.onIdentityFailure()"
-      is-inside-another-modal="true"
     ></sign-in-modal>
     <sign-up-modal
       ng-switch-when="sign-up"

--- a/src/common/components/registerAccountModal/registerAccountModal.tpl.html
+++ b/src/common/components/registerAccountModal/registerAccountModal.tpl.html
@@ -65,7 +65,6 @@
       ng-switch-when="sign-up"
       on-sign-up-error="$ctrl.onSignUpError(donorDetails)"
       on-sign-in="$ctrl.onSignIn()"
-      is-inside-another-modal="true"
       last-purchase-id="$ctrl.lastPurchaseId"
     ></sign-up-modal>
     <div ng-switch-when="loading-donor" class="modal-body">

--- a/src/common/components/signInModal/signInModal.component.js
+++ b/src/common/components/signInModal/signInModal.component.js
@@ -21,10 +21,6 @@ class SignInModalController {
       this.$window.location = `/checkout.html${window.location.search}`
     }
   }
-
-  getOktaUrl () {
-    return this.sessionService.getOktaUrl()
-  }
 }
 
 export default angular
@@ -42,7 +38,6 @@ export default angular
       // Called when the user clicks the create account link
       onSignUp: '&',
       onSuccess: '&',
-      onFailure: '&',
-      isInsideAnotherModal: '='
+      onFailure: '&'
     }
   })

--- a/src/common/components/signInModal/signInModal.component.spec.js
+++ b/src/common/components/signInModal/signInModal.component.spec.js
@@ -11,7 +11,6 @@ describe('signInModal', function () {
   beforeEach(inject(function (_$componentController_) {
     bindings = {
       modalTitle: '',
-      onStateChange: onStateChange,
       onSuccess: jest.fn()
     }
     $ctrl = _$componentController_(module.name, {}, bindings)
@@ -47,15 +46,6 @@ describe('signInModal', function () {
         expect($ctrl.modalTitle).toEqual('Sign In')
         expect($ctrl.$window.location).toEqual('https://give.cru.org/')
       })
-    })
-  })
-
-  describe('getOktaUrl', () => {
-    it('should call sessionService getOktaUrl', () => {
-      jest.spyOn($ctrl.sessionService, 'getOktaUrl').mockReturnValue('URL')
-      expect($ctrl.sessionService.getOktaUrl).not.toHaveBeenCalled()
-      $ctrl.getOktaUrl()
-      expect($ctrl.sessionService.getOktaUrl).toHaveBeenCalled()
     })
   })
 })

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -850,9 +850,6 @@ export default angular
       onSignUpError: '&',
       // Called when the user clicks back to sign in link
       onSignIn: '&',
-      // Called with the user dismisses the modal via the close button
-      onCancel: '&',
-      lastPurchaseId: '<',
-      isInsideAnotherModal: '='
+      lastPurchaseId: '<'
     }
   })

--- a/src/common/components/signUpModal/signUpModal.tpl.html
+++ b/src/common/components/signUpModal/signUpModal.tpl.html
@@ -1,18 +1,5 @@
-<div class="modal-header" ng-if="!$ctrl.isInsideAnotherModal">
-  <button type="button" class="close" aria-label="Close" ng-click="$ctrl.onCancel()">
-    <span aria-hidden="true">×</span>
-  </button>
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-xs-12">
-        <h3 class="signup-header" translate>Create Your Account</h3>
-      </div>
-    </div>
-  </div>
-</div>
-
 <div class="modal-body" class="sticky-buttons">
-  <h3 ng-if="$ctrl.isInsideAnotherModal" class="signup-header" translate>Create Your Account</h3>
+  <h3 class="signup-header" translate>Create Your Account</h3>
   <div class="content">
     <div class="signup-steps">
       <div class="step">
@@ -54,8 +41,6 @@
         />
       </div>
     </div>
-
-    <loading ng-if="$ctrl.isLoading && $ctrl.currentStep !== 5" class="okta-signup-loading"></loading>
 
     <div ng-if="$ctrl.currentStep === 5" class="welcome-message">
       <loading class="redirect-loading" inline="true" icon-first="true">

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -30,6 +30,7 @@ class SessionModalController {
     this.stateChanged(this.resolve.state)
     this.hideCloseButton = this.resolve.hideCloseButton
     this.lastPurchaseId = this.resolve.lastPurchaseId
+    this.registerAccountSignUp = this.resolve.registerAccountSignUp
   }
 
   stateChanged (state) {

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -47,6 +47,12 @@ class SessionModalController {
     this.close()
   }
 
+  onAccountBenefitsRegister () {
+    this.sessionService.removeOktaRedirectIndicator()
+    this.registerAccountSignUp = true
+    this.stateChanged('register-account')
+  }
+
   onAccountBenefitsSuccess () {
     this.sessionService.removeOktaRedirectIndicator()
     this.stateChanged('register-account')

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -74,8 +74,9 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       dismissAnalyticsEvent: 'ga-registration-exit'
     }).result,
     accountBenefits: (lastPurchaseId) => openModal('account-benefits', { resolve: { lastPurchaseId: () => lastPurchaseId }, size: 'sm' }).result,
-    registerAccount: ({ dismissable = true } = {}) => openModal('register-account', {
+    registerAccount: ({ lastPurchaseId, dismissable = true } = {}) => openModal('register-account', {
       resolve: {
+        lastPurchaseId: () => lastPurchaseId,
         hideCloseButton: () => !dismissable
       },
       backdrop: 'static',

--- a/src/common/services/session/sessionModal.service.js
+++ b/src/common/services/session/sessionModal.service.js
@@ -74,10 +74,11 @@ const SessionModalService = /* @ngInject */ function ($uibModal, $log, modalStat
       dismissAnalyticsEvent: 'ga-registration-exit'
     }).result,
     accountBenefits: (lastPurchaseId) => openModal('account-benefits', { resolve: { lastPurchaseId: () => lastPurchaseId }, size: 'sm' }).result,
-    registerAccount: ({ lastPurchaseId, dismissable = true } = {}) => openModal('register-account', {
+    registerAccount: ({ lastPurchaseId, dismissable = true, signUp = false } = {}) => openModal('register-account', {
       resolve: {
         lastPurchaseId: () => lastPurchaseId,
-        hideCloseButton: () => !dismissable
+        hideCloseButton: () => !dismissable,
+        registerAccountSignUp: () => signUp
       },
       backdrop: 'static',
       keyboard: false

--- a/src/common/services/session/sessionModal.service.spec.js
+++ b/src/common/services/session/sessionModal.service.spec.js
@@ -2,6 +2,8 @@ import angular from 'angular'
 import 'angular-mocks'
 import module from './sessionModal.service'
 
+const lastPurchaseId = 'gxwpz='
+
 describe('sessionModalService', function () {
   beforeEach(angular.mock.module(module.name))
   let sessionModalService; let $uibModal; let counter = 0
@@ -164,10 +166,10 @@ describe('sessionModalService', function () {
     })
 
     it('should open signIn modal with last purchase id', () => {
-      sessionModalService.signIn('gxwpz=')
+      sessionModalService.signIn(lastPurchaseId)
 
       expect($uibModal.open).toHaveBeenCalledTimes(1)
-      expect($uibModal.open.mock.calls[0][0].resolve.lastPurchaseId()).toEqual('gxwpz=')
+      expect($uibModal.open.mock.calls[0][0].resolve.lastPurchaseId()).toEqual(lastPurchaseId)
     })
   })
 
@@ -182,20 +184,21 @@ describe('sessionModalService', function () {
 
   describe('registerAccount', () => {
     it('should open registerAccount modal', () => {
-      sessionModalService.registerAccount()
+      sessionModalService.registerAccount({ lastPurchaseId })
 
       expect($uibModal.open).toHaveBeenCalledTimes(1)
       expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('register-account')
+      expect($uibModal.open.mock.calls[0][0].resolve.lastPurchaseId()).toEqual(lastPurchaseId)
     })
   })
 
   describe('accountBenefits', () => {
     it('should open accountBenefits modal', () => {
-      sessionModalService.accountBenefits('gxwpz=')
+      sessionModalService.accountBenefits(lastPurchaseId)
 
       expect($uibModal.open).toHaveBeenCalledTimes(1)
       expect($uibModal.open.mock.calls[0][0].resolve.state()).toEqual('account-benefits')
-      expect($uibModal.open.mock.calls[0][0].resolve.lastPurchaseId()).toEqual('gxwpz=')
+      expect($uibModal.open.mock.calls[0][0].resolve.lastPurchaseId()).toEqual(lastPurchaseId)
     })
   })
 })

--- a/src/common/services/session/sessionModal.tpl.html
+++ b/src/common/services/session/sessionModal.tpl.html
@@ -1,14 +1,8 @@
 <div class="loading-overlay-parent">
   <div ng-switch="$ctrl.state">
-    <sign-up-modal ng-switch-when="sign-up"
-      modal-title="$ctrl.modalTitle"
-      last-purchase-id="$ctrl.lastPurchaseId"
-      on-sign-up="$ctrl.onSignUpSuccess()"
-      on-sign-in="$ctrl.onSignIn()"
-      on-cancel="$ctrl.close()"
-    ></sign-up-modal>
     <register-account-modal ng-switch-when="register-account"
       modal-title="$ctrl.modalTitle"
+      show-sign-up="$ctrl.registerAccountSignUp"
       hide-close-button="$ctrl.hideCloseButton"
       last-purchase-id="$ctrl.lastPurchaseId"
       on-success="$ctrl.onSignUpSuccess()"
@@ -17,7 +11,7 @@
     ></register-account-modal>
     <account-benefits-modal ng-switch-when="account-benefits"
       modal-title="$ctrl.modalTitle"
-      on-state-change="$ctrl.stateChanged(state)"
+      on-register="$ctrl.onAccountBenefitsRegister()"
       on-success="$ctrl.onAccountBenefitsSuccess()"
       on-cancel="$ctrl.onCancel()"
     ></account-benefits-modal>


### PR DESCRIPTION
## Description

On the thank you page, a modal pops up on page load with a "Register Your Account" button. This PR makes that button open the register account modal opened to the sign up form instead of a minimal sign up form.

This PR also does some cleanup in the logic in `accountBenefits.component.js`, correctly passes in `lastPurchaseId` to the register account modal, and removes some old Okta redirect logic in `accountBenefitsModal.component.js`.

EP-2603