### PR TITLE
EP-1593 - Search in place instead of full page reload

### DIFF
--- a/src/app/searchResults/searchResults.component.js
+++ b/src/app/searchResults/searchResults.component.js
@@ -82,6 +82,12 @@ class SearchResultsController {
   // Re-read the URL params and re-run the search if they changed
   // (e.g. browser back/forward). No-op for our own URL updates.
   syncFromLocation() {
+    // When navigating away, $locationChangeSuccess fires before this scope is
+    // destroyed. Ignore location changes that leave the search-results page so
+    // we don't wipe the params and fire a stray search request.
+    if (!includes(this.$location.path(), 'search-results')) {
+      return;
+    }
     const params = this.$location.search();
     if (
       (params.q || undefined) === (this.searchParams.keyword || undefined) &&

--- a/src/app/searchResults/searchResults.component.js
+++ b/src/app/searchResults/searchResults.component.js
@@ -15,6 +15,7 @@ const componentName = 'searchResults';
 class SearchResultsController {
   /* @ngInject */
   constructor(
+    $scope,
     $window,
     $location,
     $log,
@@ -23,6 +24,7 @@ class SearchResultsController {
     analyticsFactory,
     envService,
   ) {
+    this.$scope = $scope;
     this.$window = $window;
     this.$location = $location;
     this.$log = $log;
@@ -44,7 +46,57 @@ class SearchResultsController {
     this.featuredGroupBy = 'startMonth';
 
     this.requestGiveSearch(this.searchParams.type);
+    // Support back/forward navigation since in-place searches update the URL
+    // without reloading the page (so $onInit only runs once).
+    this.$scope.$on('$locationChangeSuccess', () => this.syncFromLocation());
     this.analyticsFactory.pageLoaded();
+  }
+
+  // Submit handler for the main keyword search box
+  submitKeywordSearch() {
+    this.searchParams.first_name = undefined;
+    this.searchParams.last_name = undefined;
+    this.updateLocationSearch();
+    this.requestGiveSearch(this.searchParams.type);
+  }
+
+  // Submit handler for the advanced people (first/last name) search
+  submitNameSearch() {
+    this.searchParams.keyword = undefined;
+    this.searchParams.type = 'people';
+    this.updateLocationSearch();
+    this.requestGiveSearch('people');
+  }
+
+  // Reflect the current search params in the URL so results stay
+  // shareable/bookmarkable without triggering a full page reload.
+  updateLocationSearch() {
+    this.$location.search({
+      q: this.searchParams.keyword || null,
+      fName: this.searchParams.first_name || null,
+      lName: this.searchParams.last_name || null,
+      type: this.searchParams.type || null,
+    });
+  }
+
+  // Re-read the URL params and re-run the search if they changed
+  // (e.g. browser back/forward). No-op for our own URL updates.
+  syncFromLocation() {
+    const params = this.$location.search();
+    if (
+      (params.q || undefined) === (this.searchParams.keyword || undefined) &&
+      (params.fName || undefined) ===
+        (this.searchParams.first_name || undefined) &&
+      (params.lName || undefined) ===
+        (this.searchParams.last_name || undefined) &&
+      (params.type || undefined) === (this.searchParams.type || undefined)
+    ) {
+      return;
+    }
+    this.searchParams.keyword = params.q;
+    this.searchParams.first_name = params.fName;
+    this.searchParams.last_name = params.lName;
+    this.requestGiveSearch(params.type);
   }
 
   requestGiveSearch(type) {

--- a/src/app/searchResults/searchResults.spec.js
+++ b/src/app/searchResults/searchResults.spec.js
@@ -148,7 +148,6 @@ describe('searchResults', function () {
         type: 'featured',
       });
       expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('featured');
-      expect($ctrl.$window.location.href).toEqual('/search-results.html');
     });
 
     it('clears the name params on a new keyword search', () => {
@@ -188,7 +187,6 @@ describe('searchResults', function () {
         type: 'people',
       });
       expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('people');
-      expect($ctrl.$window.location.href).toEqual('/search-results.html');
     });
 
     it('clears the keyword param on a new name search', () => {
@@ -207,6 +205,7 @@ describe('searchResults', function () {
 
   describe('$locationChangeSuccess', () => {
     beforeEach(() => {
+      $location.path('/search-results.html');
       jest.spyOn($ctrl, 'requestGiveSearch').mockImplementation(() => {});
     });
 
@@ -229,6 +228,44 @@ describe('searchResults', function () {
       $rootScope.$broadcast('$locationChangeSuccess');
 
       expect($ctrl.requestGiveSearch).not.toHaveBeenCalled();
+    });
+
+    it('ignores location changes that navigate away from the search-results page', () => {
+      $location.search({ q: 'steve', type: 'featured' });
+      $ctrl.$onInit();
+      $ctrl.requestGiveSearch.mockClear();
+
+      // Navigating to another route fires $locationChangeSuccess before the
+      // search-results scope is destroyed by the route transition.
+      $location.path('/checkout.html');
+      $location.search({});
+      $rootScope.$broadcast('$locationChangeSuccess');
+
+      expect($ctrl.requestGiveSearch).not.toHaveBeenCalled();
+      expect($ctrl.searchParams.keyword).toEqual('steve');
+      expect($ctrl.searchParams.type).toEqual('featured');
+    });
+
+    it('runs exactly one search per in-place keyword search', () => {
+      $rootScope.$digest();
+      jest.spyOn($location, 'search');
+      $ctrl.$onInit();
+      $ctrl.requestGiveSearch.mockClear();
+
+      $ctrl.searchParams.keyword = 'steve';
+      $ctrl.searchParams.type = 'featured';
+      $ctrl.submitKeywordSearch();
+      // Let the genuine $locationChangeSuccess from the URL update fire
+      $rootScope.$digest();
+
+      expect($location.search).toHaveBeenCalledWith({
+        q: 'steve',
+        fName: null,
+        lName: null,
+        type: 'featured',
+      });
+      expect($ctrl.requestGiveSearch).toHaveBeenCalledTimes(1);
+      expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('featured');
     });
   });
 

--- a/src/app/searchResults/searchResults.spec.js
+++ b/src/app/searchResults/searchResults.spec.js
@@ -7,10 +7,17 @@ import module from './searchResults.component';
 
 describe('searchResults', function () {
   beforeEach(angular.mock.module(module.name));
-  let $ctrl;
+  let $ctrl, $rootScope, $location;
 
-  beforeEach(inject(function (_$componentController_) {
+  beforeEach(inject(function (
+    _$componentController_,
+    _$rootScope_,
+    _$location_,
+  ) {
+    $rootScope = _$rootScope_;
+    $location = _$location_;
     $ctrl = _$componentController_(module.name, {
+      $scope: $rootScope.$new(),
       $window: {
         location: {
           href: '/search-results.html',
@@ -115,6 +122,113 @@ describe('searchResults', function () {
       expect(
         $ctrl.analyticsFactory.productViewDetailsEvent,
       ).toHaveBeenCalledWith('product');
+    });
+  });
+
+  describe('submitKeywordSearch', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl, 'requestGiveSearch').mockImplementation(() => {});
+      jest.spyOn($location, 'search');
+    });
+
+    it('updates the URL params and searches in place without reloading', () => {
+      $ctrl.searchParams = {
+        keyword: 'steve',
+        first_name: 'first',
+        last_name: 'last',
+        type: 'featured',
+      };
+
+      $ctrl.submitKeywordSearch();
+
+      expect($location.search).toHaveBeenCalledWith({
+        q: 'steve',
+        fName: null,
+        lName: null,
+        type: 'featured',
+      });
+      expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('featured');
+      expect($ctrl.$window.location.href).toEqual('/search-results.html');
+    });
+
+    it('clears the name params on a new keyword search', () => {
+      $ctrl.searchParams = {
+        keyword: 'steve',
+        first_name: 'first',
+        last_name: 'last',
+      };
+
+      $ctrl.submitKeywordSearch();
+
+      expect($ctrl.searchParams.first_name).toBeUndefined();
+      expect($ctrl.searchParams.last_name).toBeUndefined();
+    });
+  });
+
+  describe('submitNameSearch', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl, 'requestGiveSearch').mockImplementation(() => {});
+      jest.spyOn($location, 'search');
+    });
+
+    it('updates the URL params and searches people in place without reloading', () => {
+      $ctrl.searchParams = {
+        keyword: 'steve',
+        first_name: 'first',
+        last_name: 'last',
+        type: 'people',
+      };
+
+      $ctrl.submitNameSearch();
+
+      expect($location.search).toHaveBeenCalledWith({
+        q: null,
+        fName: 'first',
+        lName: 'last',
+        type: 'people',
+      });
+      expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('people');
+      expect($ctrl.$window.location.href).toEqual('/search-results.html');
+    });
+
+    it('clears the keyword param on a new name search', () => {
+      $ctrl.searchParams = {
+        keyword: 'steve',
+        first_name: 'first',
+        last_name: 'last',
+        type: 'people',
+      };
+
+      $ctrl.submitNameSearch();
+
+      expect($ctrl.searchParams.keyword).toBeUndefined();
+    });
+  });
+
+  describe('$locationChangeSuccess', () => {
+    beforeEach(() => {
+      jest.spyOn($ctrl, 'requestGiveSearch').mockImplementation(() => {});
+    });
+
+    it('re-reads params and re-runs the search when the URL changes (back/forward)', () => {
+      $ctrl.$onInit();
+      $ctrl.requestGiveSearch.mockClear();
+
+      $location.search({ q: 'new keyword', type: 'featured' });
+      $rootScope.$broadcast('$locationChangeSuccess');
+
+      expect($ctrl.searchParams.keyword).toEqual('new keyword');
+      expect($ctrl.requestGiveSearch).toHaveBeenCalledWith('featured');
+    });
+
+    it('does not re-run the search when the params have not changed', () => {
+      $location.search({ q: 'steve' });
+      $ctrl.$onInit();
+      $ctrl.requestGiveSearch.mockClear();
+
+      $rootScope.$broadcast('$locationChangeSuccess');
+
+      expect($ctrl.requestGiveSearch).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/searchResults/searchResults.tpl.html
+++ b/src/app/searchResults/searchResults.tpl.html
@@ -24,7 +24,7 @@
 
       <div class="row">
         <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          <form method="get" action="">
+          <form ng-submit="$ctrl.submitKeywordSearch()">
             <div class="input-group is-search-main">
               <input
                 type="search"
@@ -58,7 +58,7 @@
             <div class="row">
               <div class="col-sm-12 col-md-3">
                 <div class="is-advanced">
-                  <form method="get" action="/search-results.html">
+                  <form ng-submit="$ctrl.submitNameSearch()">
                     <h2 class="h4 search-results-header" translate>
                       Search
                       <button
@@ -129,7 +129,7 @@
                             type="text"
                             class="form-control input-subtle"
                             name="fName"
-                            value="{{$ctrl.searchParams.first_name}}"
+                            ng-model="$ctrl.searchParams.first_name"
                           />
                         </div>
 
@@ -139,15 +139,10 @@
                             type="text"
                             class="form-control input-subtle"
                             name="lName"
-                            value="{{$ctrl.searchParams.last_name}}"
+                            ng-model="$ctrl.searchParams.last_name"
                           />
                         </div>
 
-                        <input
-                          type="hidden"
-                          name="type"
-                          value="{{$ctrl.searchParams.type}}"
-                        />
                         <button
                           id="bottomSearchButton"
                           class="btn btn-primary btn-block"


### PR DESCRIPTION
## Jira
[EP-1593](https://jira.cru.org/browse/EP-1593)

## Problem
Both search forms on the results page were native GET submits (`<form method="get" ...>` with no `ng-submit`), so every keyword/name search did a full page reload. The type-filter tabs already searched in place — only form submits reloaded.

## Fix
- Both forms now submit via `ng-submit` handlers: `submitKeywordSearch()` (clears name params, keeps the active type filter) and `submitNameSearch()` (clears keyword, forces `type=people`).
- The URL is kept shareable/bookmarkable via `$location.search({q, fName, lName, type})` — same param names `$onInit` reads, falsy values stripped.
- Back/forward works in place: a `$locationChangeSuccess` listener re-reads params and re-searches, with (a) an equality guard so the component's own URL writes and the bootstrap event don't double-search, and (b) a route-exit guard so navigating away doesn't fire a stray search on the dying scope.
- Name inputs got real `ng-model` bindings (they were one-way `value` interpolations — an in-place name search was impossible without this).
- Removing the hidden `type` input also fixes a pre-existing bug: the old name form submitted the current filter type, and the service silently drops `first_name`/`last_name` unless `type=people` — so advanced name search used to be ignored whenever a non-people filter was active.

## Behavior change to note for QA
A new keyword search now **preserves the active type filter** (the old native submit dropped it and reset to All). This matches the visible tab state, but it is a change from long-standing behavior — easy to flip if product prefers reset-to-All.

## Tests
19/19 in `src/app/searchResults` (7 new, red-first), including mutation-tested specs for the single-search-per-submit cycle (real digest fires the location event) and the route-exit guard.