### PR TITLE
[no-Jira] Track the current DataDog user

### DIFF
--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -24,4 +24,13 @@ const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
     window.datadogRum && window.datadogRum.init(config);
   }
 };
-export { dataDogConfig as default };
+
+function updateDatadogUser(person) {
+  if (person) {
+    datadogRum.setUser(person);
+  } else {
+    datadogRum.clearUser();
+  }
+}
+
+export { dataDogConfig as default, updateDatadogUser };

--- a/src/common/datadog.config.spec.js
+++ b/src/common/datadog.config.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import { datadogRum } from '@datadog/browser-rum';
 import * as module from './datadog.config';
 import { appConfig } from './app.config';
 
@@ -22,6 +23,45 @@ describe('dataDogConfig', () => {
     it('should call init() and start session reply recording', () => {
       expect(window.datadogRum).not.toEqual(undefined);
       expect(window.datadogRum.init).toEqual(expect.any(Function));
+    });
+  });
+
+  describe('updateDatadogUser', () => {
+    let setUserSpy, clearUserSpy;
+
+    beforeEach(() => {
+      setUserSpy = jest
+        .spyOn(datadogRum, 'setUser')
+        .mockImplementation(() => {});
+      clearUserSpy = jest
+        .spyOn(datadogRum, 'clearUser')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      setUserSpy.mockRestore();
+      clearUserSpy.mockRestore();
+    });
+
+    it('should call setUser with person data when person is provided', () => {
+      const person = {
+        id: 'cas|12345',
+        username: 'Fname Lname',
+        email: 'someone@email.com',
+        giveId: 'cas|12345',
+      };
+
+      module.updateDatadogUser(person);
+
+      expect(setUserSpy).toHaveBeenCalledWith(person);
+      expect(clearUserSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call clearUser when person is null', () => {
+      module.updateDatadogUser(null);
+
+      expect(clearUserSpy).toHaveBeenCalled();
+      expect(setUserSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/common/rollbar.config.js
+++ b/src/common/rollbar.config.js
@@ -69,20 +69,10 @@ const rollbarConfig = /* @ngInject */ function (envServiceProvider, $provide) {
   });
 };
 
-function updateRollbarPerson(session, giveSession) {
-  let person = {};
-  if (session) {
-    person = {
-      id: session.sub,
-      username: session.first_name + ' ' + session.last_name,
-      email: session.email,
-      giveId: giveSession.sub,
-    };
-  }
-
+function updateRollbarPerson(person) {
   Rollbar.configure({
     payload: {
-      person: person,
+      person: person || {},
     },
   });
 }

--- a/src/common/rollbar.config.spec.js
+++ b/src/common/rollbar.config.spec.js
@@ -153,26 +153,28 @@ describe('rollbarConfig', () => {
 
     describe('updateRollbarPerson', () => {
       it('should add person info to the rollbar configuration', () => {
-        module.updateRollbarPerson(
-          {
-            sub: 'cas|12345',
-            first_name: 'Fname',
-            last_name: 'Lname',
-            email: 'someone@email.com',
-          },
-          {
-            sub: 'cas|12345',
-          },
-        );
+        const person = {
+          id: 'cas|12345',
+          username: 'Fname Lname',
+          email: 'someone@email.com',
+          giveId: 'cas|12345',
+        };
+
+        module.updateRollbarPerson(person);
 
         expect(self.rollbarSpies.configure).toHaveBeenCalledWith({
           payload: {
-            person: {
-              id: 'cas|12345',
-              username: 'Fname Lname',
-              email: 'someone@email.com',
-              giveId: 'cas|12345',
-            },
+            person,
+          },
+        });
+      });
+
+      it('should clear person info when called with null', () => {
+        module.updateRollbarPerson(null);
+
+        expect(self.rollbarSpies.configure).toHaveBeenCalledWith({
+          payload: {
+            person: {},
           },
         });
       });

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -13,6 +13,7 @@ import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/finally';
 
 import { updateRollbarPerson } from 'common/rollbar.config.js';
+import { updateDatadogUser } from 'common/datadog.config.js';
 
 import appConfig from 'common/app.config';
 /* eslint-disable camelcase */
@@ -366,7 +367,16 @@ const session = /* @ngInject */ function (
     // Update sessionSubject with new value
     sessionSubject.next(session);
 
-    updateRollbarPerson(session, giveSession);
+    const person = session.sub
+      ? {
+          id: session.sub,
+          username: session.first_name + ' ' + session.last_name,
+          email: session.email,
+          giveId: giveSession.sub,
+        }
+      : null;
+    updateRollbarPerson(person);
+    updateDatadogUser(person);
     updateCheckoutSavedData();
   }
 

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import { datadogRum } from '@datadog/browser-rum';
 import module, {
   Roles,
   Sessions,
@@ -14,6 +15,7 @@ import module, {
 import { cortexRole } from 'common/services/session/fixtures/cortex-role';
 import { giveSession } from 'common/services/session/fixtures/give-session';
 import { cruProfile } from 'common/services/session/fixtures/cru-profile';
+import * as rollbarConfig from 'common/rollbar.config.js';
 import { advanceBy, advanceTo, clear } from 'jest-date-mock';
 import 'rxjs/add/observable/of';
 
@@ -875,6 +877,127 @@ describe('session service', function () {
         sessionService.clearCheckoutSavedData(true);
         const dataAfterClear = $cookies.get(checkoutSavedDataCookieName);
         expect(dataAfterClear).toEqual(undefined);
+      });
+    });
+  });
+
+  describe('updateCurrentSession user tracking', () => {
+    let rollbarSpy, datadogSetUserSpy, datadogClearUserSpy;
+
+    beforeEach(() => {
+      rollbarSpy = jest.spyOn(rollbarConfig, 'updateRollbarPerson');
+      datadogSetUserSpy = jest
+        .spyOn(datadogRum, 'setUser')
+        .mockImplementation(() => {});
+      datadogClearUserSpy = jest
+        .spyOn(datadogRum, 'clearUser')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      rollbarSpy.mockRestore();
+      datadogSetUserSpy.mockRestore();
+      datadogClearUserSpy.mockRestore();
+    });
+
+    describe('with a logged-in user', () => {
+      beforeEach(() => {
+        $cookies.put(Sessions.role, cortexRole.registered);
+        $cookies.put(Sessions.profile, cruProfile);
+        $cookies.put(Sessions.give, giveSession);
+        $rootScope.$digest();
+      });
+
+      it('should pass person object to updateRollbarPerson', () => {
+        expect(rollbarSpy).toHaveBeenCalledWith({
+          id: 'cas|873f88fa-327b-b95d-7d7a-7add211a9b64',
+          username: 'Charles Xavier',
+          email: 'professorx@xavier.edu',
+          giveId: 'cas|873f88fa-327b-b95d-7d7a-7add211a9b64',
+        });
+      });
+
+      it('should call datadogRum.setUser with person object', () => {
+        expect(datadogSetUserSpy).toHaveBeenCalledWith({
+          id: 'cas|873f88fa-327b-b95d-7d7a-7add211a9b64',
+          username: 'Charles Xavier',
+          email: 'professorx@xavier.edu',
+          giveId: 'cas|873f88fa-327b-b95d-7d7a-7add211a9b64',
+        });
+      });
+
+      it('should not call datadogRum.clearUser when logged in', () => {
+        expect(datadogClearUserSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with no user session', () => {
+      beforeEach(() => {
+        // Remove all session cookies to simulate logged-out state
+        $cookies.remove(Sessions.role);
+        $cookies.remove(Sessions.profile);
+        $cookies.remove(Sessions.give);
+        $rootScope.$digest();
+      });
+
+      it('should pass null to updateRollbarPerson', () => {
+        expect(rollbarSpy).toHaveBeenCalledWith(null);
+      });
+
+      it('should call datadogRum.clearUser when no session exists', () => {
+        expect(datadogClearUserSpy).toHaveBeenCalled();
+      });
+
+      it('should not call datadogRum.setUser when no session exists', () => {
+        expect(datadogSetUserSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when session changes from logged-in to logged-out', () => {
+      beforeEach(() => {
+        $cookies.put(Sessions.role, cortexRole.registered);
+        $cookies.put(Sessions.profile, cruProfile);
+        $cookies.put(Sessions.give, giveSession);
+        $rootScope.$digest();
+
+        // Clear spies to track only the logout transition
+        rollbarSpy.mockClear();
+        datadogSetUserSpy.mockClear();
+        datadogClearUserSpy.mockClear();
+
+        // Simulate logout
+        $cookies.remove(Sessions.role);
+        $cookies.remove(Sessions.profile);
+        $cookies.remove(Sessions.give);
+        $rootScope.$digest();
+      });
+
+      it('should pass null to updateRollbarPerson after logout', () => {
+        expect(rollbarSpy).toHaveBeenCalledWith(null);
+      });
+
+      it('should call datadogRum.clearUser after logout', () => {
+        expect(datadogClearUserSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('with a public session', () => {
+      beforeEach(() => {
+        $cookies.put(Sessions.role, cortexRole.public);
+        $rootScope.$digest();
+      });
+
+      it('should still set person with partial sub for public session', () => {
+        // Public cortex role has sub: "cas|" which is truthy
+        expect(rollbarSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'cas|' }),
+        );
+      });
+
+      it('should call datadogRum.setUser for public session with partial sub', () => {
+        expect(datadogSetUserSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'cas|' }),
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

Track the current DataDog user, like we do with Rollbar. This will make it easier in the future to find logs related to specific users.

## Testing

- Go to https://give-stage2.cru.org
- Ensure that your browser isn't blocking tracking
- Interact with the page
- Find your session in DataDog RUM
- Check that your name and email address are set

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [x] I have tested my changes in staging for branded checkout
