### PR TITLE
EP-2490/EP-2491 - Don't fail entire payment method list when one instrument is malformed

### DIFF
--- a/src/app/profile/payment-methods/payment-methods.component.js
+++ b/src/app/profile/payment-methods/payment-methods.component.js
@@ -144,7 +144,7 @@ class PaymentMethodsController {
           if (data.address) {
             data.address = formatAddressForTemplate(data.address);
           } else if (
-            data['payment-instrument-identification-attributes'][
+            data['payment-instrument-identification-attributes']?.[
               'street-address'
             ]
           ) {

--- a/src/common/services/api/order.service.js
+++ b/src/common/services/api/order.service.js
@@ -304,7 +304,7 @@ class Order {
           if (
             paymentMethod.description[
               'payment-instrument-identification-attributes'
-            ]['street-address']
+            ]?.['street-address']
           ) {
             paymentMethod.description.address = formatAddressForTemplate(
               paymentMethod.description[
@@ -339,7 +339,9 @@ class Order {
       .map((data) => {
         if (
           data &&
-          data['payment-instrument-identification-attributes']['street-address']
+          data['payment-instrument-identification-attributes']?.[
+            'street-address'
+          ]
         ) {
           data.address = formatAddressForTemplate(
             data['payment-instrument-identification-attributes'],

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -1032,7 +1032,7 @@ describe('order service', () => {
       self.$httpBackend.flush();
     });
 
-    it('should not fail when the current payment is missing payment-instrument-identification-attributes', (done) => {
+    it('should pass when the current payment is missing payment-instrument-identification-attributes', (done) => {
       const clonedResponse = angular.copy(paymentMethodCreditCardResponse);
       const description =
         clonedResponse._order[0]._paymentinstrumentselector[0]._chosen[0]

--- a/src/common/services/api/order.service.spec.js
+++ b/src/common/services/api/order.service.spec.js
@@ -893,6 +893,39 @@ describe('order service', () => {
 
       self.$httpBackend.flush();
     });
+
+    it('should still load all payment methods when one is missing payment-instrument-identification-attributes', (done) => {
+      delete clonedPaymentMethodSelectorResponse._order[0]
+        ._paymentinstrumentselector[0]._choice[0]._description[0][
+        'payment-instrument-identification-attributes'
+      ];
+
+      // The malformed payment method is still returned, just without its identification attributes
+      expectedResponse[2] = {
+        self: expectedResponse[2].self,
+        messages: [],
+        links: [],
+        'default-on-profile': false,
+        name: 'Cru Payment Instrument',
+        selectAction: expectedResponse[2].selectAction,
+      };
+
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:choice,order:paymentinstrumentselector:choice:description,order:paymentinstrumentselector:chosen,order:paymentinstrumentselector:chosen:description',
+        )
+        .respond(200, clonedPaymentMethodSelectorResponse);
+
+      self.orderService.getExistingPaymentMethods().subscribe(
+        (data) => {
+          expect(data).toEqual(expectedResponse);
+          done();
+        },
+        (error) => done(error),
+      );
+
+      self.$httpBackend.flush();
+    });
   });
 
   describe('selectPaymentMethod', () => {
@@ -995,6 +1028,31 @@ describe('order service', () => {
         expect(data).toEqual(expectedPaymentInfo);
         done();
       });
+
+      self.$httpBackend.flush();
+    });
+
+    it('should not fail when the current payment is missing payment-instrument-identification-attributes', (done) => {
+      const clonedResponse = angular.copy(paymentMethodCreditCardResponse);
+      const description =
+        clonedResponse._order[0]._paymentinstrumentselector[0]._chosen[0]
+          ._description[0];
+      delete description['payment-instrument-identification-attributes'];
+
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/carts/crugive/default?zoom=order:paymentinstrumentselector:chosen:description',
+        )
+        .respond(200, clonedResponse);
+
+      self.orderService.getCurrentPayment().subscribe(
+        (data) => {
+          expect(data).toEqual(angular.copy(description));
+          expect(data.address).toBeUndefined();
+          done();
+        },
+        (error) => done(error),
+      );
 
       self.$httpBackend.flush();
     });

--- a/src/common/services/api/profile.service.js
+++ b/src/common/services/api/profile.service.js
@@ -216,7 +216,7 @@ class Profile {
         paymentMethods = map(paymentMethods, (paymentMethod) => {
           paymentMethod.id = paymentMethod.self.uri.split('/').pop();
           if (
-            paymentMethod['payment-instrument-identification-attributes'][
+            paymentMethod['payment-instrument-identification-attributes']?.[
               'street-address'
             ]
           ) {
@@ -239,7 +239,7 @@ class Profile {
       .map((paymentMethod) => {
         paymentMethod.id = paymentMethod.self.uri.split('/').pop();
         if (
-          paymentMethod['payment-instrument-identification-attributes'][
+          paymentMethod['payment-instrument-identification-attributes']?.[
             'street-address'
           ]
         ) {
@@ -264,7 +264,7 @@ class Profile {
       .map((paymentMethods) => {
         paymentMethods = map(paymentMethods, (paymentMethod) => {
           if (
-            paymentMethod['payment-instrument-identification-attributes'][
+            paymentMethod['payment-instrument-identification-attributes']?.[
               'street-address'
             ]
           ) {

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -224,6 +224,35 @@ describe('profile service', () => {
       };
       testGetPaymentMethod(incomingPaymentMethodResponse);
     });
+
+    it('should still load the payment method when it is missing payment-instrument-identification-attributes', (done) => {
+      const incomingPaymentMethodResponse = angular.copy(paymentmethodResponse);
+      incomingPaymentMethodResponse.address = undefined;
+      delete incomingPaymentMethodResponse[
+        'payment-instrument-identification-attributes'
+      ];
+
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/selfservicepaymentinstruments/crugive/giydiojyg4=',
+        )
+        .respond(200, incomingPaymentMethodResponse);
+
+      self.profileService
+        .getPaymentMethod('/selfservicepaymentinstruments/crugive/giydiojyg4=')
+        .subscribe(
+          (data) => {
+            // The payment method missing identification attributes is still returned, just without an address
+            expect(data.id).toEqual('giydiojyg4=');
+            expect(data['card-number']).toEqual('1111');
+            expect(data.address).toBeUndefined();
+            expect(data.streetAddress).toBeUndefined();
+            done();
+          },
+          (error) => done(error),
+        );
+      self.$httpBackend.flush();
+    });
   });
 
   describe('getPaymentMethodsWithDonations', () => {

--- a/src/common/services/api/profile.service.spec.js
+++ b/src/common/services/api/profile.service.spec.js
@@ -120,6 +120,55 @@ describe('profile service', () => {
       };
       testGetPaymentMethods(incomingPaymentMethodsResponse);
     });
+
+    it('should still load all payment methods when one is missing payment-instrument-identification-attributes', (done) => {
+      const incomingPaymentMethodsResponse = angular.copy(
+        paymentmethodsResponse,
+      );
+      const incomingPaymentMethods =
+        incomingPaymentMethodsResponse._selfservicepaymentinstruments[0]
+          ._element;
+      incomingPaymentMethods[0][
+        'payment-instrument-identification-attributes'
+      ] = {
+        'country-name': 'US',
+        'street-address': '123 First St',
+        'extended-address': '',
+        locality: 'Sacramento',
+        'postal-code': '12345',
+        region: 'CA',
+      };
+      delete incomingPaymentMethods[1][
+        'payment-instrument-identification-attributes'
+      ];
+
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:element',
+        )
+        .respond(200, incomingPaymentMethodsResponse);
+
+      self.profileService.getPaymentMethods().subscribe(
+        (data) => {
+          expect(data.length).toEqual(2);
+          // The bank account missing identification attributes is still returned, just without an address
+          expect(data[0]['account-type']).toEqual('Savings');
+          expect(data[0].address).toBeUndefined();
+          // The well-formed payment method is unaffected
+          expect(data[1].address).toEqual({
+            country: 'US',
+            streetAddress: '123 First St',
+            extendedAddress: '',
+            locality: 'Sacramento',
+            region: 'CA',
+            postalCode: '12345',
+          });
+          done();
+        },
+        (error) => done(error),
+      );
+      self.$httpBackend.flush();
+    });
   });
 
   describe('getPaymentMethod', () => {
@@ -200,6 +249,37 @@ describe('profile service', () => {
       self.profileService.getPaymentMethodsWithDonations().subscribe((data) => {
         expect(data).toEqual(expectedData);
       });
+      self.$httpBackend.flush();
+    });
+
+    it('should still load all payment methods when one is missing payment-instrument-identification-attributes', (done) => {
+      const incomingResponse = cloneDeep(paymentmethodsWithDonationsResponse);
+      const incomingPaymentMethods =
+        incomingResponse._selfservicepaymentinstruments[0]._element;
+      delete incomingPaymentMethods[0][
+        'payment-instrument-identification-attributes'
+      ];
+
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/cortex/profiles/crugive/default?zoom=selfservicepaymentinstruments:element,selfservicepaymentinstruments:element:recurringgifts',
+        )
+        .respond(200, incomingResponse);
+
+      self.profileService.getPaymentMethodsWithDonations().subscribe(
+        (data) => {
+          expect(data.length).toEqual(2);
+          // The payment method missing identification attributes is still returned, just without an address
+          expect(data[0].address).toBeUndefined();
+          // The other payment method is unaffected
+          expect(data[1].recurringGifts).toEqual([
+            expect.any(RecurringGiftModel),
+            expect.any(RecurringGiftModel),
+          ]);
+          done();
+        },
+        (error) => done(error),
+      );
       self.$httpBackend.flush();
     });
   });


### PR DESCRIPTION
## Jira
[EP-2490](https://jira.cru.org/browse/EP-2490) (Critical), [EP-2491](https://jira.cru.org/browse/EP-2491)

## Problem
One malformed payment instrument — missing `payment-instrument-identification-attributes` (seen with instruments created in checkout without a billing address) — threw a TypeError during list mapping. The error took down the whole observable, so:
- self-service showed "There was an error loading your payment methods. You may try again." (EP-2491)
- checkout step 2 silently fell back to the empty/new-payment form as if the donor had no saved payment methods (EP-2490)

## Fix
Optional-chaining guards at the five mapping sites:
- `profile.service.js`: `getPaymentMethods()`, `getPaymentMethod()`, `getPaymentMethodsWithDonations()`
- `order.service.js`: `getExistingPaymentMethods()`, `getCurrentPayment()`

Malformed entries are now mapped defensively (attribute fields absent) instead of failing the list; well-formed results are byte-identical (covered by full-list assertions).

## Tests
5 new specs written red-first (each reproduces the production TypeError without the fix). `profile.service.spec.js` + `order.service.spec.js`: 117 passing.

## Notes
- This fixes the **symptom**. The backend root cause (DELETE not persisted + NPE in `CruPaymentResourceHelpers.buildPaymentInstrumentAttributesEntity`) is tracked in [EP-2633](https://jira.cru.org/browse/EP-2633).
- Review follow-ups (not in scope): same unguarded read in `payment-methods.component.js:147` add-flow handler; several legacy specs in these files assert vacuously (failures swallowed by $q digest).

## How you can test it

1. Add multiple credit cards to your payment methods. Test cards are here - https://developer.globalpayments.com/resources/test-cards
2. Add a gift to your cart.
3. Ensure all show on step 2
<img width="703" height="271" alt="Screenshot 2026-06-11 at 3 31 11 PM" src="https://github.com/user-attachments/assets/04676ee5-2ef2-424a-81e0-13dfb22db1b7" />

