### PR TITLE
[HS-7296729] Swallow exceptions in BrandedCheckout callbacks

### DIFF
--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -175,25 +175,33 @@ class BrandedCheckoutController {
   }
 
   onThankYouPurchaseLoaded(purchase) {
-    this.onOrderCompleted({
-      $event: {
-        $window: this.$window,
-        purchase: changeCaseObject.camelCase(
-          pick(purchase, ['donorDetails', 'lineItems']),
-        ),
-      },
-    });
+    try {
+      this.onOrderCompleted({
+        $event: {
+          $window: this.$window,
+          purchase: changeCaseObject.camelCase(
+            pick(purchase, ['donorDetails', 'lineItems']),
+          ),
+        },
+      });
+    } catch (error) {
+      console.error('onOrderCompleted callback threw:', error);
+    }
     this.brandedAnalyticsFactory.savePurchase(purchase);
     this.brandedAnalyticsFactory.purchase();
   }
 
   onPaymentFailed(donorDetails) {
-    this.onOrderFailed({
-      $event: {
-        $window: this.$window,
-        donorDetails: changeCaseObject.camelCase(donorDetails),
-      },
-    });
+    try {
+      this.onOrderFailed({
+        $event: {
+          $window: this.$window,
+          donorDetails: changeCaseObject.camelCase(donorDetails),
+        },
+      });
+    } catch (error) {
+      console.error('onOrderFailed callback threw:', error);
+    }
   }
 
   fireAnalyticsEvents(...checkoutSteps) {

--- a/src/app/branded/branded-checkout.spec.js
+++ b/src/app/branded/branded-checkout.spec.js
@@ -315,6 +315,19 @@ describe('branded checkout', () => {
       );
       expect($ctrl.brandedAnalyticsFactory.purchase).toHaveBeenCalled();
     });
+
+    it('should swallow errors thrown by onOrderCompleted', () => {
+      $ctrl.onOrderCompleted = jest.fn(() => {
+        throw new Error('Callback failed');
+      });
+
+      $ctrl.onThankYouPurchaseLoaded(purchaseData);
+
+      expect($ctrl.brandedAnalyticsFactory.savePurchase).toHaveBeenCalledWith(
+        purchaseData,
+      );
+      expect($ctrl.brandedAnalyticsFactory.purchase).toHaveBeenCalled();
+    });
   });
 
   describe('onPaymentFailed', () => {
@@ -331,6 +344,16 @@ describe('branded checkout', () => {
           },
         },
       });
+    });
+
+    it('should swallow errors thrown by onOrderFailed', () => {
+      $ctrl.onOrderFailed = jest.fn(() => {
+        throw new Error('Callback failed');
+      });
+
+      expect(() =>
+        $ctrl.onPaymentFailed({ 'donor-type': 'Household' }),
+      ).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Description

When `onOrderCompleted` (which is caller-provided and outside the control of this repo) throws an exception, this was preventing analytics from firing.

I'm using `console.error` instead of `$log.error` because I don't think we want these logs outside of our control showing up in `give-web` Rollbar.

HelpScout ticket: https://secure.helpscout.net/inboxes/2c1fe7d687998a44/views/7296729

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [ ] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout
