### PR TITLE
[no-Jira] Upgrade to node v24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ coverage
 .sass-cache
 stats.json
 
-# asdf
-.tool-versions
-
-
 # Okta sign in  assets
 src/assets/okta-sign-in/font
 src/assets/okta-sign-in/labels

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 18.20.4
+nodejs 24.3.0
 yarn 1.22.17


### PR DESCRIPTION
Upgrade to the latest stable node version (currently 24.3.0).