### PR TITLE
Urgent fix - Adding reCaptcha logic to the Sign up widget

### DIFF
--- a/src/assets/scss/components/_oktaSigninWidget.scss
+++ b/src/assets/scss/components/_oktaSigninWidget.scss
@@ -125,6 +125,10 @@ sign-up-modal {
         border: 1px solid transparent;
         border-radius: 0;
 
+        &::after {
+          display: none;
+        }
+
         span {
           // Make the selected item color match the color of text inputs
           color: $okta-text-color;

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -209,12 +209,22 @@ class SignUpModalController {
     const passwordInput = schema.find(
       (field) => field.name === 'credentials.passcode',
     );
-    // When Okta has CAPTCHA enabled for sign-up, the schema includes a field
-    // with `type: 'captcha'`. The widget's CaptchaView renders it and supplies
-    // the `captchaVerify` token on submit. It must be present in the step that
-    // actually submits to Okta (step 3) — otherwise the IDX call fails with
-    // "captchaVerify is null".
-    const captchaInput = schema.find((field) => field.type === 'captcha');
+    // When Okta has CAPTCHA enabled, the schema includes two flattened
+    // captchaVerify.* fields:
+    //   - captchaVerify.captchaId   — a hidden field whose value is the
+    //     Okta-side captcha config id (we need to send this back)
+    //   - captchaVerify.captchaToken — a type:'captcha' field that the
+    //     widget uses to render and resolve the reCAPTCHA challenge
+    // We capture the captchaId here so submitFinalData can attach it to
+    // the IDX payload; the widget's v2 view-builder only writes the token.
+    const captchaIdField = schema.find(
+      (field) => field.name === 'captchaVerify.captchaId',
+    );
+    this.captchaId = captchaIdField?.value || null;
+    const captchaTokenInput = schema.find(
+      (field) => field.name === 'captchaVerify.captchaToken',
+    );
+
     return {
       // Step 1: Name, email, account type and organization name (if applicable)
       1: this.getStep1Fields(schema),
@@ -222,7 +232,7 @@ class SignUpModalController {
       2: this.getStep2Fields(schema),
       // Step 3: Password (We don't save the password for security reasons.
       // Which is why it's the last step)
-      3: [passwordInput, ...(captchaInput ? [captchaInput] : [])],
+      3: [passwordInput, ...(captchaTokenInput ? [captchaTokenInput] : [])],
     };
   }
 
@@ -511,6 +521,12 @@ class SignUpModalController {
       lastName: this.$scope.lastName,
       email: this.$scope.email,
     };
+    // Okta requires captchaVerify to contain BOTH captchaId and
+    // captchaToken. The widget's v2 view-builder only writes the token,
+    // so we attach the captchaId we captured from the schema in getSteps.
+    if (postData.captchaVerify && this.captchaId) {
+      postData.captchaVerify.captchaId = this.captchaId;
+    }
     onSuccess(postData);
   }
 

--- a/src/common/components/signUpModal/signUpModal.component.js
+++ b/src/common/components/signUpModal/signUpModal.component.js
@@ -209,6 +209,12 @@ class SignUpModalController {
     const passwordInput = schema.find(
       (field) => field.name === 'credentials.passcode',
     );
+    // When Okta has CAPTCHA enabled for sign-up, the schema includes a field
+    // with `type: 'captcha'`. The widget's CaptchaView renders it and supplies
+    // the `captchaVerify` token on submit. It must be present in the step that
+    // actually submits to Okta (step 3) — otherwise the IDX call fails with
+    // "captchaVerify is null".
+    const captchaInput = schema.find((field) => field.type === 'captcha');
     return {
       // Step 1: Name, email, account type and organization name (if applicable)
       1: this.getStep1Fields(schema),
@@ -216,7 +222,7 @@ class SignUpModalController {
       2: this.getStep2Fields(schema),
       // Step 3: Password (We don't save the password for security reasons.
       // Which is why it's the last step)
-      3: [passwordInput],
+      3: [passwordInput, ...(captchaInput ? [captchaInput] : [])],
     };
   }
 

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -446,6 +446,32 @@ describe('signUpForm', function () {
         ]);
       });
     });
+
+    describe('getStep3Fields() (captcha passthrough)', () => {
+      const onSuccess = jest.fn();
+      beforeEach(() => {
+        $ctrl.currentStep = 3;
+        onSuccess.mockClear();
+      });
+
+      it('returns just the password field when no captcha is in the schema', () => {
+        $ctrl.parseSchema(schema, onSuccess);
+        expect(onSuccess).toHaveBeenCalledWith([schema[3]]);
+      });
+
+      it('includes the captcha field on step 3 when Okta has CAPTCHA enabled', () => {
+        const captchaField = {
+          name: 'captchaVerify',
+          type: 'captcha',
+          required: true,
+        };
+        const schemaWithCaptcha = [...schema, captchaField];
+
+        $ctrl.parseSchema(schemaWithCaptcha, onSuccess);
+
+        expect(onSuccess).toHaveBeenCalledWith([schema[3], captchaField]);
+      });
+    });
   });
 
   describe('loadCountries()', () => {

--- a/src/common/components/signUpModal/signUpModal.component.spec.js
+++ b/src/common/components/signUpModal/signUpModal.component.spec.js
@@ -451,25 +451,39 @@ describe('signUpForm', function () {
       const onSuccess = jest.fn();
       beforeEach(() => {
         $ctrl.currentStep = 3;
+        $ctrl.captchaId = null;
         onSuccess.mockClear();
       });
 
-      it('returns just the password field when no captcha is in the schema', () => {
+      it('returns just the password field when no captcha fields are in the schema', () => {
         $ctrl.parseSchema(schema, onSuccess);
         expect(onSuccess).toHaveBeenCalledWith([schema[3]]);
+        expect($ctrl.captchaId).toBeNull();
       });
 
-      it('includes the captcha field on step 3 when Okta has CAPTCHA enabled', () => {
-        const captchaField = {
-          name: 'captchaVerify',
+      it('captures captchaId and includes the captchaToken field when Okta has CAPTCHA enabled', () => {
+        const captchaIdField = {
+          name: 'captchaVerify.captchaId',
+          type: 'string',
+          value: 'abc123captchaConfigId',
+          visible: false,
+        };
+        const captchaTokenField = {
+          name: 'captchaVerify.captchaToken',
           type: 'captcha',
           required: true,
+          visible: false,
         };
-        const schemaWithCaptcha = [...schema, captchaField];
+        const schemaWithCaptcha = [
+          ...schema,
+          captchaIdField,
+          captchaTokenField,
+        ];
 
         $ctrl.parseSchema(schemaWithCaptcha, onSuccess);
 
-        expect(onSuccess).toHaveBeenCalledWith([schema[3], captchaField]);
+        expect(onSuccess).toHaveBeenCalledWith([schema[3], captchaTokenField]);
+        expect($ctrl.captchaId).toBe('abc123captchaConfigId');
       });
     });
   });
@@ -918,6 +932,45 @@ describe('signUpForm', function () {
           email: user.email,
         },
       });
+    });
+
+    it('wraps captchaVerify with the captured captchaId before submission', () => {
+      $ctrl.captchaId = 'abc123captchaConfigId';
+      $ctrl.$scope.firstName = 'Daniel';
+      $ctrl.$scope.lastName = 'Bisgrove';
+      $ctrl.$scope.email = 'd@example.com';
+
+      const postData = {
+        captchaVerify: { captchaToken: 'real-grecaptcha-token-from-google' },
+      };
+      const onSuccess = jest.fn();
+
+      $ctrl.submitFinalData(postData, onSuccess);
+
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          captchaVerify: {
+            captchaId: 'abc123captchaConfigId',
+            captchaToken: 'real-grecaptcha-token-from-google',
+          },
+        }),
+      );
+    });
+
+    it('leaves postData unchanged when no captchaVerify is present', () => {
+      $ctrl.captchaId = 'abc123captchaConfigId';
+      $ctrl.$scope.firstName = 'Daniel';
+      $ctrl.$scope.lastName = 'Bisgrove';
+      $ctrl.$scope.email = 'd@example.com';
+
+      const postData = {};
+      const onSuccess = jest.fn();
+
+      $ctrl.submitFinalData(postData, onSuccess);
+
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.not.objectContaining({ captchaVerify: expect.anything() }),
+      );
     });
   });
 


### PR DESCRIPTION
## Description
In this PR, I address the issue preventing users from signing up due to the reCaptcha problem.

On April 20th, our Okta instance enabled reCaptcha for production. Since the Give site hosts the sign-up widget, we needed to add our give domains to the reCaptcha allowed list. We also updated the sign-up widget to include two new reCaptcha fields and ensure the correct information is sent to Okta.

Today, I updated Terraform to include the Give site domains: https://github.com/CruGlobal/cru-terraform/pull/10582.

This PR modifies the Give site to enable reCaptcha functionality.

Yes, this does mean since April 20th no one has been able to sign up on the Give site.

## Testing
Sign up for an account and ensure you make it to the verify email section. The recaptcha section is on the password step.

## Checklist:

- [ ] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [ ] I have requested a review from another person on the project
- [ ] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [ ] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout
