### PR TITLE
[RB-65975] Make loading Okta callback page not an error

### DIFF
--- a/src/app/oktaAuthCallback/oktaAuthCallback.component.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.component.js
@@ -49,6 +49,14 @@ class OktaAuthCallbackController {
   }
 
   onSignInSuccess(data) {
+    // handleOktaRedirect emits `false` when the page loads without an Okta
+    // login redirect in the URL (direct navigation, refresh, bookmark, back
+    // button, etc). Redirect to the sign-in page instead of showing an error
+    // message.
+    if (data === false) {
+      this.redirectToSignInPage();
+      return;
+    }
     if (!data) {
       this.onSignInFailure(data);
       return;

--- a/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
+++ b/src/app/oktaAuthCallback/oktaAuthCallback.spec.js
@@ -403,6 +403,14 @@ describe('oktaAuthCallback', function () {
       expect($ctrl.redirectToLocationPriorToLogin).not.toHaveBeenCalled();
     });
 
+    it('should redirect to sign in when there is no Okta login redirect', () => {
+      jest.spyOn($ctrl, 'onSignInFailure');
+      jest.spyOn($ctrl, 'redirectToSignInPage').mockImplementation(() => {});
+      $ctrl.onSignInSuccess(false);
+      expect($ctrl.redirectToSignInPage).toHaveBeenCalled();
+      expect($ctrl.onSignInFailure).not.toHaveBeenCalled();
+    });
+
     it('should not fail if has data', () => {
       jest.spyOn($ctrl, 'onSignInFailure');
       jest


### PR DESCRIPTION
## Description

Fix [Rollbar #65975](https://app.rollbar.com/a/Cru/fix/item/give-web/65975) by not treating non-redirect Okta callback hits as auth errors.

handleOktaRedirect emits `false` when okta-auth-callback.html loads without an Okta login redirect in the URL (direct nav, refresh, bookmark, back button, or bots/prefetchers). onSignInSuccess routed that `false` into onSignInFailure, which logged a Rollbar error and showed the user "Failed to authenticate user when redirecting from Okta" — 4242 occurrences across 427 users, almost all benign.

Treat the `false` sentinel as "no login redirect" and send the user to the sign-in page instead. Real auth failures still arrive as Error objects on the error channel and are logged as before. `undefined`/`null` data (a genuinely empty sign-in response) is also still treated as a failure.

This should also resolve another failed to authenticate issue:
* https://app.rollbar.com/a/Cru/fix/item/give-web/66007#detail

## Testing

- Go to `/okta-auth-callback.html`
- Check that you are taken to the sign in page without an error
- Go to `/okta-auth-callback.html?code=foo`
- Check that an authentication error is shown

## Checklist:

- [x] I have given my PR a title with the format "EP-(JIRA#) (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels (_Add the label "On Staging" to get the branch automatically merged into staging_)
- [x] I have requested a review from another person on the project
- [x] I have checked that `stage-branch-merger` successfully merged my branch to staging or manually merged it myself
- [x] I have tested my changes in staging for regular checkout
- [x] I have tested my changes in staging for branded checkout
