### PR TITLE
HS-1577837 - Add Material Icons to Manifest

### DIFF
--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -4,10 +4,13 @@ const defaultChunks = [
   'fontawesome.css',
   'material.css',
   'material-outlined.css',
+  'material-icons.woff2',
+  'material-icons-outlined.woff2',
 ];
 
 const SCRIPT = /.*\.js$/;
 const STYLE = /.*\.css$/;
+const FONT = /.*\.woff2$/;
 
 const loadManifest = () => {
   return new Promise((resolve, reject) => {
@@ -40,6 +43,18 @@ const addStyleTag = (filename) => {
   });
 };
 
+const addFontLink = (filename) => {
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+    link.addEventListener('load', resolve);
+    link.href = filename;
+    link.rel = 'preload';
+    link.as = 'font';
+    link.type = 'font/woff2';
+    document.head.appendChild(link);
+  });
+};
+
 const Loader = {
   start: async (chunks = []) => {
     const manifest = await loadManifest();
@@ -49,6 +64,8 @@ const Loader = {
           return addScriptTag(manifest[name]);
         } else if (STYLE.test(name)) {
           return addStyleTag(manifest[name]);
+        } else if (FONT.test(name)) {
+          return addFontLink(manifest[name]);
         }
         return Promise.resolve();
       }),

--- a/src/loaders/loader.js
+++ b/src/loaders/loader.js
@@ -1,5 +1,10 @@
 /* global XMLHttpRequest */
-const defaultChunks = ['angular.js', 'fontawesome.css'];
+const defaultChunks = [
+  'angular.js',
+  'fontawesome.css',
+  'material.css',
+  'material-outlined.css',
+];
 
 const SCRIPT = /.*\.js$/;
 const STYLE = /.*\.css$/;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -272,6 +272,10 @@ module.exports = (env = {}) => [
           'material.css': '//fonts.googleapis.com/icon?family=Material+Icons',
           'material-outlined.css':
             '//fonts.googleapis.com/icon?family=Material+Icons+Outlined',
+          'material-icons.woff2':
+            '//fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2',
+          'material-icons-outlined.woff2':
+            '//fonts.gstatic.com/s/materialiconsoutlined/v110/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUcel5euIg.woff2',
         },
       }),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -269,6 +269,9 @@ module.exports = (env = {}) => [
         publicPath: (process.env.S3_GIVE_DOMAIN || '') + '/',
         seed: {
           'fontawesome.css': '//give.cru.org/css/fontawesome.css',
+          'material.css': '//fonts.googleapis.com/icon?family=Material+Icons',
+          'material-outlined.css':
+            '//fonts.googleapis.com/icon?family=Material+Icons+Outlined',
         },
       }),
     ],


### PR DESCRIPTION
## Description
[Helpscout](https://secure.helpscout.net/conversation/3272053029/1577837?viewId=6657787)

The branded checkout requires material icons for the hidden EFT agreement link, but it is not being delivered by default like fontawesome is. This causes problems for branded checkouts on sites without Material being brought in already.

## Testing
- In the dev tools of Chrome, look at the manifest.json and determine that Material Icons and Material Icons Outlined are brought in
- Go to a branded checkout on a site not bringing in Material Icons itself (not sure if any exist in stage like this, I tested [this page](https://sites-stage.cru.org/cru-branded-checkout-use-v3/) but not sure if it has material icons separate from BCO) and ensure the arrow_outward is being resolved.

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [x] I have tested my changes in staging for branded checkout
