### PR TITLE
EP-2378 - Require a valid amount before submitting recurring gifts

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -42,6 +42,10 @@ class EditRecurringGiftsController {
   allPaymentMethodsValid() {
     return every(this.recurringGifts, (gift) => gift.paymentMethod);
   }
+
+  allAmountsValid() {
+    return every(this.recurringGifts, (gift) => gift.hasValidAmount());
+  }
 }
 
 export default angular

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.js
@@ -39,12 +39,15 @@ class EditRecurringGiftsController {
     }
   }
 
-  allPaymentMethodsValid() {
-    return every(this.recurringGifts, (gift) => gift.paymentMethod);
-  }
-
-  allAmountsValid() {
-    return every(this.recurringGifts, (gift) => gift.hasValidAmount());
+  allGiftsValid() {
+    const hasPaymentMethods = every(
+      this.recurringGifts,
+      (gift) => gift.paymentMethod,
+    );
+    const hasValidAmounts = every(this.recurringGifts, (gift) =>
+      gift.hasValidAmount(),
+    );
+    return hasPaymentMethods && hasValidAmounts;
   }
 }
 

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
@@ -61,7 +61,7 @@ describe('editRecurringGiftsModal', () => {
       });
     });
 
-    describe('allPaymentMethodsValid', () => {
+    describe('allGiftsValid', () => {
       beforeEach(() => {
         RecurringGiftModel.paymentMethods = [
           {
@@ -70,34 +70,23 @@ describe('editRecurringGiftsModal', () => {
         ];
       });
 
-      it('should return true if all payment methods are valid', () => {
+      it('should return true if all gifts have valid payment methods and amounts', () => {
         self.controller.recurringGifts = [
           new RecurringGiftModel({}).setDefaults(),
           new RecurringGiftModel({}).setDefaults(),
         ];
 
-        expect(self.controller.allPaymentMethodsValid()).toEqual(true);
+        expect(self.controller.allGiftsValid()).toEqual(true);
       });
 
-      it('should return false if any payment methods is invalid', () => {
+      it('should return false if any payment method is invalid', () => {
         self.controller.recurringGifts = [
           new RecurringGiftModel({}).setDefaults(),
           new RecurringGiftModel({}).setDefaults(),
         ];
         self.controller.recurringGifts[0].paymentMethodId = 'something invalid';
 
-        expect(self.controller.allPaymentMethodsValid()).toEqual(false);
-      });
-    });
-
-    describe('allAmountsValid', () => {
-      it('should return true if all amounts are valid', () => {
-        self.controller.recurringGifts = [
-          new RecurringGiftModel({}).setDefaults(),
-          new RecurringGiftModel({}).setDefaults(),
-        ];
-
-        expect(self.controller.allAmountsValid()).toEqual(true);
+        expect(self.controller.allGiftsValid()).toEqual(false);
       });
 
       it('should return false if any amount is invalid', () => {
@@ -107,7 +96,7 @@ describe('editRecurringGiftsModal', () => {
         ];
         self.controller.recurringGifts[0].amount = undefined;
 
-        expect(self.controller.allAmountsValid()).toEqual(false);
+        expect(self.controller.allGiftsValid()).toEqual(false);
       });
     });
   });

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.component.spec.js
@@ -89,5 +89,26 @@ describe('editRecurringGiftsModal', () => {
         expect(self.controller.allPaymentMethodsValid()).toEqual(false);
       });
     });
+
+    describe('allAmountsValid', () => {
+      it('should return true if all amounts are valid', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({}).setDefaults(),
+          new RecurringGiftModel({}).setDefaults(),
+        ];
+
+        expect(self.controller.allAmountsValid()).toEqual(true);
+      });
+
+      it('should return false if any amount is invalid', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({}).setDefaults(),
+          new RecurringGiftModel({}).setDefaults(),
+        ];
+        self.controller.recurringGifts[0].amount = undefined;
+
+        expect(self.controller.allAmountsValid()).toEqual(false);
+      });
+    });
   });
 });

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
@@ -80,7 +80,7 @@
       type="button"
       ng-if="!$ctrl.loadingError"
       ng-click="$ctrl.next({ recurringGifts: $ctrl.recurringGifts })"
-      ng-disabled="!$ctrl.allPaymentMethodsValid()"
+      ng-disabled="!$ctrl.allPaymentMethodsValid() || !$ctrl.allAmountsValid()"
       translate
     >
       Continue

--- a/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step1/editRecurringGifts.tpl.html
@@ -80,7 +80,7 @@
       type="button"
       ng-if="!$ctrl.loadingError"
       ng-click="$ctrl.next({ recurringGifts: $ctrl.recurringGifts })"
-      ng-disabled="!$ctrl.allPaymentMethodsValid() || !$ctrl.allAmountsValid()"
+      ng-disabled="!$ctrl.allGiftsValid()"
       translate
     >
       Continue

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import every from 'lodash/every';
 
 import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
 import giftUpdateView from 'common/components/giftViews/giftUpdateView/giftUpdateView.component';
@@ -10,6 +11,13 @@ const componentName = 'step3ConfigureRecentRecipients';
 class ConfigureRecentRecipientsController {
   /* @ngInject */
   constructor() /* eslint-disable-line no-useless-constructor */ {}
+
+  allGiftsValid() {
+    return every(
+      this.additions,
+      (gift) => gift.paymentMethod && gift.hasValidAmount(),
+    );
+  }
 }
 
 export default angular

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.component.spec.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import 'angular-mocks';
 
+import RecurringGiftModel from 'common/models/recurringGift.model';
+
 import module from './configureRecentRecipients.component';
 
 describe('editRecurringGiftsModal', () => {
@@ -20,6 +22,36 @@ describe('editRecurringGiftsModal', () => {
 
     it('should get all selected gifts and pass them to the next step', () => {
       expect(self.controller).toBeDefined();
+    });
+
+    describe('allGiftsValid', () => {
+      beforeEach(() => {
+        RecurringGiftModel.paymentMethods = [
+          {
+            self: { uri: '/selfservicepaymentinstruments/crugive/giydgnrxgm=' },
+          },
+        ];
+        self.controller.additions = [
+          new RecurringGiftModel({}).setDefaults(),
+          new RecurringGiftModel({}).setDefaults(),
+        ];
+      });
+
+      it('should return true if all gifts have valid amounts and payment methods', () => {
+        expect(self.controller.allGiftsValid()).toEqual(true);
+      });
+
+      it('should return false if any amount is invalid', () => {
+        self.controller.additions[0].amount = undefined;
+
+        expect(self.controller.allGiftsValid()).toEqual(false);
+      });
+
+      it('should return false if any payment method is invalid', () => {
+        self.controller.additions[0].paymentMethodId = 'something invalid';
+
+        expect(self.controller.allGiftsValid()).toEqual(false);
+      });
     });
   });
 });

--- a/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step3/configureRecentRecipients.tpl.html
@@ -52,6 +52,7 @@
       class="btn btn-primary"
       type="button"
       ng-click="$ctrl.next({ additions: $ctrl.additions })"
+      ng-disabled="!$ctrl.allGiftsValid()"
       translate
     >
       Continue

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -103,6 +103,16 @@ export default class RecurringGiftModel {
     this.gift['updated-amount'] = value !== this.gift.amount ? value : '';
   }
 
+  // Mirrors the amount validation rules in giftUpdateView.tpl.html
+  hasValidAmount() {
+    const amount = this.amount;
+    return (
+      /^[0-9]+(\.[0-9]{1,2})?$/.test(amount) &&
+      amount >= 1 &&
+      amount <= 10000000
+    );
+  }
+
   get paymentMethodId() {
     let paymentMethodId =
       this.gift['updated-payment-instrument-id'] ||
@@ -256,8 +266,11 @@ export default class RecurringGiftModel {
   }
 
   hasChanges() {
+    // updated-amount is undefined when the amount input was cleared or invalid
+    // (ng-model sets the model to undefined), so it isn't a change to submit
     return (
-      this.gift['updated-amount'] !== '' ||
+      (this.gift['updated-amount'] !== '' &&
+        this.gift['updated-amount'] !== undefined) ||
       this.gift['updated-payment-instrument-id'] !== '' ||
       this.gift['updated-rate'].recurrence.interval !== '' ||
       this.gift['updated-recurring-day-of-month'] !== '' ||

--- a/src/common/models/recurringGift.model.js
+++ b/src/common/models/recurringGift.model.js
@@ -266,11 +266,8 @@ export default class RecurringGiftModel {
   }
 
   hasChanges() {
-    // updated-amount is undefined when the amount input was cleared or invalid
-    // (ng-model sets the model to undefined), so it isn't a change to submit
     return (
-      (this.gift['updated-amount'] !== '' &&
-        this.gift['updated-amount'] !== undefined) ||
+      !!this.gift['updated-amount'] ||
       this.gift['updated-payment-instrument-id'] !== '' ||
       this.gift['updated-rate'].recurrence.interval !== '' ||
       this.gift['updated-recurring-day-of-month'] !== '' ||

--- a/src/common/models/recurringGift.model.spec.js
+++ b/src/common/models/recurringGift.model.spec.js
@@ -182,6 +182,54 @@ describe('recurringGift model', () => {
     });
   });
 
+  describe('hasValidAmount', () => {
+    it('should return true for the original amount', () => {
+      expect(giftModel.hasValidAmount()).toEqual(true);
+    });
+
+    it('should return true for a valid updated amount', () => {
+      giftModel.amount = 50;
+
+      expect(giftModel.hasValidAmount()).toEqual(true);
+    });
+
+    it('should return true for a valid updated amount with two decimal places', () => {
+      giftModel.amount = 50.25;
+
+      expect(giftModel.hasValidAmount()).toEqual(true);
+    });
+
+    it('should return false if the amount was cleared (ng-model sets it to undefined)', () => {
+      giftModel.amount = undefined;
+
+      expect(giftModel.hasValidAmount()).toEqual(false);
+    });
+
+    it('should return false for an amount less than 1', () => {
+      giftModel.gift['updated-amount'] = 0.5;
+
+      expect(giftModel.hasValidAmount()).toEqual(false);
+    });
+
+    it('should return false for an amount greater than 10000000', () => {
+      giftModel.amount = 10000001;
+
+      expect(giftModel.hasValidAmount()).toEqual(false);
+    });
+
+    it('should return false for an amount with more than two decimal places', () => {
+      giftModel.amount = 50.123;
+
+      expect(giftModel.hasValidAmount()).toEqual(false);
+    });
+
+    it('should return false for a non-numeric amount', () => {
+      giftModel.amount = 'fifty';
+
+      expect(giftModel.hasValidAmount()).toEqual(false);
+    });
+  });
+
   describe('paymentMethodId getter', () => {
     it("should load payment id if it hasn't been updated", () => {
       expect(giftModel.paymentMethodId).toEqual(
@@ -549,6 +597,12 @@ describe('recurringGift model', () => {
       giftModel.amount = 50;
 
       expect(giftModel.hasChanges()).toEqual(true);
+    });
+
+    it('should return false if the amount was cleared (ng-model sets it to undefined)', () => {
+      giftModel.amount = undefined;
+
+      expect(giftModel.hasChanges()).toEqual(false);
     });
 
     it('should return true if payment id has been updated', () => {


### PR DESCRIPTION
## Jira
[EP-2378](https://jira.cru.org/browse/EP-2378) (High)

## Problem
The "Edit my recurring donations" flow allowed submitting recurring gifts with no amount:
- Step 1 Continue was only gated on `allPaymentMethodsValid()` — amount never checked.
- Step 3 ("Set up your new recurring gifts") Continue had **no `ng-disabled` at all** — the $50 default could be cleared and submitted blank.
- A cleared amount became `updated-amount: undefined`, which `hasChanges()` treated as a change, flowing a blank/$0.00 amount to the confirmation step.

## Fix
- New `RecurringGiftModel.hasValidAmount()` mirroring the giftUpdateView input rules (pattern, ≥ $1, ≤ $10,000,000) — single shared rule for both steps.
- Step 1: Continue now also requires `allAmountsValid()`. The no-gifts case (`every([]) === true`) is deliberately preserved — the template invites users with no gifts to continue and add new ones.
- Step 3: Continue now gated on `allGiftsValid()` (payment method + valid amount per addition).
- `hasChanges()` ignores `updated-amount: undefined` (defense-in-depth; the gates are the primary fix).
- Audited the remaining steps: step 2 only selects recipients (no amounts); step 4 was already gated.

## Out of scope
The broader pattern (outer modal buttons not consuming inner `giftForm` validity, affecting giveOneTimeGift/restartGift/redirectGift) is tracked in [EP-1996](https://jira.cru.org/browse/EP-1996).

## Tests
14 new specs written red-first (model validity rules, both step gates, hasChanges with cleared amount). Targeted suites: 161/161. Regression across all RecurringGiftModel consumers: 305/305.