### PR TITLE
EP-2335 - Block order submission when the selected credit card has expired

### DIFF
--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -8,6 +8,7 @@ import { SignInEvent } from 'common/services/session/session.service';
 import capitalizeFilter from 'common/filters/capitalize.filter';
 import desigSrcDirective from 'common/directives/desigSrc.directive';
 import { startDate } from 'common/services/giftHelpers/giftDates.service';
+import { validPaymentMethod } from 'common/services/paymentHelpers/validPaymentMethods';
 import analyticsFactory from 'app/analytics/analytics.factory';
 import checkoutErrorMessages from 'app/checkout/checkout-error-messages/checkout-error-messages.component';
 import displayAddressComponent from 'common/components/display-address/display-address.component';
@@ -133,11 +134,19 @@ class Step3Controller {
       });
   }
 
+  isCardExpired() {
+    return (
+      !!this.creditCardPaymentDetails &&
+      !validPaymentMethod(this.creditCardPaymentDetails)
+    );
+  }
+
   canSubmitOrder() {
     let enableSubmitBtn = !!(
       this.cartData &&
       this.donorDetails &&
       (this.bankAccountPaymentDetails || this.creditCardPaymentDetails) &&
+      !this.isCardExpired() &&
       !this.needinfoErrors
     );
     enableSubmitBtn =

--- a/src/app/checkout/step-3/step-3.component.js
+++ b/src/app/checkout/step-3/step-3.component.js
@@ -162,6 +162,11 @@ class Step3Controller {
   }
 
   submitOrder() {
+    // Guards direct callers (submitOrderEvent, branded submit binding) and
+    // cards that expire after the button state was last evaluated
+    if (this.isCardExpired()) {
+      return;
+    }
     this.orderService.submitOrder(this).subscribe(() => {
       if (!this.isBranded) {
         // Branded checkout submits its purchase analytics event on the thank you page

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -487,6 +487,22 @@ describe('checkout', () => {
           newStep: 'thankYou',
         });
       });
+
+      it('should not submit when the selected credit card has expired', () => {
+        advanceTo(new Date(2015, 0, 10));
+        jest.spyOn(self.controller.orderService, 'submitOrder');
+        self.controller.creditCardPaymentDetails = {
+          'card-type': 'Visa',
+          'expiry-month': '12',
+          'expiry-year': '2014',
+        };
+
+        self.controller.submitOrder();
+
+        expect(self.controller.orderService.submitOrder).not.toHaveBeenCalled();
+        expect(self.controller.changeStep).not.toHaveBeenCalled();
+        clear();
+      });
     });
 
     describe('logToDatadogRum', () => {

--- a/src/app/checkout/step-3/step-3.component.spec.js
+++ b/src/app/checkout/step-3/step-3.component.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import { advanceTo, clear } from 'jest-date-mock';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
@@ -262,7 +263,64 @@ describe('checkout', () => {
       });
     });
 
+    describe('isCardExpired', () => {
+      beforeEach(() => {
+        advanceTo(new Date(2015, 0, 10));
+      });
+
+      afterEach(clear);
+
+      it('should be false when no credit card payment is loaded', () => {
+        self.controller.creditCardPaymentDetails = undefined;
+
+        expect(self.controller.isCardExpired()).toEqual(false);
+      });
+
+      it('should be false for a bank account payment', () => {
+        self.controller.bankAccountPaymentDetails = {
+          'account-type': 'Checking',
+        };
+        self.controller.creditCardPaymentDetails = undefined;
+
+        expect(self.controller.isCardExpired()).toEqual(false);
+      });
+
+      it('should be false for an unexpired credit card', () => {
+        self.controller.creditCardPaymentDetails = {
+          'card-type': 'Visa',
+          'expiry-month': '01',
+          'expiry-year': '2015',
+        };
+
+        expect(self.controller.isCardExpired()).toEqual(false);
+      });
+
+      it('should be true for an expired credit card', () => {
+        self.controller.creditCardPaymentDetails = {
+          'card-type': 'Visa',
+          'expiry-month': '12',
+          'expiry-year': '2014',
+        };
+
+        expect(self.controller.isCardExpired()).toEqual(true);
+      });
+
+      it('should be true for a credit card missing expiry attributes', () => {
+        self.controller.creditCardPaymentDetails = {
+          'card-type': 'Visa',
+        };
+
+        expect(self.controller.isCardExpired()).toEqual(true);
+      });
+    });
+
     describe('canSubmitOrder', () => {
+      beforeEach(() => {
+        advanceTo(new Date(2015, 0, 10));
+      });
+
+      afterEach(clear);
+
       function runCanSubmitOrder(config) {
         self.controller.cartData = config.cartData;
         self.controller.donorDetails = config.donorDetails;
@@ -298,9 +356,29 @@ describe('checkout', () => {
           cartData: {},
           donorDetails: {},
           bankAccountPaymentDetails: undefined,
-          creditCardPaymentDetails: {},
+          creditCardPaymentDetails: {
+            'card-type': 'Visa',
+            'expiry-month': '01',
+            'expiry-year': '2015',
+          },
           needinfoErrors: undefined,
           outcome: true,
+          submittingOrder: false,
+        });
+      });
+
+      it('should not let you submit the order if the selected credit card has expired', () => {
+        runCanSubmitOrder({
+          cartData: {},
+          donorDetails: {},
+          bankAccountPaymentDetails: undefined,
+          creditCardPaymentDetails: {
+            'card-type': 'Visa',
+            'expiry-month': '12',
+            'expiry-year': '2014',
+          },
+          needinfoErrors: undefined,
+          outcome: false,
           submittingOrder: false,
         });
       });

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -136,6 +136,20 @@
                   ></display-address>
                 </div>
               </div>
+              <div class="col-md-12" ng-if="$ctrl.isCardExpired()">
+                <div class="alert alert-danger" role="alert">
+                  <p translate>{{'REVIEW_SELECTED_CARD_EXPIRED_ERROR'}}</p>
+                  <button
+                    id="expiredCardChangePaymentButton"
+                    class="btn btn-default"
+                    ng-click="$ctrl.changeStep({newStep: 'payment'})"
+                    aria-label="Update payment method"
+                    translate
+                  >
+                    {{'CHANGE'}}
+                  </button>
+                </div>
+              </div>
             </div>
             <loading ng-if="$ctrl.loadingCurrentPayment"></loading>
           </div>

--- a/src/app/checkout/step-3/step-3.tpl.html
+++ b/src/app/checkout/step-3/step-3.tpl.html
@@ -141,7 +141,7 @@
                   <p translate>{{'REVIEW_SELECTED_CARD_EXPIRED_ERROR'}}</p>
                   <button
                     id="expiredCardChangePaymentButton"
-                    class="btn btn-default"
+                    class="btn btn-primary"
                     ng-click="$ctrl.changeStep({newStep: 'payment'})"
                     aria-label="Update payment method"
                     translate

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -395,6 +395,8 @@ export const appConfig = /* @ngInject */ function (
     REVIEW_SUBMITTING_PAYMENT_ERROR:
       'There was an error submitting your payment. Verify that your payment info is correct or try adding it again. If you are still seeing this message, please contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.',
     REVIEW_CARD_EXPIRED_ERROR: 'Your card is expired.',
+    REVIEW_SELECTED_CARD_EXPIRED_ERROR:
+      'The credit card you selected has expired. Please choose or add another payment method.',
     REVIEW_INVALID_CARD_ERROR: 'The credit card number entered is invalid.',
     REVIEW_CARD_DECLINED_ERROR: 'Your credit card was declined.',
     REVIEW_INSUFFICIENT_FUNDS_ERROR:
@@ -695,6 +697,8 @@ export const appConfig = /* @ngInject */ function (
     REVIEW_SUBMITTING_PAYMENT_ERROR:
       'There was an error submitting your payment. Verify that your payment info is correct or try adding it again. If you are still seeing this message, please contact <a href="mailto:eGift@cru.org">eGift@cru.org</a> for assistance.',
     REVIEW_CARD_EXPIRED_ERROR: 'Your card is expired.',
+    REVIEW_SELECTED_CARD_EXPIRED_ERROR:
+      'La tarjeta de crédito que seleccionó ha expirado. Por favor, elija o agregue otro método de pago.',
     REVIEW_INVALID_CARD_ERROR: 'The credit card number entered is invalid.',
     REVIEW_CARD_DECLINED_ERROR: 'Your credit card was declined.',
     REVIEW_INSUFFICIENT_FUNDS_ERROR:


### PR DESCRIPTION
## Jira
[EP-2335](https://jira.cru.org/browse/EP-2335) (High)

## Problem
Expired saved credit cards could be submitted at checkout. Step 2 blocks selecting expired cards (`validPaymentMethod` filter + disabled radios), but step 3 (review) never re-validated:
- Deep-linking to `?step=review` skips step 2 entirely, so a card selected in a previous session that has since expired submits as-is.
- A card can also expire between step 2 and submit at a month boundary.
- The donor sees a successful submission, but the gift won't process (see the Rollbar example on the ticket).

## Fix
- New `isCardExpired()` in step-3, reusing the **same** `validPaymentMethod` helper step 2 uses (one source of truth; month-granularity rules identical, bank accounts unaffected).
- `canSubmitOrder()` now requires `!isCardExpired()` — submit button disables live via the existing digest-driven binding.
- `submitOrder()` itself also early-returns on an expired card, guarding the direct call paths that bypass button state (the `submitOrderEvent` listener, the branded-checkout submit binding, and month-boundary expiry after the last digest).
- Template: `alert-danger` in the payment panel — "The credit card you selected has expired. Please choose or add another payment method." — with a CHANGE button reusing the existing `changeStep({newStep: 'payment'})` navigation. Translate key added to both en and es tables.
- A card missing expiry attributes is treated as expired — identical to step 2's behavior with the same helper, so step 3 can never be more permissive than step 2.

## Tests
7 new specs written red-first (no card / bank account / valid / expired / missing-expiry / canSubmitOrder gate / submitOrder guard), using `jest-date-mock` like the existing validPaymentMethods specs. 80/80 passing across step-3, existingPaymentMethods, and paymentHelpers suites.

## Note
Server-side expiry validation at submit remains backend work (per ticket, the backend doesn't always reject at submit).


## How to test

First test on his branch on localhost, then on production to see the error.

1. Add item to cart.
2. Either have a credit card pre-selected or go through the steps, but stop at step 3
3. In the **Network** tab. locate the request that brings in your **pre-selected credit card** details.
4. On the request URL name, **right-click** and select **Override content**
5. Edit the expiration year to 2022.
6. Refresh the page.
<img width="720" height="575" alt="Screenshot 2026-06-11 at 5 00 29 PM" src="https://github.com/user-attachments/assets/d0cee7bc-2030-4e2f-bc4d-2da70c6976e5" />

