### PR TITLE
More quick Rollbar fixes

### DIFF
--- a/src/app/profile/profile.component.js
+++ b/src/app/profile/profile.component.js
@@ -364,7 +364,7 @@ class ProfileController {
       (error) => {
         this.mailingAddressLoading = false;
         this.mailingAddressError = 'updating';
-        this.$log.error('Failed loading mailing address', error);
+        this.$log.error('Failed updating mailing address', error);
       },
     );
   }

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -273,7 +273,7 @@ class Profile {
             );
           }
           paymentMethod.recurringGifts = flatMap(
-            paymentMethod.recurringgifts.donations,
+            paymentMethod.recurringgifts?.donations,
             (donation) => {
               return map(donation['donation-lines'], (donationLine) => {
                 return new RecurringGiftModel(donationLine, donation);


### PR DESCRIPTION
## Description

Fixes: https://app.rollbar.com/a/Cru/fix/item/give-web/65860 `Error loading payment methods undefined is not an object (evaluating 'e.recurringgifts.donations')`

Makes the Rollbar error message when updating mailing addresses more accurate.

~~Fixes: https://app.rollbar.com/a/Cru/fix/item/give-web/66403 `TypeError: Cannot read properties of undefined (reading 'uri')`~~ (reverted while investigating whether this is the right solution)

> When getDonorDetails fails, donorDetails remains the placeholder object from $onInit, which has no self link. Submitting the contact info form then crashed in updateDonorDetails reading details.self.uri. Now it shows the submission error alert instead.

~~Fixes: https://app.rollbar.com/a/Cru/fix/item/give-web/66475 `TypeError: Cannot read properties of undefined (reading 'uri')`~~ (reverted while investigating whether this is the right solution)

> When the product config form data fails to load, productData is never set. If the form is submitted anyway, saveGiftToCart crashed reading this.productData.uri. Now it shows the generic saving error instead.

## Testing

I wasn't able to reproduce them myself because they are from weird data or transient backend outages.

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [ ] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout
