### PR TITLE
EP-2382 - Tighten phone number validation to block malformed input

### DIFF
--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -29,9 +29,10 @@ const mobileBreakpoint = 575;
 
 // Generic phone number regex, matches + and 011 prefixes.
 // Anchored at both ends, allows digits/spaces/hyphens/parentheses/dots,
-// requires 7-15 digits (ITU E.164 max), and supports an optional extension.
+// requires 7-15 digits (ITU E.164 max, excluding a leading 011 international
+// access prefix), and supports an optional extension.
 const phoneNumberRegex =
-  /^(\+?(?:[\s\-().]*\d){7,15})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/;
+  /^((?:011[\s\-.]*)?\+?(?:[\s\-().]*\d){7,15})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/;
 
 // See envServiceProvider.config in common/app.config.js for url configurations
 

--- a/src/common/app.constants.js
+++ b/src/common/app.constants.js
@@ -28,9 +28,10 @@ const cortexScope = 'crugive';
 const mobileBreakpoint = 575;
 
 // Generic phone number regex, matches + and 011 prefixes.
-// See https://stackoverflow.com/a/19592342/2860048
+// Anchored at both ends, allows digits/spaces/hyphens/parentheses/dots,
+// requires 7-15 digits (ITU E.164 max), and supports an optional extension.
 const phoneNumberRegex =
-  /([0-9\s-]{7,})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/;
+  /^(\+?(?:[\s\-().]*\d){7,15})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/;
 
 // See envServiceProvider.config in common/app.config.js for url configurations
 

--- a/src/common/app.constants.spec.js
+++ b/src/common/app.constants.spec.js
@@ -14,6 +14,9 @@ describe('app.constants', () => {
         ['1234567890'],
         ['(111) 111-111'],
         ['011 44 20 7946 0958'],
+        ['011 86 139 1234 5678'], // 13 digits after the 011 access prefix
+        ['011 49 30 12345678901'], // 15 digits after the prefix; 011 is excluded from the digit cap
+        ['0115551234'], // plain 10-digit number that happens to start with 011
         ['407.555.1234'],
       ])('should match %s', (number) => {
         expect(phoneNumberRegex.test(number)).toEqual(true);
@@ -45,6 +48,7 @@ describe('app.constants', () => {
         [''],
         ['123456'], // fewer than 7 digits
         ['1234567890123456'], // more than 15 digits
+        ['011 49 30 123456789012'], // 16 digits after the 011 prefix exceeds the E.164 max
         ['407-555-1234 ext.'], // extension marker without digits
       ])('should not match %s', (number) => {
         expect(phoneNumberRegex.test(number)).toEqual(false);

--- a/src/common/app.constants.spec.js
+++ b/src/common/app.constants.spec.js
@@ -1,0 +1,54 @@
+import { phoneNumberRegex } from 'common/app.constants';
+
+describe('app.constants', () => {
+  describe('phoneNumberRegex', () => {
+    describe('valid phone numbers', () => {
+      it.each([
+        ['4075551234'],
+        ['407-555-1234'],
+        ['(407) 555-1234'],
+        ['+1 407 555 1234'],
+        ['541-967-0010'],
+        ['555-555-5555'],
+        ['(909) 337-2433'],
+        ['1234567890'],
+        ['(111) 111-111'],
+        ['011 44 20 7946 0958'],
+        ['407.555.1234'],
+      ])('should match %s', (number) => {
+        expect(phoneNumberRegex.test(number)).toEqual(true);
+      });
+    });
+
+    describe('valid phone numbers with extensions', () => {
+      it.each([
+        ['407-555-1234 ext. 5678'],
+        ['407-555-1234 ext 5678'],
+        ['407-555-1234 extension 22'],
+        ['4075551234x99'],
+        ['4075551234 x. 99'],
+        ['4075551234 #99'],
+      ])('should match %s', (number) => {
+        expect(phoneNumberRegex.test(number)).toEqual(true);
+      });
+    });
+
+    describe('malformed input', () => {
+      it.each([
+        ['abc!!!1234567'],
+        ['call me at 5551234'],
+        ['5551234 is my number'],
+        ['-------'],
+        ['- - - - - - -'],
+        ['   -   -   '],
+        ['123-abc-7890'],
+        [''],
+        ['123456'], // fewer than 7 digits
+        ['1234567890123456'], // more than 15 digits
+        ['407-555-1234 ext.'], // extension marker without digits
+      ])('should not match %s', (number) => {
+        expect(phoneNumberRegex.test(number)).toEqual(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Jira
[EP-2382](https://jira.cru.org/browse/EP-2382)

## Problem
The shared phone regex in `app.constants.js` (unchanged since 2019) was **not anchored at the start** and **required no actual digits**, so input like `abc!!!1234567`, `call me at 5551234`, or seven hyphens passed client validation and reached the backend phone validator — which crashes non-gracefully on them (see Rollbar links on the ticket).

## Fix
New pattern (same constant, so both consumers — profile self-service and checkout contact info — benefit):
```
/^((?:011[\s\-.]*)?\+?(?:[\s\-().]*\d){7,15})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$/
```
- Anchored; counts **7–15 actual digits** (ITU E.164 max), with separators (space, hyphen, parens, dot) allowed between them.
- Leading `+` and `011` international access prefix supported; the 011 prefix doesn't count toward the digit cap.
- Extension suffix and capture groups preserved verbatim.
- Verified compatible with every phone format in existing specs/fixtures (`(909) 337-2433`, `555-555-5555`, `541-967-0010`, `1234567890`, etc.) plus international and extension forms.
- Reviewed for catastrophic backtracking: bounded quantifiers, disjoint character classes; pathological inputs ≤ 0.2 ms.

## Newly rejected
`abc!!!1234567`, `call me at 5551234`, `-------`, 16+ digit strings, extension marker without digits.

## Tests
New `app.constants.spec.js` (32 tests, written red-first — 7 failed on the old regex). 116/116 green across constants, profile, and contactInfo suites.

## Note
This blocks the malformed input most likely to crash the backend parser; hardening the backend validator itself to return 400 instead of crashing remains Cortex work (per ticket).