### PR TITLE
Amend PR #1117 as it removed some parts of PR #1155

### DIFF
--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -460,13 +460,15 @@ class Order {
       submitRequest = this.submit()
     } else if (controller.creditCardPaymentDetails) {
       const cvv = this.retrieveCardSecurityCode()
-      submitRequest = this.submit(cvv)
+      const cardBin = this.retrieveCardBin()
+      submitRequest = this.submit(cvv, cardBin)
     } else {
       submitRequest = Observable.throw({ data: 'Current payment type is unknown' })
     }
     return submitRequest
       .do(() => {
         this.clearCardSecurityCodes()
+        this.clearCardBins()
         this.clearCoverFees()
         controller.onSubmitted()
         controller.$scope.$emit(cartUpdatedEvent)

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -1096,13 +1096,13 @@ describe('order service', () => {
     })
 
     describe('clearCardBins', () => {
-      it('should clear the stored the encrypted cvv', () => {
+      it('should clear the stored the card bin', () => {
         self.$window.sessionStorage.setItem('cardBin', '411111')
         self.$window.sessionStorage.setItem('storedBins', { 'some uri': '411111' })
         self.orderService.clearCardBins()
 
-        expect(self.$window.sessionStorage.getItem('cvv')).toBeNull()
-        expect(self.$window.sessionStorage.getItem('storedCvvs')).toBeNull()
+        expect(self.$window.sessionStorage.getItem('cardBin')).toBeNull()
+        expect(self.$window.sessionStorage.getItem('storedBins')).toBeNull()
       })
     })
   })


### PR DESCRIPTION
When PR #1117 was merged, it removed some of the cardBin logic which was added in PR #1155. This was quite easy to do with a significant PR (which is why we generally prefer smaller PRs, but we had to make a big one for this change), also since the developers moved the entire function to another file, it made it hard to spot the issue.