### PR TITLE
Moving saveDonorDataForRegistration into the order service

### DIFF
--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -127,20 +127,6 @@ class Step3Controller {
     return enableSubmitBtn
   }
 
-  saveDonorDataForRegistration () {
-    if (this.donorDetails['registration-state'] !== 'COMPLETED') {
-      const storeSessionData = {}
-      storeSessionData.name = { ...this.donorDetails.name }
-      storeSessionData.mailingAddress = { ...this.donorDetails.mailingAddress }
-      storeSessionData['spouse-name'] = { ...this.donorDetails['spouse-name'] }
-      storeSessionData['donor-type'] = this.donorDetails['donor-type']
-      storeSessionData['organization-name'] = this.donorDetails['organization-name']
-      storeSessionData['phone-number'] = this.donorDetails['phone-number']
-      storeSessionData.email = this.donorDetails.email
-      this.sessionService.updateCheckoutSavedData(storeSessionData)
-    }
-  }
-
   submitOrder () {
     this.orderService.submitOrder(this).subscribe(() => {
       if (!this.isBranded) {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -445,6 +445,20 @@ class Order {
     }
   }
 
+  saveDonorDataForRegistration (donorDetails) {
+    if (donorDetails['registration-state'] !== 'COMPLETED') {
+      const storeSessionData = {}
+      storeSessionData.name = { ...donorDetails.name }
+      storeSessionData.mailingAddress = { ...donorDetails.mailingAddress }
+      storeSessionData['spouse-name'] = { ...donorDetails['spouse-name'] }
+      storeSessionData['donor-type'] = donorDetails['donor-type']
+      storeSessionData['organization-name'] = donorDetails['organization-name']
+      storeSessionData['phone-number'] = donorDetails['phone-number']
+      storeSessionData.email = donorDetails.email
+      this.sessionService.updateCheckoutSavedData(storeSessionData)
+    }
+  }
+
   submitOrder (controller) {
     delete controller.submissionError
     delete controller.submissionErrorStatus
@@ -472,7 +486,7 @@ class Order {
         this.clearCoverFees()
         controller.onSubmitted()
         controller.$scope.$emit(cartUpdatedEvent)
-        controller.saveDonorDataForRegistration()
+        this.saveDonorDataForRegistration(controller.donorDetails)
       },
       (error) => {
         // Handle the error side effects when the observable errors

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -1284,16 +1284,21 @@ describe('order service', () => {
 
   describe('submitOrder', () => {
     let mockController
+    const mockDonorDetails = {
+      'email-address': 'email@cru.org',
+      'first-name': 'Test',
+      'last-name': 'User',
+    }
 
     beforeEach(() => {
       mockController = {
         submittingOrder: false,
         onSubmittingOrder: jest.fn(),
         onSubmitted: jest.fn(),
-        saveDonorDataForRegistration: jest.fn(),
         $scope: {
           $emit: jest.fn(),
         },
+        donorDetails: mockDonorDetails,
       }
 
       // Mock the submit() method to return a resolved observable
@@ -1319,6 +1324,7 @@ describe('order service', () => {
           self.orderService.clearCardSecurityCodes = jest.fn()
           self.orderService.retrieveCardSecurityCode = jest.fn()
           self.orderService.clearCoverFees = jest.fn()
+          self.orderService.saveDonorDataForRegistration = jest.fn()
           mockController.loadCart = jest.fn()
           self.$window.scrollTo = jest.fn()
         })
@@ -1335,9 +1341,9 @@ describe('order service', () => {
             () => {
               expect(self.orderService.submit).toHaveBeenCalled()
               expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+              expect(self.orderService.saveDonorDataForRegistration).toHaveBeenCalledWith(mockDonorDetails)
       
               expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-              expect(mockController.saveDonorDataForRegistration).toHaveBeenCalledWith()
               done()
             }, done)
       })
@@ -1353,6 +1359,7 @@ describe('order service', () => {
             expect(self.orderService.submit).toHaveBeenCalled()
             expect(mockController.loadCart).toHaveBeenCalled()
             expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.orderService.saveDonorDataForRegistration).not.toHaveBeenCalled()
             expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'error saving bank account' }])
             expect(mockController.submissionError).toEqual('error saving bank account')
             expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)
@@ -1369,8 +1376,8 @@ describe('order service', () => {
         self.orderService.submitOrder(mockController).subscribe(() => {
           expect(self.orderService.submit).toHaveBeenCalledWith('1234', '411111')
           expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+          expect(self.orderService.saveDonorDataForRegistration).toHaveBeenCalledWith(mockDonorDetails)
           expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-          expect(mockController.saveDonorDataForRegistration).toHaveBeenCalledWith()
           done()
         }, done)
       })
@@ -1383,8 +1390,8 @@ describe('order service', () => {
         self.orderService.submitOrder(mockController).subscribe(() => {
           expect(self.orderService.submit).toHaveBeenCalledWith(undefined, undefined)
           expect(self.orderService.clearCardSecurityCodes).toHaveBeenCalled()
+          expect(self.orderService.saveDonorDataForRegistration).toHaveBeenCalledWith(mockDonorDetails)
           expect(mockController.$scope.$emit).toHaveBeenCalledWith(cartUpdatedEvent)
-          expect(mockController.saveDonorDataForRegistration).toHaveBeenCalledWith()
           done()
         }, done)
       })
@@ -1399,6 +1406,7 @@ describe('order service', () => {
           () => { // error handler
             expect(self.orderService.submit).toHaveBeenCalledWith('1234', '411111')
             expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.orderService.saveDonorDataForRegistration).not.toHaveBeenCalled()
             expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'CardErrorException: Invalid Card Number: some details' }])
             expect(mockController.submissionError).toEqual('CardErrorException')
             expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)
@@ -1426,6 +1434,7 @@ describe('order service', () => {
           () => { // error handler
             expect(self.orderService.submit).not.toHaveBeenCalled()
             expect(self.orderService.clearCardSecurityCodes).not.toHaveBeenCalled()
+            expect(self.orderService.saveDonorDataForRegistration).not.toHaveBeenCalled()
             expect(self.$log.error.logs[0]).toEqual(['Error submitting purchase:', { data: 'Current payment type is unknown' }])
             expect(mockController.submissionError).toEqual('Current payment type is unknown')
             expect(self.$window.scrollTo).toHaveBeenCalledWith(0, 0)


### PR DESCRIPTION
## In this PR, I move saveDonorDataForRegistration into the order service, like they have done in the branded-checkout PR.