### PR TITLE
[EP-2517] Add back custom amount input

### DIFF
--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -138,6 +138,33 @@
                   {{$ctrl.suggestedAmount(suggested.amount)}} {{suggested.label}}
                 </label>
               </div>
+              <div class="radio radio-custom-amount form-inline" ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}">
+                <div class="form-group">
+                  <label>
+                    <input name="suggestedAmount"
+                           type="radio"
+                           ng-checked="$ctrl.customInputActive" />
+                    <input class="form-control form-control-subtle"
+                           name="amount"
+                           type="text"
+                           step="1"
+                           ng-model="$ctrl.customAmount"
+                           ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
+                           ng-focus="$ctrl.customInputActive = true"
+                           ng-required="$ctrl.customInputActive"
+                           placeholder="{{'OTHER_PLACEHOLDER' | translate}}" />
+                  </label>
+                  <div role="alert" ng-messages="$ctrl.itemConfigForm.amount.$error"
+                       ng-if="($ctrl.itemConfigForm.amount | showErrors)">
+                    <div class="help-block" ng-message="pattern" translate>{{'VALID_DOLLAR_AMOUNT_ERROR'}}</div>
+                    <div class="help-block" ng-message="required" translate>{{'AMOUNT_EMPTY_ERROR'}}</div>
+                    <div class="help-block" ng-message="minimum" translate translate-values="{currencyLimit: (1 | currency)}">{{'AMOUNT_MIN_ERROR'}}</div>
+                    <div class="help-block" ng-message="maximum" translate translate-values="{currencyLimit: (10000000 | currency)}">
+                      {{'AMOUNT_MAX_ERROR'}}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
Add back the custom amount input for v2 when there are suggested amounts. This was accidentally removed in #1117.

## Testing

* Make sure that `use-v3="true"` is NOT set
* Update `productConfigForm.component.js` locally to mock some suggested amounts
```patch
diff --git a/branded-checkout.html b/branded-checkout.html
diff --git a/src/app/productConfig/productConfigForm/productConfigForm.component.js b/src/app/productConfig/productConfigForm/productConfigForm.component.js
index 83267cc97..9a385d2f1 100644
--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -144,7 +144,7 @@ class ProductConfigFormController {
 
     const suggestedAmountsObservable = this.designationsService.suggestedAmounts(this.code, this.itemConfig)
       .do(suggestedAmounts => {
-        this.suggestedAmounts = suggestedAmounts.filter((amount) => amount?.amount)
+        this.suggestedAmounts = [{amount: 10, order: 1} , {amount: 50, order: 2}, {amount: 100, order: 3}]
         this.useSuggestedAmounts = !isEmpty(this.suggestedAmounts)
       })
 ```
* Verify that the other input is shown
<img width="371" alt="Screenshot 2025-05-30 at 9 43 47 AM" src="https://github.com/user-attachments/assets/958bcd67-20b2-43f2-8518-f3ff911cd626" />

This PR doesn't change the v3 branch, but it would be good to double-check that it looks correct in v3 also.

EP-2517

https://secure.helpscout.net/conversation/2955050711/1375661?viewId=7296729