### PR TITLE
[HS-1424192] Initialize the amount radio buttons with the suggested amount

### DIFF
--- a/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
+++ b/src/app/productConfig/productConfigForm/productConfigForm.tpl.html
@@ -136,8 +136,8 @@
                   name="suggestedAmount"
                   id="sa-{{$index}}"
                   ng-click="$ctrl.changeAmount(suggested.amount)"
-                  ng-class=" {'active': !$ctrl.customInputActive && $ctrl.itemConfig.AMOUNT === suggested.amount}"
-                  ng-checked="$first"
+                  ng-class="{'active': !$ctrl.customInputActive && $ctrl.itemConfig.AMOUNT === suggested.amount}"
+                  ng-checked="$ctrl.itemConfig.AMOUNT === suggested.amount"
                 />
                 <label for="sa-{{$index}}">
                   <span class="amount-box"


### PR DESCRIPTION
## Description

When adding a preselected amount in branded checkout v3, the item config would be correct, but the wrong amount would be selected (it was always showing the first amount as selected). This PR changes the radio button to show the correct amount as selected.

## Testing

Edit `branded-checkout.html` to enable v3 and have a preselected amount, for example:

```html
<branded-checkout
  use-v3="true"
  designation-number="2584059"
  amount="76"      
  show-cover-fees="true"
  ng-cloak>
</branded-checkout>
```

Verify that the $76 amount is selected in the UI, not $38.

https://secure.helpscout.net/conversation/3032947354/1424192/