### PR TITLE
[no-Jira] Fix "Unknown provider" error

### DIFF
--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -9,7 +9,6 @@ const componentName = 'signInForm'
 class SignInFormController {
   /* @ngInject */
   constructor (gettext) {
-    this.$injector = angular.injector()
     this.gettext = gettext
   }
 

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -13,10 +13,6 @@ describe('signInForm', function () {
     bindings = {
       onSuccess: jest.fn(),
       onFailure: jest.fn(),
-      $injector: {
-        has: jest.fn(),
-        loadNewModules: jest.fn()
-      }
     }
 
     const scope = { $apply: jest.fn() }

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -42,7 +42,7 @@ export const SignOutEvent = 'SessionSignedOut'
 // DOM event triggered on document.body when the user signs in
 export const BodySignInEvent = 'giveSignInSuccess'
 
-const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http, $timeout, $window, $location, envService) {
+const session = /* @ngInject */ function ($cookies, $document, $injector, $rootScope, $http, $timeout, $window, $location, envService) {
   const session = {}
   const sessionSubject = new BehaviorSubject(session)
   let sessionTimeout
@@ -132,7 +132,6 @@ const session = /* @ngInject */ function ($cookies, $document, $rootScope, $http
         })
         .subscribe({
           next: response => {
-            const $injector = angular.injector()
             $document[0].body.dispatchEvent(
               new window.CustomEvent(BodySignInEvent, { bubbles: true, detail: { $injector } })
             )

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -33,9 +33,9 @@ describe('session service', function () {
   }))
 
   beforeEach(angular.mock.module(module.name))
-  let sessionService, $httpBackend, $cookies, $q, $rootScope, $verifyNoPendingTasks, $window, $location, envService
+  let sessionService, $httpBackend, $cookies, $q, $rootScope, $verifyNoPendingTasks, $window, $location, $injector, envService
 
-  beforeEach(inject(function (_sessionService_, _$httpBackend_, _$cookies_, _$q_, _$rootScope_, _$verifyNoPendingTasks_, _$window_, _$location_, _envService_) {
+  beforeEach(inject(function (_sessionService_, _$httpBackend_, _$cookies_, _$q_, _$rootScope_, _$verifyNoPendingTasks_, _$window_, _$location_, _$injector_, _envService_) {
     sessionService = _sessionService_
     $httpBackend = _$httpBackend_
     $cookies = _$cookies_
@@ -44,6 +44,7 @@ describe('session service', function () {
     $verifyNoPendingTasks = _$verifyNoPendingTasks_
     $window = _$window_
     $location = _$location_
+    $injector = _$injector_
     envService = _envService_
   }))
 
@@ -315,9 +316,6 @@ describe('session service', function () {
           accessToken: 'accessToken'
         }
       }))
-
-      const $injector = {}
-      jest.spyOn(angular, 'injector').mockReturnValue($injector)
 
       const giveSignInSuccessCallback = jest.fn()
       window.document.body.addEventListener(BodySignInEvent, giveSignInSuccessCallback, { once: true })

--- a/src/common/services/session/sessionModal.component.js
+++ b/src/common/services/session/sessionModal.component.js
@@ -18,7 +18,6 @@ class SessionModalController {
   constructor (sessionService, analyticsFactory) {
     this.sessionService = sessionService
     this.analyticsFactory = analyticsFactory
-    this.$injector = angular.injector()
     this.isLoading = false
     this.scrollModalToTop = scrollModalToTop
   }


### PR DESCRIPTION
The way we were creating a new injector with `angular.injector()` appears to be incorrect because using it to load the session service would throw unknown provider errors. Now, we dependency inject `$injector` and use that injector.