### PR TITLE
EP-2481 - Fix un-interpolated frequency labels and annual gift day display

### DIFF
--- a/src/common/components/giftViews/giftDetailsView/giftDetailsView.component.spec.js
+++ b/src/common/components/giftViews/giftDetailsView/giftDetailsView.component.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import moment from 'moment';
 
 import module from './giftDetailsView.component';
 
@@ -14,6 +15,33 @@ describe('giftViews', () => {
 
     it('is defined', () => {
       expect($ctrl).toBeDefined();
+    });
+
+    describe('template', () => {
+      let $compile, $rootScope;
+
+      beforeEach(inject((_$compile_, _$rootScope_) => {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+      }));
+
+      it('renders the day label for annual gifts', () => {
+        const scope = $rootScope.$new();
+        scope.gift = {
+          amount: 25,
+          frequency: 'Annual',
+          transactionDay: '15',
+          nextGiftDate: moment.utc('2056-07-15'),
+        };
+        const element = $compile(
+          '<gift-details-view gift="gift"></gift-details-view>',
+        )(scope);
+        $rootScope.$digest();
+        const text = element.text().replace(/\s+/g, ' ').trim();
+
+        expect(text).toContain('On July 15th of each year');
+        expect(text).not.toContain('{{');
+      });
     });
   });
 });

--- a/src/common/components/giftViews/giftDetailsView/giftDetailsView.tpl.html
+++ b/src/common/components/giftViews/giftDetailsView/giftDetailsView.tpl.html
@@ -9,7 +9,7 @@
     On the {{$ctrl.gift.transactionDay | ordinal}} of
     {{$ctrl.quarterlyMonths(null, $ctrl.gift.nextGiftDate)}}
   </div>
-  <div class="u-block" ng-switch-when="Annually">
+  <div class="u-block" ng-switch-when="Annual">
     On {{$ctrl.gift.nextGiftDate.format('MMMM')}} {{$ctrl.gift.transactionDay |
     ordinal}} of each year
   </div>

--- a/src/common/components/giftViews/giftSummaryView/giftSummaryView.component.spec.js
+++ b/src/common/components/giftViews/giftSummaryView/giftSummaryView.component.spec.js
@@ -1,11 +1,13 @@
 import angular from 'angular';
 import 'angular-mocks';
+import 'angular-translate';
+import moment from 'moment';
 
 import module from './giftSummaryView.component';
 
 describe('giftViews', () => {
   describe('giftSummaryView', () => {
-    beforeEach(angular.mock.module(module.name));
+    beforeEach(angular.mock.module(module.name, 'pascalprecht.translate'));
     let $ctrl;
 
     beforeEach(inject(($componentController) => {
@@ -14,6 +16,55 @@ describe('giftViews', () => {
 
     it('is defined', () => {
       expect($ctrl).toBeDefined();
+    });
+
+    describe('template', () => {
+      let $compile, $rootScope;
+
+      beforeEach(inject((_$compile_, _$rootScope_) => {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+      }));
+
+      const compileWithGift = (gift) => {
+        const scope = $rootScope.$new();
+        scope.gift = gift;
+        const element = $compile(
+          '<gift-summary-view gift="gift"></gift-summary-view>',
+        )(scope);
+        $rootScope.$digest();
+        return element.text().replace(/\s+/g, ' ').trim();
+      };
+
+      const buildGift = (frequency) => ({
+        amount: 25,
+        frequency: frequency,
+        transactionDay: '15',
+        nextGiftDate: moment.utc('2056-07-15'),
+      });
+
+      it('renders the interpolated day label for monthly gifts', () => {
+        const text = compileWithGift(buildGift('Monthly'));
+
+        expect(text).toContain('On the 15th of each month');
+        expect(text).not.toContain('{{');
+      });
+
+      it('renders the interpolated day label for quarterly gifts', () => {
+        const text = compileWithGift(buildGift('Quarterly'));
+
+        expect(text).toContain(
+          'On the 15th of July, October, January, and April',
+        );
+        expect(text).not.toContain('{{');
+      });
+
+      it('renders the interpolated day label for annual gifts', () => {
+        const text = compileWithGift(buildGift('Annual'));
+
+        expect(text).toContain('On July 15th of each year');
+        expect(text).not.toContain('{{');
+      });
     });
   });
 });

--- a/src/common/components/giftViews/giftSummaryView/giftSummaryView.tpl.html
+++ b/src/common/components/giftViews/giftSummaryView/giftSummaryView.tpl.html
@@ -2,14 +2,14 @@
   {{$ctrl.gift.amount | currency}} {{$ctrl.gift.frequency}}
 </h5>
 <div ng-switch="$ctrl.gift.frequency">
-  <small ng-switch-when="Monthly" translate>
+  <small ng-switch-when="Monthly">
     On the {{$ctrl.gift.transactionDay | ordinal}} of each month
   </small>
-  <small ng-switch-when="Quarterly" translate>
+  <small ng-switch-when="Quarterly">
     On the {{$ctrl.gift.transactionDay | ordinal}} of
     {{$ctrl.quarterlyMonths(null, $ctrl.gift.nextGiftDate)}}
   </small>
-  <small ng-switch-when="Annually" translate>
+  <small ng-switch-when="Annual">
     On {{$ctrl.gift.nextGiftDate.format('MMMM')}} {{$ctrl.gift.transactionDay |
     ordinal}} of each year
   </small>


### PR DESCRIPTION
## Jira
[EP-2481](https://jira.cru.org/browse/EP-2481)

## Problems
1. **Un-interpolated labels:** `giftSummaryView.tpl.html` had `translate` attributes on elements containing interpolation bindings, so angular-translate rendered the raw template text (e.g. `On the {{$ctrl.gift.transactionDay | ordinal}} of...`) in the Stop a Gift dialog and delete-payment-method modal. The identical bug was fixed in `giftDetailsView` by 399bc8b2 (EP-2383) — this template was missed.
2. **Annual gifts showed no day label at all:** both templates switched on `ng-switch-when="Annually"`, but the model's frequency value is `'Annual'` (see `<option value="Annual">` in giftUpdateView and the `frequency === 'Annual'` gates). The `displayRateTotals` "Annually" strings are Cortex rate-display values — a different domain, untouched.

## Fix
Removed the three `translate` attributes (mirroring 399bc8b2 — those keys were never in the translation tables, so no i18n change) and corrected the switch values to `Annual` in both templates.

## Tests
6 new template-rendering specs, written red-first (reproduced both symptoms: raw binding text for quarterly, missing day label for annual). `src/common/components/giftViews`: 20/20 passing.


<img width="600" height="445" alt="Screenshot 2026-06-11 at 4 26 51 PM" src="https://github.com/user-attachments/assets/6ea967db-ed6c-4f6d-8d33-b8fafda8cf3e" />
