### PR TITLE
switching functions so Prod can sign out fully

### DIFF
--- a/src/app/signIn/signIn.component.js
+++ b/src/app/signIn/signIn.component.js
@@ -34,7 +34,7 @@ class SignInController {
   }
 
   checkoutAsGuest () {
-    this.sessionService.downgradeToGuest(true).subscribe({
+    this.sessionService.downgradeToGuestOld(true).subscribe({
       error: () => {
         this.$window.location = `/checkout.html${window.location.search}`
       },

--- a/src/app/signIn/signIn.spec.js
+++ b/src/app/signIn/signIn.spec.js
@@ -71,18 +71,18 @@ describe('signIn', function () {
   })
 
   describe('checkoutAsGuest()', () => {
-    describe('downgradeToGuest success', () => {
+    describe('downgradeToGuestOld success', () => {
       it('navigates to checkout', () => {
-        jest.spyOn($ctrl.sessionService, 'downgradeToGuest').mockReturnValue(Observable.of({}))
+        jest.spyOn($ctrl.sessionService, 'downgradeToGuestOld').mockReturnValue(Observable.of({}))
         $ctrl.checkoutAsGuest()
 
         expect($ctrl.$window.location).toEqual('/checkout.html')
       })
     })
 
-    describe('downgradeToGuest failure', () => {
+    describe('downgradeToGuestOld failure', () => {
       it('navigates to checkout', () => {
-        jest.spyOn($ctrl.sessionService, 'downgradeToGuest').mockReturnValue(Observable.throw({}))
+        jest.spyOn($ctrl.sessionService, 'downgradeToGuestOld').mockReturnValue(Observable.throw({}))
         $ctrl.checkoutAsGuest()
 
         expect($ctrl.$window.location).toEqual('/checkout.html')

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -83,6 +83,7 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
     oktaSignInWidgetDefaultOptions,
     clearCheckoutSavedData: clearCheckoutSavedData,
     downgradeToGuest: downgradeToGuest,
+    downgradeToGuestOld: downgradeToGuestOld,
     getRole: currentRole,
     getOktaUrl: getOktaUrl,
     handleOktaRedirect: handleOktaRedirect,
@@ -202,7 +203,7 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
     return Observable.from(authClient.isAuthenticated())
   }
 
-  function signOut (redirectHome = true) {
+  function downgradeToGuest (redirectHome = true) {
     const oktaSignOut = () => {
       // Add session data so on return to page we can show an explanation to the user about what happened.
       if (!redirectHome) {
@@ -230,6 +231,10 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
           .then(() => authClient.revokeRefreshToken())
           .then(() => oktaSignOut())
       })
+  }
+
+  function signOut (redirectHome = true) {
+    return this.downgradeToGuest(redirectHome)
   }
 
   function signOutWithoutRedirectToOkta () {
@@ -260,7 +265,7 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
     }, 2000)
   }
 
-  function downgradeToGuest (skipEvent = false) {
+  function downgradeToGuestOld (skipEvent = false) {
     const observable = currentRole() === Roles.public
       ? Observable.throw('must be IDENTIFIED')
       : Observable

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -507,14 +507,16 @@ describe('session service', function () {
 
 
 
-  describe('downgradeToGuest( skipEvent )', () => {
+
+
+  describe('downgradeToGuestOld( skipEvent )', () => {
     beforeEach(() => {
       jest.spyOn($rootScope, '$broadcast')
     })
 
     describe('with \'PUBLIC\' role', () => {
       it('throws error', () => {
-        sessionService.downgradeToGuest().subscribe(angular.noop, (error) => {
+        sessionService.downgradeToGuestOld().subscribe(angular.noop, (error) => {
           expect(error).toBeDefined()
         })
 
@@ -532,7 +534,7 @@ describe('session service', function () {
 
       it('make http request to cas/downgrade', done => {
         $httpBackend.expectPOST('https://give-stage2.cru.org/okta/downgrade', {}).respond(204, {})
-        sessionService.downgradeToGuest().subscribe((data) => {
+        sessionService.downgradeToGuestOld().subscribe((data) => {
           expect(data).toEqual({})
         })
         $rootScope.$digest()
@@ -556,7 +558,7 @@ describe('session service', function () {
 
       it('make http request to cas/downgrade', done => {
         $httpBackend.expectPOST('https://give-stage2.cru.org/okta/downgrade', {}).respond(204, {})
-        sessionService.downgradeToGuest(true).subscribe((data) => {
+        sessionService.downgradeToGuestOld(true).subscribe((data) => {
           expect(data).toEqual({})
         })
         $rootScope.$digest()


### PR DESCRIPTION
## Description
As AEM currently calls `downgradeToGuest` on sign out, we need to temporarily change the sign out function names so users get fully logged out of Okta.

`downgradeToGuest` -> `downgradeToGuestOld`
`signOut` -> `downgradeToGuest`
New function `signOut` that calls `downgradeToGuest`.

I had to update certain files to fix tests and ensure the proper functions were called.

