### PR TITLE
Change text and styles to improve clarity, visual hierarchy

### DIFF
--- a/src/assets/scss/components/_signInForm.scss
+++ b/src/assets/scss/components/_signInForm.scss
@@ -43,7 +43,7 @@ sign-in-form {
   }
 
   .okta-signup-button {
-    $okta-brand: #007dc1;
+    $okta-brand: $colorCru-gray;
 
     display: flex;
     width: 100%;
@@ -57,11 +57,13 @@ sign-in-form {
     font-weight: bold;
     gap: 0.5rem;
     padding-block: 20px;
+    transition: cubic-bezier(1, 0, 0, 1) 0.3s;
 
     &:hover {
       border-color: $okta-brand;
       background-color: $okta-brand;
       color: $colorCru-white;
+      transition: cubic-bezier(1, 0, 0, 1) 0.3s;
     }
 
     &:focus {

--- a/src/assets/scss/components/_signInModal.scss
+++ b/src/assets/scss/components/_signInModal.scss
@@ -22,6 +22,8 @@ sign-in-modal {
 
   sign-in-button .btn-primary {
     @include button-variant(black, $btn-primary-bg, $btn-primary-border);
+    
+    font-size: $btn-font-size + 2px;
   }
 
   .okta-button {

--- a/src/common/components/signInForm/signInButton/signInButton.tpl.html
+++ b/src/common/components/signInForm/signInButton/signInButton.tpl.html
@@ -3,9 +3,9 @@
   ng-click="$ctrl.signInWithOkta()"
   ng-disabled="$ctrl.isSigningIn"
 >
-  <strong translate>Sign in to your account</strong>
+  <strong translate>Log in</strong>
   <i class="fa fa-external-link"></i>
 </button>
 <loading type="overlay" ng-if="$ctrl.isSigningIn">
-  <translate translate>Signing you in...</translate>
+  <translate translate>Logging you in...</translate>
 </loading>

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -35,18 +35,7 @@
   ng-if="!$ctrl.onSignInPage"
   ng-click="$ctrl.onSignUpWithOkta()"
 >
-  <!-- Circular Okta aura inlined so that the color can be changed with CSS for the :hover and :focus states -->
-  <svg width="24" height="24" viewBox="0 0 16 16" aria-label="Okta logo">
-    <circle
-      cx="8"
-      cy="8"
-      r="5.25"
-      stroke="currentColor"
-      stroke-width="3.5"
-      fill="none"
-    />
-  </svg>
-  <span translate>Sign up with Okta</span>
+  <span translate>Create an Account</span>
 </button>
 <div class="details-wrapper">
   <details name="okta-help">


### PR DESCRIPTION
<details>
<summary>This PR brings text and color changes to the Okta Sign-in Form based on feedback from DSG and USDev that donors are having difficulty locating the button to Sign In. Two factors were considered responsible for this usability signal:
</summary>

1. The text "Sign in to your account" and "Sign up with Okta" lacked enough distinction to make the desired action quickly discoverable. We have opted to change the text to "Log in" for the top button and "Create an Account" for the bottom button. This will alleviate the difficulty users had when scanning for their desired action since "Log in" and "Create an Account" do not share the leading word "Sign." For consistency, the `<loading>` indicator was changed to "Logging you in..." to match the words. 
2. The `color` of the blue button was competing with the color of the yellow button. To make the primary Cru brand yellow stand out more as the primary action to "Log in" we've de-emphasized the "Create an Account" button by making it `$colorCru-gray`. The `font-size` for "Log in" was increased slightly to be similar in size to "Create an Account." Additionally, a `transition` was added to the "Create an Account" button to smooth the `:hover` effect.
3. Finally, we've removed the Okta circle logo to reduce confusion.
</details>
<table>
<thead>
<tr>
<td><strong>Before</strong></td>
<td><strong>After</strong></td>
</tr>
</thead>
<tr>
<td>
<img width="347" height="317" alt="Screenshot 2025-08-12 at 3 51 00 PM" src="https://github.com/user-attachments/assets/7f39c611-f89a-4a73-9cd9-2ce4f79d062e" />
</td>
<td>
<img width="348" height="328" alt="Screenshot 2025-08-12 at 3 54 11 PM" src="https://github.com/user-attachments/assets/b0c22128-2d9a-4198-8281-109662488f4c" />
</td>
</tr>
</table>