### PR TITLE
Normalize api-url to accept multiple formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Add the following code to your page where appropriate. See the [Branded checkout
 #### Branded checkout config
 
 The `<branded-checkout>` element is where the branded checkout Angular app will be loaded. It is configured by providing HTML attributes that will be loaded by Angular. Attributes with values containing angle brackets (such as `<designation number>`) are placeholders and should be replaced with real values or, if not needed, the whole attribute should be omitted. The `<branded-checkout>` element accepts the following attributes:
-- `api-url` - Custom API url. This is required to be on the same top level domain as the branded checkout form for use in browsers that block third party cookies. - **Required** if your domain is not a subdomain of cru.org
+- `api-url` - Custom API url. This is required to be on the same top level domain as the branded checkout form for use in browsers that block third party cookies. You can provide the URL in this format: `brandedcheckout.mydomain.com` - **Required** if your domain is not a subdomain of cru.org
 - `designation-number` - the designation number you would like donors to give to - **Required**
 - `campaign-page` - the campaign page you would like to use, used for suggested amounts - *Optional*
 - `campaign-code` - the campaign code you would like to use - *Optional*

--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -42,7 +42,7 @@ class BrandedCheckoutController {
   $onInit () {
     this.envService.data.vars[this.envService.get()].isBrandedCheckout = true
     if (this.apiUrl) { // set custom API url
-      this.envService.data.vars[this.envService.get()].apiUrl = this.apiUrl
+      this.envService.data.vars[this.envService.get()].apiUrl = this.normalizeApiUrl(this.apiUrl)
     }
     this.code = this.designationNumber
     this.tsysService.setDevice(this.tsysDevice)
@@ -61,6 +61,23 @@ class BrandedCheckoutController {
     })
     this.$translate.use(this.language || 'en')
     this.checkoutService.initializeRecaptcha()
+  }
+
+  normalizeApiUrl (url) {
+    if (!url) {
+      return url
+    }
+
+    // Remove trailing slashes
+    url = url.replace(/\/+$/, '')
+
+    // Remove protocol if present
+    url = url.replace(/^https?:/, '')
+
+    // Remove slash before query parameters if present
+    url = url.replace(/\/\?/, '?')
+
+    return url.startsWith('//') ? url : '//' + url
   }
 
   formatDonorDetails () {

--- a/src/app/branded/branded-checkout.spec.js
+++ b/src/app/branded/branded-checkout.spec.js
@@ -62,7 +62,7 @@ describe('branded checkout', () => {
       $ctrl.apiUrl = 'https://custom-api.cru.org'
       $ctrl.$onInit()
 
-      expect($ctrl.envService.read('apiUrl')).toEqual('https://custom-api.cru.org')
+      expect($ctrl.envService.read('apiUrl')).toEqual('//custom-api.cru.org')
       expect($ctrl.envService.read('isBrandedCheckout')).toEqual(true)
     })
 
@@ -82,6 +82,48 @@ describe('branded checkout', () => {
     it('should initialize recaptcha', () => {
       $ctrl.$onInit()
       expect($ctrl.checkoutService.initializeRecaptcha).toHaveBeenCalled()
+    })
+  })
+
+  describe('normalizeApiUrl', () => {
+    it('should handle URLs with https:// protocol', () => {
+      const result = $ctrl.normalizeApiUrl('https://give.domain.com')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should handle URLs with http:// protocol', () => {
+      const result = $ctrl.normalizeApiUrl('http://give.domain.com')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should handle URLs without protocol', () => {
+      const result = $ctrl.normalizeApiUrl('give.domain.com')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should handle URLs already in protocol-relative format', () => {
+      const result = $ctrl.normalizeApiUrl('//give.domain.com')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should remove trailing slashes', () => {
+      const result = $ctrl.normalizeApiUrl('https://give.domain.com/')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should remove multiple trailing slashes', () => {
+      const result = $ctrl.normalizeApiUrl('https://give.domain.com///')
+      expect(result).toEqual('//give.domain.com')
+    })
+
+    it('should preserve port in URL', () => {
+      const result = $ctrl.normalizeApiUrl('http://give.domain.com:3000/')
+      expect(result).toEqual('//give.domain.com:3000')
+    })
+
+    it('should preserve query parameters', () => {
+      const result = $ctrl.normalizeApiUrl('https://give.domain.com/?ref=abc')
+      expect(result).toEqual('//give.domain.com?ref=abc')
     })
   })
 


### PR DESCRIPTION
**Description**
Christian found an inconsistency with `branded-checkout` api-url, not allowing formats that were specified in the README. This PR normalizes api-url so all provided formats in the README should be supported. HelpScout ticket available [here](https://secure.helpscout.net/conversation/2978500106/1391468/).