### PR TITLE
EP-2628 Replace ACS email preference link with SFMC

### DIFF
--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -198,7 +198,7 @@ class ProfileController {
   linkToSfmc(subscriberId) {
     if (subscriberId) {
       window.open(
-        `https://cloud.connect.cru.org/preferences?SubscriberId=${subscriberId}`,
+        `https://cloud.connect.cru.org/preferences?SubscriberId=${encodeURIComponent(subscriberId)}`,
       );
     }
   }
@@ -508,7 +508,6 @@ class ProfileController {
 
 export default angular
   .module(componentName, [
-    'environment',
     profileService.name,
     'ngMessages',
     sessionEnforcerService.name,

--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -33,7 +33,6 @@ class ProfileController {
     $log,
     $scope,
     sessionEnforcerService,
-    envService,
     profileService,
     analyticsFactory,
   ) {
@@ -50,7 +49,6 @@ class ProfileController {
     this.emailLoading = true;
     this.phonesLoading = true;
     this.mailingAddressLoading = true;
-    this.acsUrl = envService.read('acsUrl');
   }
 
   $onInit() {
@@ -99,7 +97,7 @@ class ProfileController {
         this.donorDetails = donorDetails;
         this.hasSpouse = !!this.donorDetails['spouse-name']['family-name'];
         this.initTitles();
-        this.setPKeys();
+        this.setSubscriberIds();
         this.donorDetailsLoading = false;
       },
       (error) => {
@@ -192,14 +190,16 @@ class ProfileController {
     );
   }
 
-  setPKeys() {
-    this.profilePKey = this.donorDetails['acs-profile-pkey'];
-    this.spousePKey = this.donorDetails['acs-spouse-profile-pkey'];
+  setSubscriberIds() {
+    this.sfmcSubscriberId = this.donorDetails.sfmcSubscriberId;
+    this.sfmcSpouseSubscriberId = this.donorDetails.sfmcSpouseSubscriberId;
   }
 
-  linkToAdobeCampaign(pKey) {
-    if (pKey) {
-      window.open(`${this.acsUrl}${pKey}`);
+  linkToSfmc(subscriberId) {
+    if (subscriberId) {
+      window.open(
+        `https://cloud.connect.cru.org/preferences?SubscriberId=${subscriberId}`,
+      );
     }
   }
 

--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -46,6 +46,7 @@ class ProfileController {
     this.profileService = profileService;
     this.analyticsFactory = analyticsFactory;
     this.sfmcUrl = envService.read('sfmcUrl');
+    this.sfmcClientId = envService.read('sfmcClientId');
     this.phoneNumbers = [];
     this.donorDetailsLoading = true;
     this.emailLoading = true;

--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -32,6 +32,7 @@ class ProfileController {
     $location,
     $log,
     $scope,
+    envService,
     sessionEnforcerService,
     profileService,
     analyticsFactory,
@@ -44,6 +45,7 @@ class ProfileController {
     this.sessionEnforcerService = sessionEnforcerService;
     this.profileService = profileService;
     this.analyticsFactory = analyticsFactory;
+    this.sfmcUrl = envService.read('sfmcUrl');
     this.phoneNumbers = [];
     this.donorDetailsLoading = true;
     this.emailLoading = true;
@@ -193,14 +195,6 @@ class ProfileController {
   setSubscriberIds() {
     this.sfmcSubscriberId = this.donorDetails.sfmcSubscriberId;
     this.sfmcSpouseSubscriberId = this.donorDetails.sfmcSpouseSubscriberId;
-  }
-
-  linkToSfmc(subscriberId) {
-    if (subscriberId) {
-      window.open(
-        `https://cloud.connect.cru.org/preferences?SubscriberId=${encodeURIComponent(subscriberId)}`,
-      );
-    }
   }
 
   syncPhoneValidators() {

--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -194,8 +194,9 @@ class ProfileController {
   }
 
   setSubscriberIds() {
-    this.sfmcSubscriberId = this.donorDetails.sfmcSubscriberId;
-    this.sfmcSpouseSubscriberId = this.donorDetails.sfmcSpouseSubscriberId;
+    this.sfmcSubscriberId = this.donorDetails['sfmc-subscriber-id'];
+    this.sfmcSpouseSubscriberId =
+      this.donorDetails['sfmc-spouse-subscriber-id'];
   }
 
   syncPhoneValidators() {

--- a/src/app/profile/profile.component.spec.js
+++ b/src/app/profile/profile.component.spec.js
@@ -18,9 +18,13 @@ describe('ProfileComponent', function () {
       {
         $window: { location: '/profile.html' },
         envService: {
-          read: jest
-            .fn()
-            .mockReturnValue('https://cloud.connect.cru.org/preferences'),
+          read: jest.fn().mockImplementation((key) => {
+            const values = {
+              sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+              sfmcClientId: '534014548',
+            };
+            return values[key];
+          }),
         },
       },
       {

--- a/src/app/profile/profile.component.spec.js
+++ b/src/app/profile/profile.component.spec.js
@@ -171,7 +171,7 @@ describe('ProfileComponent', function () {
   describe('loadDonorDetails()', () => {
     beforeEach(() => {
       jest.spyOn($ctrl, 'initTitles').mockImplementation(() => {});
-      jest.spyOn($ctrl, 'setPKeys').mockImplementation(() => {});
+      jest.spyOn($ctrl, 'setSubscriberIds').mockImplementation(() => {});
     });
 
     it('should load donor details on $onInit() and have a spouse info', () => {
@@ -189,7 +189,7 @@ describe('ProfileComponent', function () {
       expect($ctrl.hasSpouse).toBe(true);
       expect($ctrl.profileService.getProfileDonorDetails).toHaveBeenCalled();
       expect($ctrl.initTitles).toHaveBeenCalled();
-      expect($ctrl.setPKeys).toHaveBeenCalled();
+      expect($ctrl.setSubscriberIds).toHaveBeenCalled();
     });
 
     it('should load donor details on $onInit() without spouse info', () => {
@@ -205,7 +205,7 @@ describe('ProfileComponent', function () {
 
       expect($ctrl.hasSpouse).toBe(false);
       expect($ctrl.initTitles).toHaveBeenCalled();
-      expect($ctrl.setPKeys).toHaveBeenCalled();
+      expect($ctrl.setSubscriberIds).toHaveBeenCalled();
     });
 
     it('should handle and error of loading donor details on $onInit()', () => {
@@ -221,7 +221,7 @@ describe('ProfileComponent', function () {
       expect($ctrl.donorDetailsError).toBe('loading');
       expect($ctrl.profileService.getProfileDonorDetails).toHaveBeenCalled();
       expect($ctrl.initTitles).not.toHaveBeenCalled();
-      expect($ctrl.setPKeys).not.toHaveBeenCalled();
+      expect($ctrl.setSubscriberIds).not.toHaveBeenCalled();
     });
   });
 
@@ -434,74 +434,74 @@ describe('ProfileComponent', function () {
     });
   });
 
-  describe('setPKeys()', () => {
-    const primaryPKey = '123456';
-    const spousePKey = '654321';
+  describe('setSubscriberIds()', () => {
+    const primarySubscriberId = '123456';
+    const spouseSubscriberId = '654321';
 
-    it('should set PKey for primary email', () => {
+    it('should set subscriberId for primary email', () => {
       $ctrl.donorDetails = {
-        'acs-profile-pkey': primaryPKey,
-        'acs-spouse-profile-pkey': undefined,
+        sfmcSubscriberId: primarySubscriberId,
+        sfmcSpouseSubscriberId: undefined,
       };
 
-      $ctrl.setPKeys();
+      $ctrl.setSubscriberIds();
 
-      expect($ctrl.profilePKey).toEqual(primaryPKey);
-      expect($ctrl.spousePKey).toEqual(undefined);
+      expect($ctrl.sfmcSubscriberId).toEqual(primarySubscriberId);
+      expect($ctrl.sfmcSpouseSubscriberId).toEqual(undefined);
     });
 
-    it('should set PKey for spouse email', () => {
+    it('should set subscriberId for spouse email', () => {
       $ctrl.donorDetails = {
-        'acs-profile-pkey': undefined,
-        'acs-spouse-profile-pkey': spousePKey,
+        sfmcSubscriberId: undefined,
+        sfmcSpouseSubscriberId: spouseSubscriberId,
       };
 
-      $ctrl.setPKeys();
+      $ctrl.setSubscriberIds();
 
-      expect($ctrl.profilePKey).toEqual(undefined);
-      expect($ctrl.spousePKey).toEqual(spousePKey);
+      expect($ctrl.sfmcSubscriberId).toEqual(undefined);
+      expect($ctrl.sfmcSpouseSubscriberId).toEqual(spouseSubscriberId);
     });
 
-    it('should set PKey for both primary and spouse emails', () => {
+    it('should set subscriberId for both primary and spouse emails', () => {
       $ctrl.donorDetails = {
-        'acs-profile-pkey': primaryPKey,
-        'acs-spouse-profile-pkey': spousePKey,
+        sfmcSubscriberId: primarySubscriberId,
+        sfmcSpouseSubscriberId: spouseSubscriberId,
       };
 
-      $ctrl.setPKeys();
+      $ctrl.setSubscriberIds();
 
-      expect($ctrl.profilePKey).toEqual(primaryPKey);
-      expect($ctrl.spousePKey).toEqual(spousePKey);
+      expect($ctrl.sfmcSubscriberId).toEqual(primarySubscriberId);
+      expect($ctrl.sfmcSpouseSubscriberId).toEqual(spouseSubscriberId);
     });
 
-    it('should set PKey to undefined for both primary and spouse emails', () => {
+    it('should set subscriberId to undefined for both primary and spouse emails', () => {
       $ctrl.donorDetails = {
-        'acs-profile-pkey': undefined,
-        'acs-spouse-profile-pkey': undefined,
+        sfmcSubscriberId: undefined,
+        sfmcSpouseSubscriberId: undefined,
       };
 
-      $ctrl.setPKeys();
+      $ctrl.setSubscriberIds();
 
-      expect($ctrl.profilePKey).toEqual(undefined);
-      expect($ctrl.spousePKey).toEqual(undefined);
+      expect($ctrl.sfmcSubscriberId).toEqual(undefined);
+      expect($ctrl.sfmcSpouseSubscriberId).toEqual(undefined);
     });
   });
 
-  describe('linkToAdobeCampaign()', () => {
+  describe('linkToSfmc()', () => {
     beforeEach(() => {
       jest.spyOn(window, 'open').mockImplementation(() => {});
     });
 
-    it('should open tab if pKey is present', () => {
-      $ctrl.linkToAdobeCampaign('123456');
+    it('should open tab if subscriberId is present', () => {
+      $ctrl.linkToSfmc('123456');
 
       expect(window.open).toHaveBeenCalledWith(
-        'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=123456',
+        'https://cloud.connect.cru.org/preferences?SubscriberId=123456',
       );
     });
 
-    it('should not open tab if pKey is undefined', () => {
-      $ctrl.linkToAdobeCampaign(undefined);
+    it('should not open tab if subscriberId is undefined', () => {
+      $ctrl.linkToSfmc(undefined);
 
       expect(window.open).not.toHaveBeenCalled();
     });

--- a/src/app/profile/profile.component.spec.js
+++ b/src/app/profile/profile.component.spec.js
@@ -449,8 +449,8 @@ describe('ProfileComponent', function () {
 
     it('should set subscriberId for primary email', () => {
       $ctrl.donorDetails = {
-        sfmcSubscriberId: primarySubscriberId,
-        sfmcSpouseSubscriberId: undefined,
+        'sfmc-subscriber-id': primarySubscriberId,
+        'sfmc-spouse-subscriber-id': undefined,
       };
 
       $ctrl.setSubscriberIds();
@@ -461,8 +461,8 @@ describe('ProfileComponent', function () {
 
     it('should set subscriberId for spouse email', () => {
       $ctrl.donorDetails = {
-        sfmcSubscriberId: undefined,
-        sfmcSpouseSubscriberId: spouseSubscriberId,
+        'sfmc-subscriber-id': undefined,
+        'sfmc-spouse-subscriber-id': spouseSubscriberId,
       };
 
       $ctrl.setSubscriberIds();
@@ -473,8 +473,8 @@ describe('ProfileComponent', function () {
 
     it('should set subscriberId for both primary and spouse emails', () => {
       $ctrl.donorDetails = {
-        sfmcSubscriberId: primarySubscriberId,
-        sfmcSpouseSubscriberId: spouseSubscriberId,
+        'sfmc-subscriber-id': primarySubscriberId,
+        'sfmc-spouse-subscriber-id': spouseSubscriberId,
       };
 
       $ctrl.setSubscriberIds();
@@ -485,8 +485,8 @@ describe('ProfileComponent', function () {
 
     it('should set subscriberId to undefined for both primary and spouse emails', () => {
       $ctrl.donorDetails = {
-        sfmcSubscriberId: undefined,
-        sfmcSpouseSubscriberId: undefined,
+        'sfmc-subscriber-id': undefined,
+        'sfmc-spouse-subscriber-id': undefined,
       };
 
       $ctrl.setSubscriberIds();

--- a/src/app/profile/profile.component.spec.js
+++ b/src/app/profile/profile.component.spec.js
@@ -17,6 +17,11 @@ describe('ProfileComponent', function () {
       module.name,
       {
         $window: { location: '/profile.html' },
+        envService: {
+          read: jest
+            .fn()
+            .mockReturnValue('https://cloud.connect.cru.org/preferences'),
+        },
       },
       {
         donorEmailForm: {
@@ -484,26 +489,6 @@ describe('ProfileComponent', function () {
 
       expect($ctrl.sfmcSubscriberId).toEqual(undefined);
       expect($ctrl.sfmcSpouseSubscriberId).toEqual(undefined);
-    });
-  });
-
-  describe('linkToSfmc()', () => {
-    beforeEach(() => {
-      jest.spyOn(window, 'open').mockImplementation(() => {});
-    });
-
-    it('should open tab if subscriberId is present', () => {
-      $ctrl.linkToSfmc('123456');
-
-      expect(window.open).toHaveBeenCalledWith(
-        'https://cloud.connect.cru.org/preferences?SubscriberId=123456',
-      );
-    });
-
-    it('should not open tab if subscriberId is undefined', () => {
-      $ctrl.linkToSfmc(undefined);
-
-      expect(window.open).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -378,9 +378,10 @@
                           </div>
                           <a
                             id="donorEmailPreferences"
-                            href=""
                             ng-if="$ctrl.sfmcSubscriberId"
-                            ng-click="$ctrl.linkToSfmc($ctrl.sfmcSubscriberId)"
+                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSubscriberId}}"
+                            target="_blank"
+                            rel="noopener noreferrer"
                             translate
                             >Edit Email Preferences</a
                           >
@@ -435,9 +436,10 @@
                           </div>
                           <a
                             id="spouseEmailPreferences"
-                            href=""
                             ng-if="$ctrl.sfmcSpouseSubscriberId"
-                            ng-click="$ctrl.linkToSfmc($ctrl.sfmcSpouseSubscriberId)"
+                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSpouseSubscriberId}}"
+                            target="_blank"
+                            rel="noopener noreferrer"
                             translate
                             >Edit Email Preferences</a
                           >

--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -379,7 +379,7 @@
                           <a
                             id="donorEmailPreferences"
                             ng-if="$ctrl.sfmcSubscriberId"
-                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSubscriberId}}"
+                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSubscriberId}}&ClientId={{$ctrl.sfmcClientId}}"
                             target="_blank"
                             rel="noopener noreferrer"
                             translate
@@ -437,7 +437,7 @@
                           <a
                             id="spouseEmailPreferences"
                             ng-if="$ctrl.sfmcSpouseSubscriberId"
-                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSpouseSubscriberId}}"
+                            ng-href="{{$ctrl.sfmcUrl}}?SubscriberId={{$ctrl.sfmcSpouseSubscriberId}}&ClientId={{$ctrl.sfmcClientId}}"
                             target="_blank"
                             rel="noopener noreferrer"
                             translate

--- a/src/app/profile/profile.tpl.html
+++ b/src/app/profile/profile.tpl.html
@@ -379,8 +379,8 @@
                           <a
                             id="donorEmailPreferences"
                             href=""
-                            ng-if="$ctrl.profilePKey"
-                            ng-click="$ctrl.linkToAdobeCampaign($ctrl.profilePKey)"
+                            ng-if="$ctrl.sfmcSubscriberId"
+                            ng-click="$ctrl.linkToSfmc($ctrl.sfmcSubscriberId)"
                             translate
                             >Edit Email Preferences</a
                           >
@@ -436,8 +436,8 @@
                           <a
                             id="spouseEmailPreferences"
                             href=""
-                            ng-if="$ctrl.spousePKey"
-                            ng-click="$ctrl.linkToAdobeCampaign($ctrl.spousePKey)"
+                            ng-if="$ctrl.sfmcSpouseSubscriberId"
+                            ng-click="$ctrl.linkToSfmc($ctrl.sfmcSpouseSubscriberId)"
                             translate
                             >Edit Email Preferences</a
                           >

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -56,8 +56,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://localhost.cru.org:9000',
         publicCru: 'https://stage.cru.org',
         publicGive: 'https://give-stage2.cru.org',
-        acsUrl:
-          'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=',
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://localhost.cru.org:9000',
@@ -69,8 +67,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-dev-cloud.cru.org',
         publicCru: 'https://stage-cloud.cru.org',
         publicGive: 'https://give-dev-cloud.cru.org',
-        acsUrl:
-          'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=',
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-dev-cloud.cru.org',
@@ -82,8 +78,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-stage-cloud.cru.org',
         publicCru: 'https://stage-cloud.cru.org',
         publicGive: 'https://give-stage-cloud.cru.org',
-        acsUrl:
-          'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=',
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage-cloud.cru.org',
@@ -95,8 +89,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-prod-cloud.cru.org',
         publicCru: 'https://www.cru.org',
         publicGive: 'https://give-prod-cloud.cru.org',
-        acsUrl:
-          'https://cru-mkt-prod1-m.adobe-campaign.com/lp/LPEmailPrefCenter?_uuid=8831d67a-0d46-406b-8987-fd07c97c4ca7&service=%400fAlW4GPmxXExp8qlx7HDlAM6FSZUd0yYRlQg6HRsO_kglfi0gs650oHPZX6LrOvg7OHoIWWpobOeGZduxdNU_m5alc&pkey=',
         oktaUrl: 'https://signon.okta.com',
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give-prod-cloud.cru.org',
@@ -108,8 +100,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-stage2.cru.org',
         publicCru: 'https://stage.cru.org',
         publicGive: 'https://give-stage2.cru.org',
-        acsUrl:
-          'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=',
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage2.cru.org',
@@ -121,8 +111,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-stage2-next.cru.org',
         publicCru: 'https://stage.cru.org',
         publicGive: 'https://give-stage2-next.cru.org',
-        acsUrl:
-          'https://cru-mkt-stage1.adobe-campaign.com/lp/LP63?_uuid=f1938f90-38ea-41a6-baad-9ac133f6d2ec&service=%404k83N_C5RZnLNvwz7waA2SwyzIuP6ATcN8vJjmT5km0iZPYKUUYk54sthkZjj-hltAuOKDYocuEi5Pxv8BSICoA4uppcvU_STKCzjv9RzLpE4hqj&pkey=',
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage2-next.cru.org',
@@ -133,8 +121,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give-preprod.cru.org',
         publicCru: 'https://www.cru.org',
         publicGive: 'https://give-preprod.cru.org',
-        acsUrl:
-          'https://cru-mkt-prod1-m.adobe-campaign.com/lp/LPEmailPrefCenter?_uuid=8831d67a-0d46-406b-8987-fd07c97c4ca7&service=%400fAlW4GPmxXExp8qlx7HDlAM6FSZUd0yYRlQg6HRsO_kglfi0gs650oHPZX6LrOvg7OHoIWWpobOeGZduxdNU_m5alc&pkey=',
         oktaUrl: 'https://signon.okta.com',
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give-preprod.cru.org',
@@ -145,8 +131,6 @@ export const appConfig = /* @ngInject */ function (
         imgDomainDesignation: 'https://give.cru.org',
         publicCru: 'https://www.cru.org',
         publicGive: 'https://give.cru.org',
-        acsUrl:
-          'https://cru-mkt-prod1-m.adobe-campaign.com/lp/LPEmailPrefCenter?_uuid=8831d67a-0d46-406b-8987-fd07c97c4ca7&service=%400fAlW4GPmxXExp8qlx7HDlAM6FSZUd0yYRlQg6HRsO_kglfi0gs650oHPZX6LrOvg7OHoIWWpobOeGZduxdNU_m5alc&pkey=',
         oktaUrl: 'https://signon.okta.com',
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give.cru.org',

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -61,6 +61,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://localhost.cru.org:9000',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       devcloud: {
         apiUrl: 'https://give-stage2.cru.org',
@@ -73,6 +74,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://give-dev-cloud.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       stagecloud: {
         apiUrl: 'https://give-stage-cloud.cru.org',
@@ -85,6 +87,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://give-stage-cloud.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       prodcloud: {
         apiUrl: 'https://give-prod-cloud.cru.org',
@@ -97,6 +100,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://give-prod-cloud.cru.org',
         recaptchaKey: '6LduSiQqAAAAAOLA7NEU8-3-mdCmBKEUCwaFQuJF',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       staging: {
         apiUrl: 'https://give-stage2.cru.org',
@@ -109,6 +113,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://give-stage2.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       nonprod: {
         apiUrl: 'https://give-stage2-next.cru.org',
@@ -120,6 +125,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage2-next.cru.org',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       preprod: {
         apiUrl: 'https://give-preprod.cru.org',
@@ -131,6 +137,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give-preprod.cru.org',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       production: {
         apiUrl: 'https://give.cru.org',
@@ -143,6 +150,7 @@ export const appConfig = /* @ngInject */ function (
         oktaReferrer: 'https://give.cru.org',
         recaptchaKey: '6LduSiQqAAAAAOLA7NEU8-3-mdCmBKEUCwaFQuJF',
         sfmcUrl: 'https://cloud.connect.cru.org/preferences',
+        sfmcClientId: '534014548',
       },
       defaults: {
         isCheckout: false,

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -60,6 +60,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://localhost.cru.org:9000',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       devcloud: {
         apiUrl: 'https://give-stage2.cru.org',
@@ -71,6 +72,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-dev-cloud.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       stagecloud: {
         apiUrl: 'https://give-stage-cloud.cru.org',
@@ -82,6 +84,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage-cloud.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       prodcloud: {
         apiUrl: 'https://give-prod-cloud.cru.org',
@@ -93,6 +96,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give-prod-cloud.cru.org',
         recaptchaKey: '6LduSiQqAAAAAOLA7NEU8-3-mdCmBKEUCwaFQuJF',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       staging: {
         apiUrl: 'https://give-stage2.cru.org',
@@ -104,6 +108,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage2.cru.org',
         recaptchaKey: '6LcCMoYqAAAAABMoyLs5CyKWwE8qn_YslEaiRPRD',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       nonprod: {
         apiUrl: 'https://give-stage2-next.cru.org',
@@ -114,6 +119,7 @@ export const appConfig = /* @ngInject */ function (
         oktaUrl: 'https://cru.oktapreview.com',
         oktaClientId: '0oa26fp9l9iFxuKJf0h8',
         oktaReferrer: 'https://give-stage2-next.cru.org',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       preprod: {
         apiUrl: 'https://give-preprod.cru.org',
@@ -124,6 +130,7 @@ export const appConfig = /* @ngInject */ function (
         oktaUrl: 'https://signon.okta.com',
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give-preprod.cru.org',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       production: {
         apiUrl: 'https://give.cru.org',
@@ -135,6 +142,7 @@ export const appConfig = /* @ngInject */ function (
         oktaClientId: '0oa22s4b0hbsS58xv0h8',
         oktaReferrer: 'https://give.cru.org',
         recaptchaKey: '6LduSiQqAAAAAOLA7NEU8-3-mdCmBKEUCwaFQuJF',
+        sfmcUrl: 'https://cloud.connect.cru.org/preferences',
       },
       defaults: {
         isCheckout: false,


### PR DESCRIPTION
## Description

- Switch the "Edit Email Preferences" link on the profile page from Adobe Campaign Standard (ACS) to Salesforce Marketing Cloud (SFMC)
- Replace `acsUrl` config with `sfmcUrl` (`https://cloud.connect.cru.org/preferences`) across all environments
- Replace `acs-profile-pkey` / `acs-spouse-profile-pkey` donor detail fields with `sfmcSubscriberId` / `sfmcSpouseSubscriberId`
- Rename `setPKeys()` to `setSubscriberIds()` and remove `linkToAdobeCampaign()` method
- Update template to use `ng-href` with `SubscriberId` query param instead of `ng-click` with pKey, opening in a new tab
- Related Jira ticket: [MPDX-9455](https://jira.cru.org/browse/MPDX-9455)

## Testing

- Go to the profile page
- Verify the "Edit Email Preferences" link appears for the primary email when `sfmcSubscriberId` is present
- Verify the "Edit Email Preferences" link appears for the spouse email when `sfmcSpouseSubscriberId` is present
- Click the link and check that it opens `https://cloud.connect.cru.org/preferences?SubscriberId=<id>` in a new tab
- Verify the link does not appear when the subscriber ID is undefined

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested a review from another person on the project
- [ ] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [ ] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout