### PR TITLE
[HS-1383851] Update priceWithFees in productConfigForm

### DIFF
--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -10,7 +10,6 @@ import cartService from 'common/services/api/cart.service'
 import orderService from 'common/services/api/order.service'
 import analyticsFactory from '../../analytics/analytics.factory'
 import brandedAnalyticsFactory from '../../branded/analytics/branded-analytics.factory'
-import { FEE_DERIVATIVE } from 'common/components/paymentMethods/coverFees/coverFees.component'
 
 import template from './branded-checkout-step-1.tpl.html'
 import 'rxjs/add/operator/catch'
@@ -54,12 +53,6 @@ class BrandedCheckoutStep1Controller {
     }
     this.itemConfig['campaign-page'] = this.campaignPage
     this.itemConfig.AMOUNT = this.amount
-
-    // These lines calculate the price with fees for amounts coming in from the client site via component config
-    if (this.amount) {
-      const amountWithFees = this.amount / FEE_DERIVATIVE
-      this.itemConfig.priceWithFees = this.$filter('currency')(amountWithFees, '$', 2)
-    }
 
     switch (this.frequency) {
       case 'monthly':

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -42,7 +42,6 @@ describe('branded checkout step 1', () => {
         CAMPAIGN_CODE: '1234',
         'campaign-page': '135',
         AMOUNT: '75',
-        priceWithFees: '$76.80',
         'RECURRING_DAY_OF_MONTH': '9'
       })
 

--- a/src/app/productConfig/productConfigForm/productConfigForm.component.js
+++ b/src/app/productConfig/productConfigForm/productConfigForm.component.js
@@ -33,11 +33,11 @@ import loading from 'common/components/loading/loading.component'
 import analyticsFactory from 'app/analytics/analytics.factory'
 import brandedAnalyticsFactory from 'app/branded/analytics/branded-analytics.factory'
 
-import { brandedCheckoutAmountUpdatedEvent } from 'common/components/paymentMethods/coverFees/coverFees.component'
-
 import template from './productConfigForm.tpl.html'
 
 export const brandedCoverFeeCheckedEvent = 'brandedCoverFeeCheckedEvent'
+
+const FEE_DERIVATIVE = 0.9765 // 2.35% processing fee (calculated by 1 - 0.0235)
 
 const componentName = 'productConfigForm'
 
@@ -95,7 +95,7 @@ class ProductConfigFormController {
     if (isNaN(amount)) {
       delete this.itemConfig.AMOUNT
     } else {
-      this.itemConfig.AMOUNT = amount
+      this.setAmount(amount)
     }
 
     if (inRange(parseInt(this.itemConfig.RECURRING_DAY_OF_MONTH, 10), 1, 29)) {
@@ -186,7 +186,7 @@ class ProductConfigFormController {
         this.changeCustomAmount(this.itemConfig.AMOUNT)
       }
     } else {
-      this.itemConfig.AMOUNT = amountOptions[0]
+      this.setAmount(amountOptions[0])
     }
   }
 
@@ -285,12 +285,11 @@ class ProductConfigFormController {
   changeAmount (amount, retainCoverFees) {
     this.itemConfigForm.$setDirty()
     this.checkAmountChanged(amount)
-    this.itemConfig.AMOUNT = amount
+    this.setAmount(amount)
     this.customAmount = ''
     this.customInputActive = false
     if (!retainCoverFees && this.amountChanged) {
       this.orderService.clearCoverFees()
-      this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
     }
     this.updateQueryParam({ key: giveGiftParams.amount, value: amount })
   }
@@ -298,12 +297,11 @@ class ProductConfigFormController {
   changeCustomAmount (amount, retainCoverFees) {
     const amountAsNumber = parseFloat(amount)
     this.checkAmountChanged(amountAsNumber)
-    this.itemConfig.AMOUNT = amountAsNumber
+    this.setAmount(amountAsNumber)
     this.customAmount = amount
     this.customInputActive = true
     if (!retainCoverFees && this.amountChanged) {
       this.orderService.clearCoverFees()
-      this.$scope.$emit(brandedCheckoutAmountUpdatedEvent)
     }
     this.updateQueryParam({ key: giveGiftParams.amount, value: amount })
   }
@@ -321,6 +319,16 @@ class ProductConfigFormController {
     this.errorAlreadyInCart = false
     this.updateQueryParam({ key: giveGiftParams.day, value: day })
     this.updateQueryParam({ key: giveGiftParams.month, value: month })
+  }
+
+  /*
+   * Set the itemConfig's amount and update priceWithFees. `itemConfig.AMOUNT` should not be updated
+   * directly without using this helper.
+   */
+  setAmount (amount) {
+    this.itemConfig.AMOUNT = amount
+    const amountWithFees = amount / FEE_DERIVATIVE
+    this.itemConfig.priceWithFees = this.$filter('currency')(amountWithFees, '$', 2)
   }
 
   saveGiftToCart () {

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.js
@@ -2,28 +2,13 @@ import orderService from 'common/services/api/order.service'
 
 import template from './coverFees.tpl.html'
 import angular from 'angular'
-import cartService from '../../../services/api/cart.service'
-
-export const brandedCheckoutAmountUpdatedEvent = 'brandedCheckoutAmountUpdatedEvent'
 
 const componentName = 'coverFees'
 
 class CoverFeesController {
   /* @ngInject */
-  constructor ($rootScope, $log, $scope, $filter, orderService, cartService) {
-    this.$rootScope = $rootScope
-    this.$log = $log
-    this.$scope = $scope
-    this.$filter = $filter
+  constructor (orderService) {
     this.orderService = orderService
-    this.cartService = cartService
-
-    this.$rootScope.$on(brandedCheckoutAmountUpdatedEvent, () => {
-      this.$onInit()
-      this.updatePriceWithFees()
-    })
-
-    this.$onInit()
   }
 
   $onInit () {
@@ -35,16 +20,7 @@ class CoverFeesController {
       }
     } else if (this.brandedCheckoutItem) {
       this.item = this.brandedCheckoutItem
-
-      if (!this.item.priceWithFees) {
-        this.updatePriceWithFees()
-      }
     }
-  }
-
-  updatePriceWithFees () {
-    const amountWithFees = this.item.AMOUNT / FEE_DERIVATIVE
-    this.item.priceWithFees = this.$filter('currency')(amountWithFees, '$', 2)
   }
 
   storeCoverFeeDecision () {
@@ -54,8 +30,7 @@ class CoverFeesController {
 
 export default angular
   .module(componentName, [
-    orderService.name,
-    cartService.name
+    orderService.name
   ])
   .component(componentName, {
     controller: CoverFeesController,
@@ -65,5 +40,3 @@ export default angular
       brandedCheckoutItem: '<'
     }
   })
-
-export const FEE_DERIVATIVE = 0.9765 // 2.35% processing fee (calculated by 1 - 0.0235)

--- a/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
+++ b/src/common/components/paymentMethods/coverFees/coverFees.component.spec.js
@@ -1,6 +1,6 @@
 import angular from 'angular'
 import 'angular-mocks'
-import module, { brandedCheckoutAmountUpdatedEvent } from './coverFees.component'
+import module from './coverFees.component'
 
 describe('coverFees', () => {
   beforeEach(angular.mock.module(module.name))
@@ -13,47 +13,6 @@ describe('coverFees', () => {
   }))
 
   describe('$onInit', () => {
-    beforeEach(() => {
-      jest.spyOn(self.controller, 'updatePriceWithFees').mockImplementation(() => {})
-    })
-
-    it('should do nothing if cart data and brandedCheckoutItem is not defined', () => {
-      jest.spyOn(self.controller.orderService, 'storeCoverFeeDecision').mockImplementation(() => {})
-      self.controller.cartData = undefined
-      self.controller.brandedCheckoutItem = undefined
-
-      self.controller.$onInit()
-
-      expect(self.controller.orderService.storeCoverFeeDecision).not.toHaveBeenCalled()
-      expect(self.controller.updatePriceWithFees).not.toHaveBeenCalled()
-    })
-
-    it('should handle large incoming numbers properly', () => {
-      self.controller.cartData = {
-        items: [
-          {
-            amount: 25000,
-            price: '$25,000.00',
-            config: {
-              AMOUNT: 25000
-            }
-          }
-        ],
-        cartTotal: 25000
-      }
-
-      self.controller.$onInit()
-      expect(self.controller.cartData.cartTotal).toEqual(25000)
-    })
-
-    it('should reload the cover fees component if gift amount changed in branded checkout', () => {
-      jest.spyOn(self.controller, '$onInit')
-      self.controller.cartData = undefined
-      self.controller.$rootScope.$emit(brandedCheckoutAmountUpdatedEvent)
-
-      expect(self.controller.$onInit).toHaveBeenCalled()
-    })
-
     it('should configure a common "item" object for the template if the cart has one item', () => {
       const cartItem = {}
       self.controller.cartData = { items: [cartItem] }
@@ -76,26 +35,6 @@ describe('coverFees', () => {
       self.controller.cartData = { items: [{}, {}] }
       self.controller.$onInit()
       expect(self.controller.item).not.toBeDefined()
-    })
-
-    it('should not call updatePriceWithFees on standard checkout', () => {
-      self.controller.cartData = { items: [{ AMOUNT: 50 }] }
-      expect(self.controller.updatePriceWithFees).not.toHaveBeenCalled()
-    })
-
-    it('should call updatePriceWithFees on branded checkout', () => {
-      self.controller.cartData = undefined
-      self.controller.brandedCheckoutItem = { AMOUNT: 50 }
-      self.controller.$onInit()
-      expect(self.controller.updatePriceWithFees).toHaveBeenCalled()
-    })
-  })
-
-  describe('updatePriceWithFees', () => {
-    it('should calculate the price to show the user', () => {
-      self.controller.item = { AMOUNT: 50 }
-      self.controller.updatePriceWithFees()
-      expect(self.controller.item.priceWithFees).toEqual('$51.20')
     })
   })
 


### PR DESCRIPTION
## Bug

#1117 [optimized](https://github.com/CruGlobal/give-web/pull/1117/files#diff-6d2b2f8f5871022726f6541687b4cfe4ff35100840b7019ff388d06187e196a4) payment method loading by not loading payment methods in branded checkout. However, this created a race condition in branded checkouts with credit card as the default payment method. Before that change, the cover fees component wasn't shown until after the payment methods loaded, and the item config was usually loaded by that point. After that change, the cover fees component rendered immediately, and the item config wasn't loaded yet. As a result, the `priceWithFees` amount was absent in the UI.

## Fix

I resolved this by making `productConfigForm` handle setting `priceWithFees` whenever it updates `itemConfig.AMOUNT`. This change also simplifies the code by reducing coupling between unrelated components.

https://secure.helpscout.net/conversation/2967009341/1383851?viewId=320673