### PR TITLE
[no-Jira] Improve logging when sign-in fails

### DIFF
--- a/src/app/oktaAuthCallback/oktaAuthCallback.component.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.component.js
@@ -119,8 +119,8 @@ class OktaAuthCallbackController {
   }
 
   onSignInFailure (error) {
-    const errorMessage = error || unknownErrorMessage
-    this.$log.error(errorMessage)
+    const errorMessage = error instanceof Error ? error.message : unknownErrorMessage
+    this.$log.error(errorMessage, error)
     this.sessionService.clearRedirectLocation()
     this.errorMessage = errorMessage
   }

--- a/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
@@ -73,26 +73,26 @@ describe('oktaAuthCallback', function () {
 
 
   describe('onSignInFailure()', () => {
-    it('should log error message', () => {
+    it('should log error message when error is an Error instance', () => {
       jest.spyOn($log, 'error').mockImplementation(() => {})
-      $ctrl.onSignInFailure('error')
-      expect($log.error).toHaveBeenCalledWith('error')
+      const error = new Error('Failed')
+      $ctrl.onSignInFailure(error)
+      expect($log.error).toHaveBeenCalledWith('Failed', error)
+      expect($ctrl.errorMessage).toEqual('Failed')
+    })
+
+    it('should log error message when error is not an Error instance', () => {
+      jest.spyOn($log, 'error').mockImplementation(() => {})
+      const error = { err: 'ERR' }
+      $ctrl.onSignInFailure(error)
+      expect($log.error).toHaveBeenCalledWith(unknownErrorMessage, error)
+      expect($ctrl.errorMessage).toEqual(unknownErrorMessage)
     })
 
     it('should call clearRedirectLocation()', () => {
       jest.spyOn($ctrl.sessionService, 'clearRedirectLocation')
-      $ctrl.onSignInFailure('error')
-      expect($ctrl.sessionService.clearRedirectLocation).toHaveBeenCalled()
-    })
-
-    it('should call clearRedirectLocation()', () => {
-      $ctrl.onSignInFailure('error')
-      expect($ctrl.errorMessage).toEqual('error')
-    })
-
-    it('should call clearRedirectLocation()', () => {
       $ctrl.onSignInFailure(undefined)
-      expect($ctrl.errorMessage).toEqual(unknownErrorMessage)
+      expect($ctrl.sessionService.clearRedirectLocation).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Since `error` is an object, it shows up in Rollbar (and probably in the UI) as `[object Object]`. This PR changes it to always show `unknownErrorMessage` to the user and log the error object in Rollbar. Unless we know how to extract a human-readable error message from `error`, this is going to be a better UX than showing them `[object Object]`.