### PR TITLE
[HS-1640116] Show latest purchase on thank you page

### DIFF
--- a/src/app/thankYou/summary/thankYouSummary.component.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.js
@@ -1,5 +1,9 @@
 import angular from 'angular';
 import map from 'lodash/map';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
+import 'rxjs/add/operator/mergeMap';
 
 import displayAddressComponent from 'common/components/display-address/display-address.component';
 import displayRateTotals from 'common/components/displayRateTotals/displayRateTotals.component';
@@ -11,6 +15,7 @@ import orderService from 'common/services/api/order.service';
 import profileService from 'common/services/api/profile.service';
 import sessionService, {
   SignOutEvent,
+  Roles,
 } from 'common/services/session/session.service';
 import sessionModalService from 'common/services/session/sessionModal.service';
 import designationsService from 'common/services/api/designations.service';
@@ -30,6 +35,7 @@ class ThankYouSummaryController {
     envService,
     orderService,
     profileService,
+    sessionService,
     sessionModalService,
     designationsService,
     $log,
@@ -39,6 +45,7 @@ class ThankYouSummaryController {
     this.envService = envService;
     this.orderService = orderService;
     this.profileService = profileService;
+    this.sessionService = sessionService;
     this.sessionModalService = sessionModalService;
     this.designationsService = designationsService;
     this.analyticsFactory = analyticsFactory;
@@ -61,12 +68,43 @@ class ThankYouSummaryController {
   loadLastPurchase() {
     this.loading = true;
     const lastPurchaseLink = this.orderService.retrieveLastPurchaseLink();
-    if (!lastPurchaseLink) {
-      this.loadingError = 'lastPurchaseLink missing';
-      this.loading = false;
+    if (lastPurchaseLink) {
+      this.loadPurchaseByUri(lastPurchaseLink, true);
       return;
     }
-    this.profileService.getPurchase(lastPurchaseLink).subscribe(
+
+    // No lastPurchaseLink (e.g. new tab/device), but a signed in
+    // user can still load their most recent purchase
+    if (this.sessionService.getRole() === Roles.registered) {
+      this.profileService
+        .getLatestPurchase()
+        .mergeMap((uri) => {
+          if (!uri) {
+            return Observable.throw('No purchases found for registered user');
+          }
+          return Observable.of(uri);
+        })
+        .subscribe(
+          (uri) => {
+            this.loadPurchaseByUri(uri, false);
+          },
+          (error) => {
+            this.$log.error(
+              'Error loading latest purchase for thank you component',
+              error,
+            );
+            this.loadingError = 'lastPurchaseLink missing';
+            this.loading = false;
+          },
+        );
+      return;
+    }
+    this.loadingError = 'lastPurchaseLink missing';
+    this.loading = false;
+  }
+
+  loadPurchaseByUri(uri, isFreshPurchase) {
+    this.profileService.getPurchase(uri).subscribe(
       (data) => {
         this.purchase = data;
 
@@ -85,11 +123,14 @@ class ThankYouSummaryController {
         });
 
         this.analyticsFactory.pageLoaded();
-        this.analyticsFactory.setPurchaseNumber(
-          data.rawData['purchase-number'],
-        );
-        if (!this.envService.read('isBrandedCheckout')) {
-          this.analyticsFactory.transactionEvent(this.purchase);
+        // Don't fire purchase analytics if the user returns to the thank you page
+        if (isFreshPurchase) {
+          this.analyticsFactory.setPurchaseNumber(
+            data.rawData['purchase-number'],
+          );
+          if (!this.envService.read('isBrandedCheckout')) {
+            this.analyticsFactory.transactionEvent(this.purchase);
+          }
         }
       },
       (error) => {

--- a/src/app/thankYou/summary/thankYouSummary.component.spec.js
+++ b/src/app/thankYou/summary/thankYouSummary.component.spec.js
@@ -7,7 +7,7 @@ import 'rxjs/add/observable/throw';
 
 import module from './thankYouSummary.component.js';
 
-import { SignOutEvent } from 'common/services/session/session.service';
+import { SignOutEvent, Roles } from 'common/services/session/session.service';
 
 describe('thank you summary', () => {
   beforeEach(angular.mock.module(module.name));
@@ -67,8 +67,12 @@ describe('thank you summary', () => {
         },
         profileService: {
           getPurchase: () => Observable.of(self.mockPurchase),
+          getLatestPurchase: () => Observable.of('/purchases/crugive/latest='),
           getEmails: () =>
             Observable.of([{ email: 'someperson@someaddress.com' }]),
+        },
+        sessionService: {
+          getRole: () => Roles.public,
         },
         $window: { location: '/thank-you.html' },
       },
@@ -170,19 +174,101 @@ describe('thank you summary', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('should not request purchase data if lastPurchaseLink is not defined', () => {
+    it('should not attempt a fallback if lastPurchaseLink is missing and user is not registered', () => {
       jest
         .spyOn(self.controller.orderService, 'retrieveLastPurchaseLink')
         .mockImplementation(() => undefined);
       jest
+        .spyOn(self.controller.sessionService, 'getRole')
+        .mockReturnValue(Roles.public);
+      jest
         .spyOn(self.controller.profileService, 'getPurchase')
         .mockImplementation(() => {});
+      jest.spyOn(self.controller.profileService, 'getLatestPurchase');
       self.controller.loadLastPurchase();
 
+      expect(
+        self.controller.profileService.getLatestPurchase,
+      ).not.toHaveBeenCalled();
       expect(self.controller.profileService.getPurchase).not.toHaveBeenCalled();
       expect(self.controller.purchase).not.toBeDefined();
       expect(self.controller.loading).toEqual(false);
       expect(self.controller.loadingError).toEqual('lastPurchaseLink missing');
+    });
+
+    describe('lastPurchaseLink missing and user is registered', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(self.controller.orderService, 'retrieveLastPurchaseLink')
+          .mockImplementation(() => undefined);
+        jest
+          .spyOn(self.controller.sessionService, 'getRole')
+          .mockReturnValue(Roles.registered);
+      });
+
+      it('should load the latest purchase as a fallback without firing transaction analytics', () => {
+        jest.spyOn(self.controller.profileService, 'getPurchase');
+        jest.spyOn(self.controller.profileService, 'getLatestPurchase');
+        jest.spyOn(self.controller.analyticsFactory, 'transactionEvent');
+        jest.spyOn(self.controller.analyticsFactory, 'setPurchaseNumber');
+        jest.spyOn(self.controller.analyticsFactory, 'pageLoaded');
+        jest.spyOn(self.controller.envService, 'read').mockReturnValue(false);
+        self.controller.loadLastPurchase();
+
+        expect(
+          self.controller.profileService.getLatestPurchase,
+        ).toHaveBeenCalled();
+        expect(self.controller.profileService.getPurchase).toHaveBeenCalledWith(
+          '/purchases/crugive/latest=',
+        );
+        expect(self.controller.purchase).toEqual(self.mockPurchase);
+        expect(self.controller.rateTotals).toEqual([
+          { frequency: 'Single', total: '$50.00', amount: 50 },
+          { frequency: 'Monthly', total: '$20.00', amount: 20 },
+        ]);
+        expect(self.controller.loading).toEqual(false);
+        expect(self.controller.loadingError).toBeUndefined();
+        expect(self.controller.onPurchaseLoaded).toHaveBeenCalledWith({
+          $event: { purchase: self.mockPurchase },
+        });
+        expect(self.controller.analyticsFactory.pageLoaded).toHaveBeenCalled();
+        expect(
+          self.controller.analyticsFactory.transactionEvent,
+        ).not.toHaveBeenCalled();
+        expect(
+          self.controller.analyticsFactory.setPurchaseNumber,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should show the missing error when there are no purchases to fall back to', () => {
+        jest
+          .spyOn(self.controller.profileService, 'getLatestPurchase')
+          .mockReturnValue(Observable.of(undefined));
+        jest.spyOn(self.controller.profileService, 'getPurchase');
+        self.controller.loadLastPurchase();
+
+        expect(
+          self.controller.profileService.getPurchase,
+        ).not.toHaveBeenCalled();
+        expect(self.controller.purchase).not.toBeDefined();
+        expect(self.controller.loading).toEqual(false);
+        expect(self.controller.loadingError).toEqual(
+          'lastPurchaseLink missing',
+        );
+      });
+
+      it('should show the missing error when the fallback lookup fails', () => {
+        jest
+          .spyOn(self.controller.profileService, 'getLatestPurchase')
+          .mockReturnValue(Observable.throw('some error'));
+        self.controller.loadLastPurchase();
+
+        expect(self.controller.purchase).not.toBeDefined();
+        expect(self.controller.loading).toEqual(false);
+        expect(self.controller.loadingError).toEqual(
+          'lastPurchaseLink missing',
+        );
+      });
     });
 
     it('should handle an api error', () => {

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -409,6 +409,17 @@ class Profile {
     });
   }
 
+  getLatestPurchase() {
+    return this.cortexApiService
+      .get({
+        path: ['profiles', this.cortexApiService.scope, 'default'],
+        zoom: {
+          purchases: 'purchases:element[]',
+        },
+      })
+      .map((data) => data.purchases?.[0]?.self.uri);
+  }
+
   getPurchase(uri) {
     return this.cortexApiService
       .get({

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -688,6 +688,52 @@ describe('profile service', () => {
     });
   });
 
+  describe('getLatestPurchase', () => {
+    it('should return the URI of the newest purchase', () => {
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=purchases:element',
+        )
+        .respond(200, {
+          self: { uri: '/profiles/crugive/default' },
+          _purchases: [
+            {
+              _element: [
+                { self: { uri: '/purchases/crugive/newest=' } },
+                { self: { uri: '/purchases/crugive/older=' } },
+              ],
+            },
+          ],
+        });
+
+      let result;
+      self.profileService.getLatestPurchase().subscribe((uri) => {
+        result = uri;
+      });
+      self.$httpBackend.flush();
+
+      expect(result).toEqual('/purchases/crugive/newest=');
+    });
+
+    it('should return undefined when there are no purchases', () => {
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=purchases:element',
+        )
+        .respond(200, {
+          self: { uri: '/profiles/crugive/default' },
+        });
+
+      let result = 'unset';
+      self.profileService.getLatestPurchase().subscribe((uri) => {
+        result = uri;
+      });
+      self.$httpBackend.flush();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('getDonorDetails', () => {
     it("should load the user's donorDetails", () => {
       self.$httpBackend


### PR DESCRIPTION
## Description

Storing the last purchase ID in session storage is fragile. In Todd's case, our best guess is that he reached /thank-you.html by direct navigation. Is actual gift was in a separate earlier session/device, whose sessionStorage was gone by the time he opened /thank-you.html.

This PR makes it more robust by loading the user's most recent purchase if there is not stored purchase ID. If the user isn't logged in, we can't recover their purchase and instead show the same message as before.

HelpScout ticket: https://secure.helpscout.net/conversation/3342302582/1640116/

## Testing

- Log in with an account that has a previous purchase
- Go to `thank-you.html`
- Check that it shows your previous purchase

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [ ] I have tested my changes in staging for branded checkout
