### PR TITLE
Detect partial-login state and fix shadowing cortex-role cookie

### DIFF
--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -489,7 +489,7 @@ export const appConfig = /* @ngInject */ function (
     SESSION_MISMATCH_STEP_1:
       'Click the <strong>three dots</strong> (top-right corner) &rarr; <strong>Settings</strong>',
     SESSION_MISMATCH_STEP_2:
-      'Go to <strong>Privacy and Security</strong> &rarr; <strong>Site and Shields Settings</strong>',
+      'Go to <strong>Privacy and Security</strong> &rarr; <strong>Site Settings</strong>',
     SESSION_MISMATCH_STEP_3:
       'Click <strong>View permissions and data stored across sites</strong>',
     SESSION_MISMATCH_STEP_4:

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -489,11 +489,13 @@ export const appConfig = /* @ngInject */ function (
     SESSION_MISMATCH_STEP_1:
       'Click the <strong>three dots</strong> (top-right corner) &rarr; <strong>Settings</strong>',
     SESSION_MISMATCH_STEP_2:
-      'Go to <strong>Privacy and Security</strong> &rarr; <strong>Site Settings</strong>',
+      'Go to <strong>Privacy and Security</strong> &rarr; <strong>Third-Party Cookies</strong>',
     SESSION_MISMATCH_STEP_3:
-      'Click <strong>View permissions and data stored across sites</strong>',
+      'Click <strong>See all site data and permissions</strong>',
     SESSION_MISMATCH_STEP_4:
       'Find <strong>cru.org</strong> and click the <strong>trash can icon</strong> to delete it',
+    SESSION_MISMATCH_RELOAD_AGAIN:
+      'Then reload the page and log in again.',
     SESSION_MISMATCH_CONTACT:
       'Still stuck? Email <a href="mailto:techhelp@cru.org">techhelp@cru.org</a> - we\'re happy to help!',
   });
@@ -808,11 +810,13 @@ export const appConfig = /* @ngInject */ function (
     SESSION_MISMATCH_STEP_1:
       'Haga clic en los <strong>tres puntos</strong> (esquina superior derecha) &rarr; <strong>Configuración</strong>',
     SESSION_MISMATCH_STEP_2:
-      'Vaya a <strong>Privacidad y seguridad</strong> &rarr; <strong>Configuración de sitios</strong>',
+      'Vaya a <strong>Privacidad y seguridad</strong> &rarr; <strong>Cookies de terceros</strong>',
     SESSION_MISMATCH_STEP_3:
-      'Haga clic en <strong>Ver permisos y datos almacenados en los sitios</strong>',
+      'Haga clic en <strong>Ver todos los datos y permisos de los sitios</strong>',
     SESSION_MISMATCH_STEP_4:
       'Busque <strong>cru.org</strong> y haga clic en el <strong>ícono de papelera</strong> para eliminarlo',
+    SESSION_MISMATCH_RELOAD_AGAIN:
+      'Luego vuelva a cargar la página e inicie sesión de nuevo.',
     SESSION_MISMATCH_CONTACT:
       '¿Aún tiene problemas? Escríbanos a <a href="mailto:techhelp@cru.org">techhelp@cru.org</a>; ¡con gusto le ayudaremos!',
   });

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -494,8 +494,7 @@ export const appConfig = /* @ngInject */ function (
       'Click <strong>See all site data and permissions</strong>',
     SESSION_MISMATCH_STEP_4:
       'Find <strong>cru.org</strong> and click the <strong>trash can icon</strong> to delete it',
-    SESSION_MISMATCH_RELOAD_AGAIN:
-      'Then reload the page and log in again.',
+    SESSION_MISMATCH_RELOAD_AGAIN: 'Then reload the page and log in again.',
     SESSION_MISMATCH_CONTACT:
       'Still stuck? Email <a href="mailto:techhelp@cru.org">techhelp@cru.org</a> - we\'re happy to help!',
   });

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -482,6 +482,20 @@ export const appConfig = /* @ngInject */ function (
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
     CUSTOM_AMOUNT: 'Custom Amount',
+    SESSION_MISMATCH_RELOAD:
+      '<strong>Please reload this page and log in again.</strong>',
+    SESSION_MISMATCH_CLEAR_DATA:
+      "If it still doesn't work, you'll need to clear saved data for cru.org in Chrome:",
+    SESSION_MISMATCH_STEP_1:
+      'Click the <strong>three dots</strong> (top-right corner) &rarr; <strong>Settings</strong>',
+    SESSION_MISMATCH_STEP_2:
+      'Go to <strong>Privacy and Security</strong> &rarr; <strong>Site and Shields Settings</strong>',
+    SESSION_MISMATCH_STEP_3:
+      'Click <strong>View permissions and data stored across sites</strong>',
+    SESSION_MISMATCH_STEP_4:
+      'Find <strong>cru.org</strong> and click the <strong>trash can icon</strong> to delete it',
+    SESSION_MISMATCH_CONTACT:
+      'Still stuck? Email <a href="mailto:techhelp@cru.org">techhelp@cru.org</a> - we\'re happy to help!',
   });
 
   $translateProvider.translations('es', {
@@ -787,6 +801,20 @@ export const appConfig = /* @ngInject */ function (
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
     CUSTOM_AMOUNT: 'Custom Amount',
+    SESSION_MISMATCH_RELOAD:
+      '<strong>Vuelva a cargar esta página e inicie sesión de nuevo.</strong>',
+    SESSION_MISMATCH_CLEAR_DATA:
+      'Si aún no funciona, deberá borrar los datos guardados de cru.org en Chrome:',
+    SESSION_MISMATCH_STEP_1:
+      'Haga clic en los <strong>tres puntos</strong> (esquina superior derecha) &rarr; <strong>Configuración</strong>',
+    SESSION_MISMATCH_STEP_2:
+      'Vaya a <strong>Privacidad y seguridad</strong> &rarr; <strong>Configuración de sitios</strong>',
+    SESSION_MISMATCH_STEP_3:
+      'Haga clic en <strong>Ver permisos y datos almacenados en los sitios</strong>',
+    SESSION_MISMATCH_STEP_4:
+      'Busque <strong>cru.org</strong> y haga clic en el <strong>ícono de papelera</strong> para eliminarlo',
+    SESSION_MISMATCH_CONTACT:
+      '¿Aún tiene problemas? Escríbanos a <a href="mailto:techhelp@cru.org">techhelp@cru.org</a>; ¡con gusto le ayudaremos!',
   });
   $translateProvider.preferredLanguage('en');
 };

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import 'angular-gettext';
 import uibTooltip from 'angular-ui-bootstrap/src/tooltip';
+import sessionService, { Roles } from 'common/services/session/session.service';
 import signInButtonComponent from './signInButton/signInButton.component';
 import template from './signInForm.tpl.html';
 
@@ -8,17 +9,60 @@ const componentName = 'signInForm';
 
 class SignInFormController {
   /* @ngInject */
-  constructor(gettext) {
+  constructor($scope, $timeout, gettext, sessionService) {
+    this.$scope = $scope;
+    this.$timeout = $timeout;
     this.gettext = gettext;
+    this.sessionService = sessionService;
   }
 
   $onInit() {
     this.onSignInPage = this.onSignInPage || false;
+    this.showSessionMismatchMessage = false;
+    // Delay the initial check so a normal Okta-redirect flow has time to set
+    // the Cortex session cookies before we conclude the user is in a stuck
+    // state. After the delay, subscribe to sessionSubject so the warning
+    // clears automatically if the role updates later (e.g. the /okta/login
+    // POST was just slow).
+    this.mismatchCheck = this.$timeout(() => {
+      this.sessionSubscription = this.sessionService.sessionSubject.subscribe(
+        () => this.evaluateMismatch(),
+      );
+    }, 2000);
+  }
+
+  $onDestroy() {
+    if (this.mismatchCheck) {
+      this.$timeout.cancel(this.mismatchCheck);
+    }
+    if (this.sessionSubscription) {
+      this.sessionSubscription.unsubscribe();
+    }
+  }
+
+  evaluateMismatch() {
+    this.sessionService
+      .oktaIsUserAuthenticated()
+      .subscribe((isAuthenticated) => {
+        // Mismatch = Okta says signed in, Cortex says anything other than
+        // REGISTERED (PUBLIC, IDENTIFIED, or any future non-REGISTERED state).
+        const mismatch =
+          isAuthenticated && this.sessionService.getRole() !== Roles.registered;
+        if (this.showSessionMismatchMessage !== mismatch) {
+          this.showSessionMismatchMessage = mismatch;
+          this.$scope.$applyAsync();
+        }
+      });
   }
 }
 
 export default angular
-  .module(componentName, [signInButtonComponent.name, uibTooltip, 'gettext'])
+  .module(componentName, [
+    signInButtonComponent.name,
+    sessionService.name,
+    uibTooltip,
+    'gettext',
+  ])
   .component(componentName, {
     controller: SignInFormController,
     templateUrl: template,

--- a/src/common/components/signInForm/signInForm.component.js
+++ b/src/common/components/signInForm/signInForm.component.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 import 'angular-gettext';
 import uibTooltip from 'angular-ui-bootstrap/src/tooltip';
-import sessionService, { Roles } from 'common/services/session/session.service';
+import sessionService from 'common/services/session/session.service';
 import signInButtonComponent from './signInButton/signInButton.component';
 import template from './signInForm.tpl.html';
 
@@ -9,9 +9,8 @@ const componentName = 'signInForm';
 
 class SignInFormController {
   /* @ngInject */
-  constructor($scope, $timeout, gettext, sessionService) {
+  constructor($scope, gettext, sessionService) {
     this.$scope = $scope;
-    this.$timeout = $timeout;
     this.gettext = gettext;
     this.sessionService = sessionService;
   }
@@ -19,40 +18,22 @@ class SignInFormController {
   $onInit() {
     this.onSignInPage = this.onSignInPage || false;
     this.showSessionMismatchMessage = false;
-    // Delay the initial check so a normal Okta-redirect flow has time to set
-    // the Cortex session cookies before we conclude the user is in a stuck
-    // state. After the delay, subscribe to sessionSubject so the warning
-    // clears automatically if the role updates later (e.g. the /okta/login
-    // POST was just slow).
-    this.mismatchCheck = this.$timeout(() => {
-      this.sessionSubscription = this.sessionService.sessionSubject.subscribe(
-        () => this.evaluateMismatch(),
-      );
-    }, 2000);
+    // The session service self-heals a shadowing parent-domain cortex-role
+    // cookie on every session refresh and sets cortexRoleShadowed only when
+    // a non-REGISTERED duplicate persists after that attempt — the one case
+    // where the user has to clear the cookie manually.
+    this.sessionSubscription = this.sessionService.sessionSubject.subscribe(
+      (session) => {
+        this.showSessionMismatchMessage = !!session.cortexRoleShadowed;
+        this.$scope.$applyAsync();
+      },
+    );
   }
 
   $onDestroy() {
-    if (this.mismatchCheck) {
-      this.$timeout.cancel(this.mismatchCheck);
-    }
     if (this.sessionSubscription) {
       this.sessionSubscription.unsubscribe();
     }
-  }
-
-  evaluateMismatch() {
-    this.sessionService
-      .oktaIsUserAuthenticated()
-      .subscribe((isAuthenticated) => {
-        // Mismatch = Okta says signed in, Cortex says anything other than
-        // REGISTERED (PUBLIC, IDENTIFIED, or any future non-REGISTERED state).
-        const mismatch =
-          isAuthenticated && this.sessionService.getRole() !== Roles.registered;
-        if (this.showSessionMismatchMessage !== mismatch) {
-          this.showSessionMismatchMessage = mismatch;
-          this.$scope.$applyAsync();
-        }
-      });
   }
 }
 

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -1,25 +1,19 @@
 import angular from 'angular';
 import 'angular-mocks';
-import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import { Roles } from 'common/services/session/session.service';
 import module from './signInForm.component';
 
 describe('signInForm', function () {
   beforeEach(angular.mock.module(module.name));
-  let $ctrl, bindings, $timeout;
+  let $ctrl, bindings;
 
-  beforeEach(inject(function (_$componentController_, _$timeout_) {
-    $timeout = _$timeout_;
+  beforeEach(inject(function (_$componentController_) {
     bindings = {
       onSuccess: jest.fn(),
       onFailure: jest.fn(),
     };
 
     const scope = { $applyAsync: jest.fn() };
-    scope.$applyAsync.mockImplementation(() => {});
     $ctrl = _$componentController_(module.name, { $scope: scope }, bindings);
     $ctrl.sessionService.sessionSubject = new BehaviorSubject({});
   }));
@@ -28,85 +22,41 @@ describe('signInForm', function () {
     expect($ctrl).toBeDefined();
   });
 
-  describe('session mismatch detection', () => {
-    it('shows the mismatch message when Okta is authenticated but Cortex role is PUBLIC', () => {
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(true));
-      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
-
+  describe('session mismatch warning', () => {
+    it('stays hidden while the session has no shadowed cortex-role', () => {
       $ctrl.$onInit();
-      $timeout.flush();
-
-      expect($ctrl.showSessionMismatchMessage).toBe(true);
-    });
-
-    it('shows the mismatch message when Okta is authenticated but Cortex role is IDENTIFIED', () => {
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(true));
-      jest
-        .spyOn($ctrl.sessionService, 'getRole')
-        .mockReturnValue(Roles.identified);
-
-      $ctrl.$onInit();
-      $timeout.flush();
-
-      expect($ctrl.showSessionMismatchMessage).toBe(true);
-    });
-
-    it('does not show the mismatch message when Okta is not authenticated', () => {
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(false));
-      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
-
-      $ctrl.$onInit();
-      $timeout.flush();
 
       expect($ctrl.showSessionMismatchMessage).toBe(false);
     });
 
-    it('does not show the mismatch message when the user is already registered', () => {
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(true));
-      jest
-        .spyOn($ctrl.sessionService, 'getRole')
-        .mockReturnValue(Roles.registered);
-
+    it('shows when the session service reports a shadow it could not heal', () => {
       $ctrl.$onInit();
-      $timeout.flush();
 
-      expect($ctrl.showSessionMismatchMessage).toBe(false);
+      $ctrl.sessionService.sessionSubject.next({ cortexRoleShadowed: true });
+
+      expect($ctrl.showSessionMismatchMessage).toBe(true);
+      expect($ctrl.$scope.$applyAsync).toHaveBeenCalled();
     });
 
-    it('clears the mismatch message when the role updates to REGISTERED after the initial check', () => {
-      const getRoleSpy = jest
-        .spyOn($ctrl.sessionService, 'getRole')
-        .mockReturnValue(Roles.public);
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(true));
+    it('shows immediately when the session is already shadowed at init', () => {
+      $ctrl.sessionService.sessionSubject.next({ cortexRoleShadowed: true });
 
       $ctrl.$onInit();
-      $timeout.flush();
-      expect($ctrl.showSessionMismatchMessage).toBe(true);
 
-      getRoleSpy.mockReturnValue(Roles.registered);
-      $ctrl.sessionService.sessionSubject.next({});
+      expect($ctrl.showSessionMismatchMessage).toBe(true);
+    });
+
+    it('clears once a later session refresh heals the shadow', () => {
+      $ctrl.$onInit();
+      $ctrl.sessionService.sessionSubject.next({ cortexRoleShadowed: true });
+
+      $ctrl.sessionService.sessionSubject.next({ role: 'REGISTERED' });
 
       expect($ctrl.showSessionMismatchMessage).toBe(false);
     });
 
     it('unsubscribes from the session on $onDestroy', () => {
-      jest
-        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
-        .mockReturnValue(Observable.of(false));
-      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
-
       $ctrl.$onInit();
-      $timeout.flush();
       const unsubscribeSpy = jest.spyOn(
         $ctrl.sessionSubscription,
         'unsubscribe',

--- a/src/common/components/signInForm/signInForm.component.spec.js
+++ b/src/common/components/signInForm/signInForm.component.spec.js
@@ -1,26 +1,120 @@
 import angular from 'angular';
 import 'angular-mocks';
+import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/of';
+import { Roles } from 'common/services/session/session.service';
 import module from './signInForm.component';
 
 describe('signInForm', function () {
   beforeEach(angular.mock.module(module.name));
-  let $ctrl, bindings, $rootScope;
+  let $ctrl, bindings, $timeout;
 
-  beforeEach(inject(function (_$rootScope_, _$componentController_) {
-    $rootScope = _$rootScope_;
+  beforeEach(inject(function (_$componentController_, _$timeout_) {
+    $timeout = _$timeout_;
     bindings = {
       onSuccess: jest.fn(),
       onFailure: jest.fn(),
     };
 
-    const scope = { $apply: jest.fn() };
-    scope.$apply.mockImplementation(() => {});
+    const scope = { $applyAsync: jest.fn() };
+    scope.$applyAsync.mockImplementation(() => {});
     $ctrl = _$componentController_(module.name, { $scope: scope }, bindings);
+    $ctrl.sessionService.sessionSubject = new BehaviorSubject({});
   }));
 
   it('to be defined', function () {
     expect($ctrl).toBeDefined();
+  });
+
+  describe('session mismatch detection', () => {
+    it('shows the mismatch message when Okta is authenticated but Cortex role is PUBLIC', () => {
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(true));
+      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
+
+      $ctrl.$onInit();
+      $timeout.flush();
+
+      expect($ctrl.showSessionMismatchMessage).toBe(true);
+    });
+
+    it('shows the mismatch message when Okta is authenticated but Cortex role is IDENTIFIED', () => {
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(true));
+      jest
+        .spyOn($ctrl.sessionService, 'getRole')
+        .mockReturnValue(Roles.identified);
+
+      $ctrl.$onInit();
+      $timeout.flush();
+
+      expect($ctrl.showSessionMismatchMessage).toBe(true);
+    });
+
+    it('does not show the mismatch message when Okta is not authenticated', () => {
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(false));
+      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
+
+      $ctrl.$onInit();
+      $timeout.flush();
+
+      expect($ctrl.showSessionMismatchMessage).toBe(false);
+    });
+
+    it('does not show the mismatch message when the user is already registered', () => {
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(true));
+      jest
+        .spyOn($ctrl.sessionService, 'getRole')
+        .mockReturnValue(Roles.registered);
+
+      $ctrl.$onInit();
+      $timeout.flush();
+
+      expect($ctrl.showSessionMismatchMessage).toBe(false);
+    });
+
+    it('clears the mismatch message when the role updates to REGISTERED after the initial check', () => {
+      const getRoleSpy = jest
+        .spyOn($ctrl.sessionService, 'getRole')
+        .mockReturnValue(Roles.public);
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(true));
+
+      $ctrl.$onInit();
+      $timeout.flush();
+      expect($ctrl.showSessionMismatchMessage).toBe(true);
+
+      getRoleSpy.mockReturnValue(Roles.registered);
+      $ctrl.sessionService.sessionSubject.next({});
+
+      expect($ctrl.showSessionMismatchMessage).toBe(false);
+    });
+
+    it('unsubscribes from the session on $onDestroy', () => {
+      jest
+        .spyOn($ctrl.sessionService, 'oktaIsUserAuthenticated')
+        .mockReturnValue(Observable.of(false));
+      jest.spyOn($ctrl.sessionService, 'getRole').mockReturnValue(Roles.public);
+
+      $ctrl.$onInit();
+      $timeout.flush();
+      const unsubscribeSpy = jest.spyOn(
+        $ctrl.sessionSubscription,
+        'unsubscribe',
+      );
+
+      $ctrl.$onDestroy();
+
+      expect(unsubscribeSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -1,4 +1,32 @@
 <div
+  class="alert alert-warning"
+  role="alert"
+  ng-if="$ctrl.showSessionMismatchMessage"
+>
+  <p translate>
+    It appears that you logged in, but the system got a bit confused due to
+    previous cookies. Currently you are only partially logged in.
+  </p>
+  <p translate>To fix this in Chrome, please go to:</p>
+  <ol>
+    <li translate>Chrome Settings</li>
+    <li translate>Privacy and Security</li>
+    <li translate>Third Party Cookies</li>
+    <li translate>See all site data and permissions</li>
+    <li translate>
+      Find <strong>cru.org</strong> and click the trash can icon (&ldquo;Delete
+      site data and permissions for cru.org&rdquo;). Some of the stale cookies
+      are on the parent <em>cru.org</em> domain, not just <em>give.cru.org</em>,
+      so this is the level that needs to be cleared.
+    </li>
+  </ol>
+  <p translate>
+    After doing this, reload this page and log in again. If you continue to have
+    trouble, contact
+    <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
+  </p>
+</div>
+<div
   class="alert alert-danger"
   role="alert"
   ng-if="$ctrl.errorMessage"

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -11,6 +11,7 @@
     <li translate="SESSION_MISMATCH_STEP_3"></li>
     <li translate="SESSION_MISMATCH_STEP_4"></li>
   </ol>
+  <p translate="SESSION_MISMATCH_RELOAD_AGAIN"></p>
   <p translate="SESSION_MISMATCH_CONTACT"></p>
 </div>
 <div

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -7,7 +7,14 @@
     It appears that you logged in, but the system got a bit confused due to
     previous cookies. Currently you are only partially logged in.
   </p>
-  <p translate>To fix this in Chrome, please go to:</p>
+  <p translate>
+    <strong>First, try reloading this page</strong> and signing in again &mdash;
+    we&rsquo;ll attempt to straighten this out automatically.
+  </p>
+  <p translate>
+    If you still see this after reloading, clear your cookies for
+    <strong>cru.org</strong>. In Chrome:
+  </p>
   <ol>
     <li translate>Chrome Settings</li>
     <li translate>Privacy and Security</li>
@@ -21,8 +28,8 @@
     </li>
   </ol>
   <p translate>
-    After doing this, reload this page and log in again. If you continue to have
-    trouble, contact
+    Then reload this page and log in again. If it still doesn&rsquo;t work after
+    clearing your cookies, contact
     <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
   </p>
 </div>

--- a/src/common/components/signInForm/signInForm.tpl.html
+++ b/src/common/components/signInForm/signInForm.tpl.html
@@ -3,35 +3,15 @@
   role="alert"
   ng-if="$ctrl.showSessionMismatchMessage"
 >
-  <p translate>
-    It appears that you logged in, but the system got a bit confused due to
-    previous cookies. Currently you are only partially logged in.
-  </p>
-  <p translate>
-    <strong>First, try reloading this page</strong> and signing in again &mdash;
-    we&rsquo;ll attempt to straighten this out automatically.
-  </p>
-  <p translate>
-    If you still see this after reloading, clear your cookies for
-    <strong>cru.org</strong>. In Chrome:
-  </p>
+  <p translate="SESSION_MISMATCH_RELOAD"></p>
+  <p translate="SESSION_MISMATCH_CLEAR_DATA"></p>
   <ol>
-    <li translate>Chrome Settings</li>
-    <li translate>Privacy and Security</li>
-    <li translate>Third Party Cookies</li>
-    <li translate>See all site data and permissions</li>
-    <li translate>
-      Find <strong>cru.org</strong> and click the trash can icon (&ldquo;Delete
-      site data and permissions for cru.org&rdquo;). Some of the stale cookies
-      are on the parent <em>cru.org</em> domain, not just <em>give.cru.org</em>,
-      so this is the level that needs to be cleared.
-    </li>
+    <li translate="SESSION_MISMATCH_STEP_1"></li>
+    <li translate="SESSION_MISMATCH_STEP_2"></li>
+    <li translate="SESSION_MISMATCH_STEP_3"></li>
+    <li translate="SESSION_MISMATCH_STEP_4"></li>
   </ol>
-  <p translate>
-    Then reload this page and log in again. If it still doesn&rsquo;t work after
-    clearing your cookies, contact
-    <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.
-  </p>
+  <p translate="SESSION_MISMATCH_CONTACT"></p>
 </div>
 <div
   class="alert alert-danger"

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -70,11 +70,16 @@ const session = /* @ngInject */ function (
   $timeout,
   $window,
   $location,
+  $log,
   envService,
 ) {
   const session = {};
   const sessionSubject = new BehaviorSubject(session);
   let sessionTimeout;
+  // Tracks whether we have already reported the current unhealable shadow to
+  // Rollbar, so the cookie watcher re-firing updateCurrentSession does not
+  // log a duplicate for the same stuck user. Reset once the shadow clears.
+  let cortexRoleShadowReported = false;
   const maximumTimeout = 30 * 1000;
 
   const oktaSignInWidgetDefaultOptions = {
@@ -400,6 +405,17 @@ const session = /* @ngInject */ function (
       // Surfaced so the sign-in form can tell the user to clear the cookie
       // manually — only set when JS could not remove the shadowing copy.
       session.cortexRoleShadowed = true;
+      // Report to Rollbar once per occurrence so we can measure how many users
+      // actually get stuck. The JWT is intentionally omitted; only the stuck
+      // (visible) role is included.
+      if (!cortexRoleShadowReported) {
+        cortexRoleShadowReported = true;
+        $log.error('Unhealable cortex-role shadow: user must clear cookies', {
+          visibleRole: session.role,
+        });
+      }
+    } else {
+      cortexRoleShadowReported = false;
     }
 
     // Update sessionSubject with new value

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -36,6 +36,24 @@ export const checkoutSavedDataCookieName = 'checkoutSavedData';
 export const forcedUserToLogout = 'forcedUserToLogout';
 export const cookieDomain = '.cru.org';
 
+// Returns true if the given cookie header string contains more than one
+// `cortex-role=…` entry. The browser exposes duplicate cookies on different
+// domains as separate entries in document.cookie, which is the one place
+// JS can directly observe parent-domain shadowing.
+export function hasDuplicateCortexRole(cookieHeader) {
+  if (!cookieHeader) {
+    return false;
+  }
+  const prefix = Sessions.role + '=';
+  let count = 0;
+  for (const entry of cookieHeader.split(/;\s*/)) {
+    if (entry.startsWith(prefix) && ++count > 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // AngularJS event broadcasted when the user signs in
 export const SignInEvent = 'SessionSignedIn';
 // AngularJS event broadcasted when the user signs in
@@ -373,6 +391,15 @@ const session = /* @ngInject */ function (
 
   /* Private Methods */
   function updateCurrentSession() {
+    // Self-heal the parent-domain-cookie shadow on every session refresh, not
+    // just on a fresh /okta/login. This catches users who are already stuck
+    // when the code deploys: the duplicate cortex-role gets cleaned up on
+    // the next page load, and the watcher re-fires updateCurrentSession on
+    // the cleaner state.
+    const cookieHeader = $document[0] && $document[0].cookie;
+    if (hasDuplicateCortexRole(cookieHeader)) {
+      $cookies.remove(Sessions.role, { path: '/', domain: cookieDomain });
+    }
     const cortexRole = decodeCookie(Sessions.role);
     const cruProfile = updateCurrentProfile();
     const giveSession = decodeCookie(Sessions.give);

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -229,25 +229,13 @@ const session = /* @ngInject */ function (
         })
         .then((response) => {
           // /okta/login sets a give.cru.org-scoped cortex-role cookie with
-          // role=REGISTERED. If $cookies.get() still returns a non-REGISTERED
-          // value after that, a stale parent-domain (.cru.org) cookie from a
-          // prior session on another Cru property is shadowing the new one.
-          // Remove the parent-domain copy so the give.cru.org one wins on
-          // future reads. Legitimate REGISTERED cookies on .cru.org (e.g.
-          // cross-property SSO) are left alone.
-          const cookieJwt = $cookies.get(Sessions.role);
-          if (cookieJwt) {
-            try {
-              const decoded = jwtDecode(cookieJwt);
-              if (decoded.role !== Roles.registered) {
-                $cookies.remove(Sessions.role, {
-                  path: '/',
-                  domain: cookieDomain,
-                });
-              }
-            } catch (e) {
-              // Malformed cookie — ignore.
-            }
+          // role=REGISTERED. If a stale parent-domain (.cru.org) copy is
+          // shadowing it, the cookie watcher won't fire (the visible value
+          // didn't change), so attempt the heal here. Skipped on the
+          // redirect-to-Okta branch, where no /okta/login call was made and
+          // response is undefined.
+          if (response) {
+            healCortexRoleShadow();
           }
           observer.next(response);
           observer.complete();
@@ -396,10 +384,7 @@ const session = /* @ngInject */ function (
     // when the code deploys: the duplicate cortex-role gets cleaned up on
     // the next page load, and the watcher re-fires updateCurrentSession on
     // the cleaner state.
-    const cookieHeader = $document[0] && $document[0].cookie;
-    if (hasDuplicateCortexRole(cookieHeader)) {
-      $cookies.remove(Sessions.role, { path: '/', domain: cookieDomain });
-    }
+    const cortexRoleShadowed = healCortexRoleShadow();
     const cortexRole = decodeCookie(Sessions.role);
     const cruProfile = updateCurrentProfile();
     const giveSession = decodeCookie(Sessions.give);
@@ -411,6 +396,11 @@ const session = /* @ngInject */ function (
     // Copy new session into current session object
     const newSession = angular.merge({}, cortexRole, cruProfile);
     angular.copy(newSession, session);
+    if (cortexRoleShadowed) {
+      // Surfaced so the sign-in form can tell the user to clear the cookie
+      // manually — only set when JS could not remove the shadowing copy.
+      session.cortexRoleShadowed = true;
+    }
 
     // Update sessionSubject with new value
     sessionSubject.next(session);
@@ -431,6 +421,39 @@ const session = /* @ngInject */ function (
   function decodeCookie(cookieName) {
     const jwt = $cookies.get(cookieName);
     return angular.isDefined(jwt) ? jwtDecode(jwt) : {};
+  }
+
+  // A duplicate cortex-role entry in document.cookie means a parent-domain
+  // (.cru.org) copy from another Cru property or environment is shadowing the
+  // give.cru.org cookie set by /okta/login. If the visible (winning) copy is
+  // not REGISTERED, remove the parent-domain copy so the fresh cookie wins on
+  // future reads; a REGISTERED parent copy may be legitimate cross-property
+  // SSO and is left alone. Returns true when a non-REGISTERED duplicate
+  // persists after the attempt — a shadow JS cannot remove (e.g. a host-only
+  // or path-scoped copy), meaning the user must clear cookies manually.
+  function healCortexRoleShadow() {
+    // $document[0] can be undefined in unit tests that mock $document.
+    const cookieHeader = () => $document[0] && $document[0].cookie;
+    if (!hasDuplicateCortexRole(cookieHeader())) {
+      return false;
+    }
+    if (visibleCortexRole() === Roles.registered) {
+      return false;
+    }
+    $cookies.remove(Sessions.role, { path: '/', domain: cookieDomain });
+    return (
+      hasDuplicateCortexRole(cookieHeader()) &&
+      visibleCortexRole() !== Roles.registered
+    );
+  }
+
+  function visibleCortexRole() {
+    try {
+      return decodeCookie(Sessions.role).role;
+    } catch {
+      // Malformed cookie — treat as non-REGISTERED so the shadow is removed.
+      return undefined;
+    }
   }
 
   function setSessionTimeout(timeout) {
@@ -465,7 +488,7 @@ const session = /* @ngInject */ function (
     const timeout = new Date(giveSession.exp * 1000) - Date.now();
     if (timeout <= 0) {
       // Give session still exists but has expired (some browsers may not delete expired cookies)
-      $cookies.remove(Sessions.give, { path: '/', domain: '.cru.org' });
+      $cookies.remove(Sessions.give, { path: '/', domain: cookieDomain });
       return undefined;
     }
     return timeout;

--- a/src/common/services/session/session.service.js
+++ b/src/common/services/session/session.service.js
@@ -210,6 +210,27 @@ const session = /* @ngInject */ function (
           });
         })
         .then((response) => {
+          // /okta/login sets a give.cru.org-scoped cortex-role cookie with
+          // role=REGISTERED. If $cookies.get() still returns a non-REGISTERED
+          // value after that, a stale parent-domain (.cru.org) cookie from a
+          // prior session on another Cru property is shadowing the new one.
+          // Remove the parent-domain copy so the give.cru.org one wins on
+          // future reads. Legitimate REGISTERED cookies on .cru.org (e.g.
+          // cross-property SSO) are left alone.
+          const cookieJwt = $cookies.get(Sessions.role);
+          if (cookieJwt) {
+            try {
+              const decoded = jwtDecode(cookieJwt);
+              if (decoded.role !== Roles.registered) {
+                $cookies.remove(Sessions.role, {
+                  path: '/',
+                  domain: cookieDomain,
+                });
+              }
+            } catch (e) {
+              // Malformed cookie — ignore.
+            }
+          }
           observer.next(response);
           observer.complete();
         })

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -9,6 +9,7 @@ import module, {
   BodySignInEvent,
   checkoutSavedDataCookieName,
   cookieDomain,
+  hasDuplicateCortexRole,
   redirectLocation,
   locationSearchOnLogin,
   forcedUserToLogout,
@@ -139,6 +140,40 @@ describe('session service', function () {
   describe('sessionSubject', () => {
     it('to be defined', () => {
       expect(sessionService.sessionSubject).toBeDefined();
+    });
+  });
+
+  describe('hasDuplicateCortexRole helper', () => {
+    it('returns true when the cookie header has multiple cortex-role entries', () => {
+      expect(
+        hasDuplicateCortexRole(
+          'cortex-role=jwt-a; cortex-role=jwt-b; other=foo',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when there is exactly one cortex-role entry', () => {
+      expect(hasDuplicateCortexRole('cortex-role=jwt-a; other=foo')).toBe(
+        false,
+      );
+    });
+
+    it('returns false when there are no cortex-role entries', () => {
+      expect(hasDuplicateCortexRole('other=foo; another=bar')).toBe(false);
+    });
+
+    it('returns false for an empty cookie header', () => {
+      expect(hasDuplicateCortexRole('')).toBe(false);
+    });
+
+    it('returns false for undefined input', () => {
+      expect(hasDuplicateCortexRole(undefined)).toBe(false);
+    });
+
+    it('is not fooled by cookie names that merely contain "cortex-role"', () => {
+      expect(
+        hasDuplicateCortexRole('not-cortex-role=a; my-cortex-role-extra=b'),
+      ).toBe(false);
     });
   });
 

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -8,6 +8,7 @@ import module, {
   SignInEvent,
   BodySignInEvent,
   checkoutSavedDataCookieName,
+  cookieDomain,
   redirectLocation,
   locationSearchOnLogin,
   forcedUserToLogout,
@@ -496,6 +497,66 @@ describe('session service', function () {
         setTimeout(() => {
           $httpBackend.flush();
           done();
+        });
+      });
+
+      it('should remove a shadowing .cru.org cortex-role cookie after a successful login', (done) => {
+        // Simulate the bug: a stale IDENTIFIED cortex-role cookie remains
+        // visible to $cookies.get() even after /okta/login set a fresh
+        // REGISTERED one on the give.cru.org domain.
+        $cookies.put(Sessions.role, cortexRole.identified);
+        jest.spyOn($cookies, 'remove');
+
+        $httpBackend
+          .expectPOST('https://give-stage2.cru.org/okta/login', {
+            access_token: accessToken,
+          })
+          .respond(200, 'success');
+
+        sessionService.handleOktaRedirect().subscribe(() => {
+          try {
+            expect($cookies.remove).toHaveBeenCalledWith(Sessions.role, {
+              path: '/',
+              domain: cookieDomain,
+            });
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }, done);
+
+        setTimeout(() => {
+          $httpBackend.flush();
+        });
+      });
+
+      it('should leave a REGISTERED cortex-role cookie alone after a successful login', (done) => {
+        // Legitimate cross-property case: a .cru.org cortex-role with role
+        // REGISTERED is not a shadow — leave it alone so other Cru
+        // properties keep their SSO session.
+        $cookies.put(Sessions.role, cortexRole.registered);
+        jest.spyOn($cookies, 'remove');
+
+        $httpBackend
+          .expectPOST('https://give-stage2.cru.org/okta/login', {
+            access_token: accessToken,
+          })
+          .respond(200, 'success');
+
+        sessionService.handleOktaRedirect().subscribe(() => {
+          try {
+            expect($cookies.remove).not.toHaveBeenCalledWith(
+              Sessions.role,
+              expect.objectContaining({ domain: cookieDomain }),
+            );
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }, done);
+
+        setTimeout(() => {
+          $httpBackend.flush();
         });
       });
 

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -90,6 +90,47 @@ describe('session service', function () {
     });
   });
 
+  // jsdom on localhost cannot hold two cookies with the same name (that takes
+  // a give.cru.org host cookie plus a .cru.org parent-domain copy), so the
+  // shadow-cookie tests fake the jar at the document level. `removableEntry`
+  // is the entry that a {path: '/', domain: '.cru.org'} removal deletes; pass
+  // null to simulate a copy JS cannot remove (e.g. a host-only duplicate).
+  // Replaced manually rather than with jest.spyOn because two spies on the
+  // same property's get and set don't restore cleanly.
+  let originalCookieDescriptor;
+  function fakeCookieJar(entries, removableEntry = null) {
+    const jar = { entries: entries.slice() };
+    originalCookieDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'cookie',
+    );
+    Object.defineProperty(Document.prototype, 'cookie', {
+      configurable: true,
+      get: () => jar.entries.join('; '),
+      set: (value) => {
+        const isRoleRemoval =
+          value.startsWith(`${Sessions.role}=`) &&
+          value.includes(`domain=${cookieDomain}`) &&
+          value.includes('1970');
+        if (isRoleRemoval && removableEntry) {
+          jar.entries = jar.entries.filter((entry) => entry !== removableEntry);
+        }
+      },
+    });
+    return jar;
+  }
+
+  afterEach(() => {
+    if (originalCookieDescriptor) {
+      Object.defineProperty(
+        Document.prototype,
+        'cookie',
+        originalCookieDescriptor,
+      );
+      originalCookieDescriptor = undefined;
+    }
+  });
+
   it('to be defined', () => {
     expect(sessionService).toBeDefined();
   });
@@ -174,6 +215,103 @@ describe('session service', function () {
       expect(
         hasDuplicateCortexRole('not-cortex-role=a; my-cortex-role-extra=b'),
       ).toBe(false);
+    });
+  });
+
+  describe('cortex-role shadow self-heal', () => {
+    const staleIdentified = `${Sessions.role}=${cortexRole.identified}`;
+    const stalePublic = `${Sessions.role}=${cortexRole.public}`;
+    const freshRegistered = `${Sessions.role}=${cortexRole.registered}`;
+
+    it('removes a shadowing parent-domain copy on session refresh and recovers the fresh role', () => {
+      const jar = fakeCookieJar(
+        [staleIdentified, freshRegistered],
+        staleIdentified,
+      );
+
+      $rootScope.$digest();
+
+      expect(jar.entries).toEqual([freshRegistered]);
+      expect(sessionService.session.role).toEqual(Roles.registered);
+      expect(sessionService.session.cortexRoleShadowed).toBeUndefined();
+    });
+
+    it('flags the session when the shadowing copy cannot be removed', () => {
+      fakeCookieJar([stalePublic, freshRegistered], null);
+
+      $rootScope.$digest();
+
+      expect(sessionService.session.cortexRoleShadowed).toBe(true);
+      expect(sessionService.session.role).toEqual(Roles.public);
+    });
+
+    it('leaves duplicates alone when the visible cookie is REGISTERED', () => {
+      jest.spyOn($cookies, 'remove');
+      const jar = fakeCookieJar(
+        [freshRegistered, staleIdentified],
+        staleIdentified,
+      );
+
+      $rootScope.$digest();
+
+      expect($cookies.remove).not.toHaveBeenCalledWith(
+        Sessions.role,
+        expect.objectContaining({ domain: cookieDomain }),
+      );
+      expect(jar.entries).toEqual([freshRegistered, staleIdentified]);
+      expect(sessionService.session.cortexRoleShadowed).toBeUndefined();
+    });
+
+    it('does not treat a single non-REGISTERED cookie as a shadow', () => {
+      // An Okta session without a Cortex login (e.g. no donor account yet,
+      // or a failed /okta/login) has no duplicate cookie and must not
+      // trigger the clear-your-cookies warning.
+      jest.spyOn($cookies, 'remove');
+      fakeCookieJar([staleIdentified]);
+
+      $rootScope.$digest();
+
+      expect($cookies.remove).not.toHaveBeenCalledWith(
+        Sessions.role,
+        expect.objectContaining({ domain: cookieDomain }),
+      );
+      expect(sessionService.session.cortexRoleShadowed).toBeUndefined();
+    });
+
+    it('clears the flag once a later refresh finds no duplicates', () => {
+      const jar = fakeCookieJar([stalePublic, freshRegistered], null);
+      $rootScope.$digest();
+      expect(sessionService.session.cortexRoleShadowed).toBe(true);
+
+      // The user clears the offending cookie manually.
+      jar.entries = [freshRegistered];
+      $rootScope.$digest();
+
+      expect(sessionService.session.cortexRoleShadowed).toBeUndefined();
+      expect(sessionService.session.role).toEqual(Roles.registered);
+    });
+
+    it('skips the heal when sign-in redirects to Okta without a login call', (done) => {
+      jest
+        .spyOn(sessionService.authClient, 'isAuthenticated')
+        .mockResolvedValue(false);
+      jest
+        .spyOn(sessionService.authClient.token, 'getWithRedirect')
+        .mockResolvedValue(undefined);
+      jest.spyOn($cookies, 'remove');
+      fakeCookieJar([staleIdentified, freshRegistered], staleIdentified);
+
+      sessionService.signIn().subscribe(() => {
+        try {
+          expect($cookies.remove).not.toHaveBeenCalledWith(
+            Sessions.role,
+            expect.objectContaining({ domain: cookieDomain }),
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, done);
     });
   });
 
@@ -536,10 +674,12 @@ describe('session service', function () {
       });
 
       it('should remove a shadowing .cru.org cortex-role cookie after a successful login', (done) => {
-        // Simulate the bug: a stale IDENTIFIED cortex-role cookie remains
-        // visible to $cookies.get() even after /okta/login set a fresh
-        // REGISTERED one on the give.cru.org domain.
-        $cookies.put(Sessions.role, cortexRole.identified);
+        // Simulate the bug: a stale IDENTIFIED cortex-role copy is still the
+        // winning entry in document.cookie even after /okta/login set a
+        // fresh REGISTERED one on the give.cru.org domain.
+        const staleEntry = `${Sessions.role}=${cortexRole.identified}`;
+        const freshEntry = `${Sessions.role}=${cortexRole.registered}`;
+        const jar = fakeCookieJar([staleEntry, freshEntry], staleEntry);
         jest.spyOn($cookies, 'remove');
 
         $httpBackend
@@ -554,6 +694,7 @@ describe('session service', function () {
               path: '/',
               domain: cookieDomain,
             });
+            expect(jar.entries).toEqual([freshEntry]);
             done();
           } catch (e) {
             done(e);
@@ -565,11 +706,13 @@ describe('session service', function () {
         });
       });
 
-      it('should leave a REGISTERED cortex-role cookie alone after a successful login', (done) => {
-        // Legitimate cross-property case: a .cru.org cortex-role with role
-        // REGISTERED is not a shadow — leave it alone so other Cru
-        // properties keep their SSO session.
-        $cookies.put(Sessions.role, cortexRole.registered);
+      it('should leave duplicates alone when the visible cortex-role is REGISTERED', (done) => {
+        // The winning cookie is healthy, so a second copy (e.g. legitimate
+        // cross-property SSO on .cru.org) is none of our business — leave it
+        // alone so other Cru properties keep their session.
+        const freshEntry = `${Sessions.role}=${cortexRole.registered}`;
+        const otherEntry = `${Sessions.role}=${cortexRole.identified}`;
+        const jar = fakeCookieJar([freshEntry, otherEntry], otherEntry);
         jest.spyOn($cookies, 'remove');
 
         $httpBackend
@@ -584,6 +727,7 @@ describe('session service', function () {
               Sessions.role,
               expect.objectContaining({ domain: cookieDomain }),
             );
+            expect(jar.entries).toEqual([freshEntry, otherEntry]);
             done();
           } catch (e) {
             done(e);

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -246,6 +246,10 @@ describe('session service', function () {
     });
 
     it('leaves duplicates alone when the visible cookie is REGISTERED', () => {
+      // Order matters: $cookies.get returns the FIRST cortex-role entry in the
+      // header, so a REGISTERED cookie ahead of the stale one is the "visible"
+      // role and the heal short-circuits (contrast with the IDENTIFIED-first
+      // case in the test above, where the heal removes the parent-domain copy).
       jest.spyOn($cookies, 'remove');
       const jar = fakeCookieJar(
         [freshRegistered, staleIdentified],
@@ -263,9 +267,10 @@ describe('session service', function () {
     });
 
     it('does not treat a single non-REGISTERED cookie as a shadow', () => {
-      // An Okta session without a Cortex login (e.g. no donor account yet,
-      // or a failed /okta/login) has no duplicate cookie and must not
-      // trigger the clear-your-cookies warning.
+      // A single cortex-role cookie is not a shadow: hasDuplicateCortexRole is
+      // false, so nothing is removed and the session is not flagged. The
+      // clear-your-cookies warning is gated on an unhealable duplicate, not
+      // merely on a non-REGISTERED role.
       jest.spyOn($cookies, 'remove');
       fakeCookieJar([staleIdentified]);
 

--- a/src/common/services/session/session.service.spec.js
+++ b/src/common/services/session/session.service.spec.js
@@ -58,6 +58,7 @@ describe('session service', function () {
     $window,
     $location,
     $injector,
+    $log,
     envService;
 
   beforeEach(inject(function (
@@ -70,6 +71,7 @@ describe('session service', function () {
     _$window_,
     _$location_,
     _$injector_,
+    _$log_,
     _envService_,
   ) {
     sessionService = _sessionService_;
@@ -81,6 +83,7 @@ describe('session service', function () {
     $window = _$window_;
     $location = _$location_;
     $injector = _$injector_;
+    $log = _$log_;
     envService = _envService_;
   }));
 
@@ -294,6 +297,55 @@ describe('session service', function () {
 
       expect(sessionService.session.cortexRoleShadowed).toBeUndefined();
       expect(sessionService.session.role).toEqual(Roles.registered);
+    });
+
+    it('reports an unhealable shadow to Rollbar once with the stuck role', () => {
+      jest.spyOn($log, 'error').mockImplementation(() => {});
+      // A re-fire of updateCurrentSession on a still-stuck session (the visible
+      // role changes, so the cookie watcher fires again) must not re-report.
+      const jar = fakeCookieJar([stalePublic, freshRegistered], null);
+      $rootScope.$digest();
+      jar.entries = [staleIdentified, freshRegistered];
+      $rootScope.$digest();
+
+      expect($log.error).toHaveBeenCalledTimes(1);
+      expect($log.error).toHaveBeenCalledWith(
+        expect.stringContaining('cortex-role shadow'),
+        { visibleRole: Roles.public },
+      );
+    });
+
+    it('does not report to Rollbar when the duplicate self-heals', () => {
+      jest.spyOn($log, 'error').mockImplementation(() => {});
+      fakeCookieJar([staleIdentified, freshRegistered], staleIdentified);
+
+      $rootScope.$digest();
+
+      expect($log.error).not.toHaveBeenCalled();
+    });
+
+    it('does not report to Rollbar for a single non-REGISTERED cookie', () => {
+      jest.spyOn($log, 'error').mockImplementation(() => {});
+      fakeCookieJar([staleIdentified]);
+
+      $rootScope.$digest();
+
+      expect($log.error).not.toHaveBeenCalled();
+    });
+
+    it('reports again after the shadow clears and recurs', () => {
+      jest.spyOn($log, 'error').mockImplementation(() => {});
+      const jar = fakeCookieJar([stalePublic, freshRegistered], null);
+      $rootScope.$digest();
+      expect($log.error).toHaveBeenCalledTimes(1);
+
+      // User clears the offending cookie, then a later refresh reintroduces it.
+      jar.entries = [freshRegistered];
+      $rootScope.$digest();
+      jar.entries = [stalePublic, freshRegistered];
+      $rootScope.$digest();
+
+      expect($log.error).toHaveBeenCalledTimes(2);
     });
 
     it('skips the heal when sign-in redirects to Okta without a login call', (done) => {


### PR DESCRIPTION
## Summary
- Users can land "partially logged in" — authenticated to Okta but with a stale `cortex-role` cookie scoped to `.cru.org` shadowing the `give.cru.org` one. `currentRole()` returns `IDENTIFIED` instead of `REGISTERED` and the sign-in modal pops on protected pages.
- Surfaces a warning in the sign-in form when Okta says signed in but Cortex role is anything other than `REGISTERED` (was previously only `PUBLIC` — missed the real-world `IDENTIFIED` case).
- The warning copy is now a self-service escalation ladder, ordered to maximize self-resolution and minimize support contacts: (1) **reload the page** — this triggers the self-heal below and silently fixes the common duplicate-cookie case; (2) if it persists, **clear cookies for `cru.org`** via the Chrome steps (kept intact, since Chrome's per-site wipe does not touch parent-domain cookies); (3) only if that still fails, **contact `eGift@cru.org`**.
- After a successful `/okta/login`, if the readable `cortex-role` JWT is still not `REGISTERED`, removes the parent-domain copy so the `give.cru.org` cookie wins. Legitimate `REGISTERED` `.cru.org` cookies (cross-property SSO) are left alone.
- Self-heals the shadow on every session refresh (page load + cookie-watcher refire), not just on a fresh `/okta/login`, via the exported `hasDuplicateCortexRole` helper — so users already stuck before this deploys recover on their next page load with no manual cookie clearing or re-login. This is why "reload the page" is the correct first step in the message above.

## Known limitation (accepted)
This cleans up the give-side shadow only. A side effect: you can no longer hold a staging **and** production session in the same browser profile — staging scopes `cortex-role` to the parent `.cru.org`, so loading a production page detects the duplicate and removes staging's copy (production always wins). This is not a regression — previously the same cookie pair produced the stuck-modal bug on production instead. Cross-environment testing should use separate browser profiles. The real root-cause fix is backend: scope staging `cortex-role` to `.give-stage2.cru.org` like production scopes to `.give.cru.org` (follow-up with the Cortex/Okta cookie owners).

## Test plan
- [ ] All 1821 unit tests pass locally
- [ ] Reproduce the bug (stale `.cru.org` `cortex-role`) → warning appears in the sign-in modal
- [ ] Verify the message escalation reads correctly: reload first, clear-cookies second, contact support last
- [ ] Confirm the Chrome instructions clear the right cookies
- [ ] Sign in cleanly → no stale parent-domain cookie remains after `/okta/login`
- [ ] Sign in while a legitimate `REGISTERED` `.cru.org` cookie exists → confirm it is NOT removed
- [ ] Load any give page while a duplicate `cortex-role` exists → duplicate is cleared and role settles to `REGISTERED` without re-login (the "reload" self-service step)
