### PR TITLE
EP-2320 - Don't fail product config form when designation has no AEM page

### DIFF
--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -19,12 +19,14 @@ class DesignationsService {
   constructor(
     $http,
     $location,
+    $log,
     envService,
     cortexApiService,
     hateoasHelperService,
   ) {
     this.$http = $http;
     this.$location = $location;
+    this.$log = $log;
     this.envService = envService;
     this.cortexApiService = cortexApiService;
     this.hateoasHelperService = hateoasHelperService;
@@ -269,7 +271,13 @@ class DesignationsService {
         }
         return suggestedAmounts;
       })
-      .catch(() => Observable.of([]));
+      .catch((error) => {
+        this.$log.error(
+          `Error loading suggested amounts for designation ${code}`,
+          error,
+        );
+        return Observable.of([]);
+      });
   }
 
   facebookPixel(code) {
@@ -311,7 +319,13 @@ class DesignationsService {
         }
         return givingLinks;
       })
-      .catch(() => Observable.of([]));
+      .catch((error) => {
+        this.$log.error(
+          `Error loading giving links for designation ${code}`,
+          error,
+        );
+        return Observable.of([]);
+      });
   }
 
   ministriesList(pagePath) {

--- a/src/common/services/api/designations.service.js
+++ b/src/common/services/api/designations.service.js
@@ -285,31 +285,33 @@ class DesignationsService {
     const path = this.generatePath(code, campaignPage);
     return Observable.from(
       this.$http.get(this.envService.read('publicGive') + path),
-    ).map((data) => {
-      const givingLinks = [];
-      if (data.data['jcr:content']) {
-        // Map giving links
-        if (data.data['jcr:content'].givingLinks) {
-          angular.forEach(data.data['jcr:content'].givingLinks, (v, k) => {
-            if (!v || !v.name || !v.url) {
-              // Some accounts contain multiple, empty giving links. Until we figure how how they
-              // are being created, we are ignoring them on the frontend.
-              // https://jira.cru.org/browse/EP-2554
-              return;
-            }
+    )
+      .map((data) => {
+        const givingLinks = [];
+        if (data.data['jcr:content']) {
+          // Map giving links
+          if (data.data['jcr:content'].givingLinks) {
+            angular.forEach(data.data['jcr:content'].givingLinks, (v, k) => {
+              if (!v || !v.name || !v.url) {
+                // Some accounts contain multiple, empty giving links. Until we figure how how they
+                // are being created, we are ignoring them on the frontend.
+                // https://jira.cru.org/browse/EP-2554
+                return;
+              }
 
-            if (toFinite(k) > 0 || startsWith(k, 'item')) {
-              givingLinks.push({
-                name: v.name,
-                url: v.url,
-                order: toFinite(k) > 0 ? toFinite(k) : Number(k.substring(4)),
-              });
-            }
-          });
+              if (toFinite(k) > 0 || startsWith(k, 'item')) {
+                givingLinks.push({
+                  name: v.name,
+                  url: v.url,
+                  order: toFinite(k) > 0 ? toFinite(k) : Number(k.substring(4)),
+                });
+              }
+            });
+          }
         }
-      }
-      return givingLinks;
-    });
+        return givingLinks;
+      })
+      .catch(() => Observable.of([]));
   }
 
   ministriesList(pagePath) {

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -305,6 +305,21 @@ describe('designation service', () => {
         }, done);
       self.$httpBackend.flush();
     });
+
+    it('should handle a missing designation page', (done) => {
+      self.$httpBackend
+        .expectGET(
+          'https://give-stage2.cru.org/content/give/us/en/designations/0/1/2/3/4/0123456.infinity.json',
+        )
+        .respond(404, {});
+      self.designationsService
+        .givingLinks('0123456')
+        .subscribe((givingLinks) => {
+          expect(givingLinks).toEqual([]);
+          done();
+        }, done);
+      self.$httpBackend.flush();
+    });
   });
 
   describe('generatePath', () => {

--- a/src/common/services/api/designations.service.spec.js
+++ b/src/common/services/api/designations.service.spec.js
@@ -12,10 +12,11 @@ describe('designation service', () => {
   beforeEach(angular.mock.module(module.name));
   const self = {};
 
-  beforeEach(inject((designationsService, $httpBackend, $location) => {
+  beforeEach(inject((designationsService, $httpBackend, $location, $log) => {
     self.designationsService = designationsService;
     self.$httpBackend = $httpBackend;
     self.$location = $location;
+    self.$log = $log;
   }));
 
   afterEach(() => {
@@ -220,6 +221,10 @@ describe('designation service', () => {
           expect(suggestedAmounts).toEqual([]);
           expect(itemConfig['default-campaign-code']).toBeUndefined();
           expect(itemConfig['jcr-title']).toBeUndefined();
+          expect(self.$log.error.logs[0]).toEqual([
+            'Error loading suggested amounts for designation 0123456',
+            expect.objectContaining({ status: 400 }),
+          ]);
           done();
         }, done);
       self.$httpBackend.flush();
@@ -316,6 +321,10 @@ describe('designation service', () => {
         .givingLinks('0123456')
         .subscribe((givingLinks) => {
           expect(givingLinks).toEqual([]);
+          expect(self.$log.error.logs[0]).toEqual([
+            'Error loading giving links for designation 0123456',
+            expect.objectContaining({ status: 404 }),
+          ]);
           done();
         }, done);
       self.$httpBackend.flush();


### PR DESCRIPTION
## Jira
[EP-2320](https://jira.cru.org/browse/EP-2320)

## Problem
`givingLinks()` in `designations.service.js` fetches the designation's AEM `.infinity.json` content with no error handling. When a designation has no AEM page (returns 300/404/500 — common for branded checkout designations on third-party sites), the error propagated through the merged observable in `productConfigForm.loadData()` and killed the entire gift config form (`errorLoading = true`).

The sibling `suggestedAmounts()` — which fetches the same URL — already recovers with `.catch(() => Observable.of([]))`.

## Fix
Apply the same catch to `givingLinks()`: an AEM content failure now yields an empty giving-links list and the form proceeds normally. Consumer already handles `[]` (`givingLinks || []`, length-gated).

## Tests
New red-first spec: 404 on the `.infinity.json` request → `givingLinks` emits `[]` instead of erroring. 96/96 passing across `designations.service.spec.js` + `productConfigForm.component.spec.js`.

## Review notes (flagged, out of scope)
- The catch is silent (matches the existing `suggestedAmounts` convention); a debug log could aid AEM-outage diagnosis.
- `getNextDrawDate()` is another unguarded member of the same merged stream (Cortex call, different failure class).