### PR TITLE
[HS-1623169] Add an error message near the submit button

### DIFF
--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -118,7 +118,7 @@ class BrandedCheckoutStep1Controller {
 
   submit() {
     this.resetSubmission();
-    this.submissionHasErrors = false;
+    this.validationError = false;
     this.submitted = true;
   }
 
@@ -200,7 +200,7 @@ class BrandedCheckoutStep1Controller {
         }
       } else {
         this.submitted = false;
-        this.submissionHasErrors = true;
+        this.validationError = true;
       }
     }
   }

--- a/src/app/branded/step-1/branded-checkout-step-1.component.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.component.js
@@ -118,6 +118,7 @@ class BrandedCheckoutStep1Controller {
 
   submit() {
     this.resetSubmission();
+    this.submissionHasErrors = false;
     this.submitted = true;
   }
 
@@ -199,6 +200,7 @@ class BrandedCheckoutStep1Controller {
         }
       } else {
         this.submitted = false;
+        this.submissionHasErrors = true;
       }
     }
   }

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -378,6 +378,7 @@ describe('branded checkout step 1', () => {
 
       expect($ctrl.next).toHaveBeenCalled();
       expect($ctrl.submitted).toEqual(true);
+      expect($ctrl.submissionHasErrors).toBeFalsy();
     });
 
     it('should set submitted to false if submissions completed and errors', () => {
@@ -389,6 +390,7 @@ describe('branded checkout step 1', () => {
 
       expect($ctrl.next).not.toHaveBeenCalled();
       expect($ctrl.submitted).toEqual(false);
+      expect($ctrl.submissionHasErrors).toEqual(true);
     });
   });
 });

--- a/src/app/branded/step-1/branded-checkout-step-1.spec.js
+++ b/src/app/branded/step-1/branded-checkout-step-1.spec.js
@@ -378,7 +378,7 @@ describe('branded checkout step 1', () => {
 
       expect($ctrl.next).toHaveBeenCalled();
       expect($ctrl.submitted).toEqual(true);
-      expect($ctrl.submissionHasErrors).toBeFalsy();
+      expect($ctrl.validationError).toBeFalsy();
     });
 
     it('should set submitted to false if submissions completed and errors', () => {
@@ -390,7 +390,7 @@ describe('branded checkout step 1', () => {
 
       expect($ctrl.next).not.toHaveBeenCalled();
       expect($ctrl.submitted).toEqual(false);
-      expect($ctrl.submissionHasErrors).toEqual(true);
+      expect($ctrl.validationError).toEqual(true);
     });
   });
 });

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -106,6 +106,14 @@
   </div>
   <div class="panel">
     <div class="panel-body text-right">
+      <div
+        ng-if="$ctrl.submissionHasErrors"
+        class="alert alert-danger text-left"
+        role="alert"
+        translate
+      >
+        {{'SUBMIT_VALIDATION_ERROR'}}
+      </div>
       <div class="checkout-cta pull-right" ng-if="$ctrl.useV3">
         <recaptcha-wrapper
           action="'branded_checkout'"

--- a/src/app/branded/step-1/branded-checkout-step-1.tpl.html
+++ b/src/app/branded/step-1/branded-checkout-step-1.tpl.html
@@ -107,7 +107,7 @@
   <div class="panel">
     <div class="panel-body text-right">
       <div
-        ng-if="$ctrl.submissionHasErrors"
+        ng-if="$ctrl.validationError"
         class="alert alert-danger text-left"
         role="alert"
         translate

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -424,6 +424,8 @@ export const appConfig = /* @ngInject */ function (
     STARTING_DATE: 'Starts on: {{startdate}}',
     SUBMIT_GIFT: 'Submit Your Gift',
     SUBMITTING_GIFT: 'Submitting your gift...',
+    SUBMIT_VALIDATION_ERROR:
+      'Please correct the errors above before continuing.',
     RETRY_LOAD:
       'There was an error loading your gifts. You may <a id="retryLoadButton" href="" ng-click="{{retryLoadFunction}}">retry</a> loading them. If you continue to see this message, please contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.',
     FINAL_THANK_YOU_HEADING: 'Thank you for Your Gift',
@@ -722,6 +724,8 @@ export const appConfig = /* @ngInject */ function (
     STARTING_DATE: 'Starts on: {{startdate}}',
     SUBMIT_GIFT: 'Submit Your Gift',
     SUBMITTING_GIFT: 'Submitting your gift...',
+    SUBMIT_VALIDATION_ERROR:
+      'Please correct the errors above before continuing.',
     RETRY_LOAD:
       'There was an error loading your gifts. You may <a id="retryLoadButton" href="" ng-click="{{retryLoadFunction}}">retry</a> loading them. If you continue to see this message, please contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.',
     FINAL_THANK_YOU_HEADING: 'Thank you for Your Gift',


### PR DESCRIPTION
## Description

In a [HelpScout ticket](https://secure.helpscout.net/conversation/3327644829/1623169/), Margaret requests a UX hint that submission failed when the form wasn't fully filled out:

> While testing pages, I noticed that if I made a mistake filling out the form and hit submit, it appears nothing happened. I have to scroll up. I was wondering if branded check out can change so that the form scrolls to the first missing/bad field. OR add a warning label by the button stating, "Please correct the missing fields."

## Testing

- Go to https://give-stage2.cru.org/branded-checkout.html
- Click submit without filling out the form
- Check that the new error message appears above the button

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [x] I have tested my changes in staging for branded checkout
