### PR TITLE
[RB-61516] Deduplicate `carouselImages`

### DIFF
--- a/src/app/designationEditor/designationEditor.component.js
+++ b/src/app/designationEditor/designationEditor.component.js
@@ -373,8 +373,9 @@ class DesignationEditorController {
               () => {
                 this.saveStatus = 'success';
                 this.loadingOverlay = false;
-                this.carouselImages =
-                  this.designationContent.secondaryPhotos || [];
+                this.carouselImages = uniq(
+                  this.designationContent.secondaryPhotos || [],
+                );
                 this.updateCarousel();
               },
               (error) => {


### PR DESCRIPTION
## Description

Second attempt to fix https://app.rollbar.com/a/Cru/fix/item/give-web/61516.

```
Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: image in $ctrl.carouselImages, Duplicate key: string:/content/dam/give/designations/1/1/2/2/3/1122306/IMG_1641.jpeg
```

## Testing

- My account doesn't have duplicate images, so I can't reproduce.

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [ ] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [ ] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout
