### PR TITLE
Fix billing address state defaulting to wrong value

### DIFF
--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -55,6 +55,9 @@ class CreditCardController {
     if (get(changes, 'paymentFormState.currentValue') === 'submitted') {
       this.savePayment();
     }
+    if (get(changes, 'mailingAddress.currentValue') && !this.paymentMethod) {
+      assign(this.creditCardPayment.address, this.mailingAddress);
+    }
   }
 
   initExistingPaymentMethod() {

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.js
@@ -55,7 +55,11 @@ class CreditCardController {
     if (get(changes, 'paymentFormState.currentValue') === 'submitted') {
       this.savePayment();
     }
-    if (get(changes, 'mailingAddress.currentValue') && !this.paymentMethod) {
+    if (
+      get(changes, 'mailingAddress.currentValue') &&
+      !this.paymentMethod &&
+      this.useMailingAddress
+    ) {
       assign(this.creditCardPayment.address, this.mailingAddress);
     }
   }

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -119,6 +119,20 @@ describe('credit card form', () => {
         'CO',
       );
     });
+
+    it('should not update creditCardPayment address when useMailingAddress is false', () => {
+      self.controller.useMailingAddress = false;
+      self.controller.mailingAddress = { region: 'CO' };
+      self.controller.$onChanges({
+        mailingAddress: {
+          currentValue: { region: 'CO' },
+        },
+      });
+
+      expect(self.controller.creditCardPayment.address.region).not.toEqual(
+        'CO',
+      );
+    });
   });
 
   describe('waitForFormInitialization', () => {

--- a/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
+++ b/src/common/components/paymentMethods/creditCardForm/creditCardForm.component.spec.js
@@ -84,6 +84,41 @@ describe('credit card form', () => {
 
       expect(self.controller.savePayment).toHaveBeenCalled();
     });
+
+    it('should update creditCardPayment address when mailingAddress changes', () => {
+      const mailingAddress = {
+        country: 'US',
+        streetAddress: '123 Main St',
+        locality: 'Denver',
+        region: 'CO',
+        postalCode: '80202',
+      };
+      self.controller.mailingAddress = mailingAddress;
+      self.controller.$onChanges({
+        mailingAddress: {
+          currentValue: mailingAddress,
+        },
+      });
+
+      expect(self.controller.creditCardPayment.address.region).toEqual('CO');
+      expect(self.controller.creditCardPayment.address.locality).toEqual(
+        'Denver',
+      );
+    });
+
+    it('should not update creditCardPayment address when mailingAddress changes if paymentMethod exists', () => {
+      self.controller.paymentMethod = { address: { region: 'CA' } };
+      self.controller.mailingAddress = { region: 'CO' };
+      self.controller.$onChanges({
+        mailingAddress: {
+          currentValue: { region: 'CO' },
+        },
+      });
+
+      expect(self.controller.creditCardPayment.address.region).not.toEqual(
+        'CO',
+      );
+    });
   });
 
   describe('waitForFormInitialization', () => {


### PR DESCRIPTION
## Description

- Fixes a bug where selecting a state (e.g. Colorado) in the mailing address on step 1, then advancing to step 2 (credit card), would show the wrong state (e.g. California) in the billing address when "Same as Mailing Address" is checked.
- Root cause: `creditCardForm` copies `mailingAddress` into `creditCardPayment.address` during `$onInit`, but the mailing address is loaded asynchronously by step 2's `loadDonorDetails()`. By the time `$onInit` runs, `mailingAddress` is still `undefined`, so the copy is a no-op. The `$onChanges` handler only watched for `paymentFormState` changes and ignored `mailingAddress` updates.
- Fix: Added handling in `$onChanges` to update `creditCardPayment.address` when the `mailingAddress` binding changes asynchronously (only when not editing an existing payment method).
- Related HelpScout ticket: https://secure.helpscout.net/conversation/3301476295/1598742?viewId=8086747

## Testing

- Go to the checkout page and enter contact information with a mailing address in Colorado (or any state other than California)
- Advance to step 2 (payment method)
- Check that the billing address displayed under "Same as Mailing Address" shows Colorado (not California)
- Uncheck "Same as Mailing Address" and verify the billing address form is pre-filled with Colorado
- Re-check "Same as Mailing Address" and verify it still shows Colorado
- Complete the checkout and verify the correct state is submitted

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout