### PR TITLE
EP-2480 - Trace branded checkout cortex requests in DataDog RUM

### DIFF
--- a/src/app/branded/branded-checkout.component.js
+++ b/src/app/branded/branded-checkout.component.js
@@ -17,6 +17,7 @@ import checkoutService from 'common/services/checkoutHelpers/checkout.service';
 import brandedAnalyticsFactory from './analytics/branded-analytics.factory';
 
 import 'common/lib/fakeLocalStorage';
+import normalizeApiUrl from 'common/lib/normalizeApiUrl';
 
 import template from './branded-checkout.tpl.html';
 
@@ -80,20 +81,7 @@ class BrandedCheckoutController {
   }
 
   normalizeApiUrl(url) {
-    if (!url) {
-      return url;
-    }
-
-    // Remove trailing slashes
-    url = url.replace(/\/+$/, '');
-
-    // Remove protocol if present
-    url = url.replace(/^https?:/, '');
-
-    // Remove slash before query parameters if present
-    url = url.replace(/\/\?/, '?');
-
-    return url.startsWith('//') ? url : '//' + url;
+    return normalizeApiUrl(url);
   }
 
   formatDonorDetails() {

--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -11,11 +11,15 @@ const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
     const brandedCheckoutElement = document.querySelector('branded-checkout');
     const brandedCheckoutApiUrl =
       brandedCheckoutElement && brandedCheckoutElement.getAttribute('api-url');
-    const apiUrl = brandedCheckoutApiUrl
-      ? normalizeApiUrl(brandedCheckoutApiUrl)
-      : envServiceProvider.read('apiUrl');
+    // Always trace the env cortex URL; additionally trace the branded one when present
+    const apiUrls = [envServiceProvider.read('apiUrl')];
+    if (brandedCheckoutApiUrl) {
+      apiUrls.push(normalizeApiUrl(brandedCheckoutApiUrl));
+    }
     // The api-url attribute may omit the protocol, so match request urls protocol-relatively
-    const cortexUrl = apiUrl.replace(/^https?:/, '') + '/cortex';
+    const cortexUrls = apiUrls.map(
+      (apiUrl) => apiUrl.replace(/^https?:/, '') + '/cortex',
+    );
     const config = {
       applicationId: '3937053e-386b-4b5b-ab4a-c83217d2f953',
       clientToken,
@@ -23,7 +27,10 @@ const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
       service: 'give-web',
       env: envServiceProvider.get(),
       allowedTracingUrls: [
-        (url) => url.replace(/^https?:/, '').startsWith(cortexUrl),
+        (url) =>
+          cortexUrls.some((cortexUrl) =>
+            url.replace(/^https?:/, '').startsWith(cortexUrl),
+          ),
       ],
       version: process.env.GITHUB_SHA,
       sessionSampleRate: envServiceProvider.is('staging') ? 100 : 50,

--- a/src/common/datadog.config.js
+++ b/src/common/datadog.config.js
@@ -1,16 +1,30 @@
 import 'angular-environment';
 import { datadogRum } from '@datadog/browser-rum';
+import normalizeApiUrl from 'common/lib/normalizeApiUrl';
 
 const dataDogConfig = /* @ngInject */ function (envServiceProvider) {
   const clientToken = process.env.DATADOG_RUM_CLIENT_TOKEN;
   if (clientToken) {
+    // Branded checkout overrides the API url via the <branded-checkout api-url="..."> attribute,
+    // but that override is applied in the component's $onInit, after DataDog has already
+    // initialized, so resolve the attribute from the DOM here instead.
+    const brandedCheckoutElement = document.querySelector('branded-checkout');
+    const brandedCheckoutApiUrl =
+      brandedCheckoutElement && brandedCheckoutElement.getAttribute('api-url');
+    const apiUrl = brandedCheckoutApiUrl
+      ? normalizeApiUrl(brandedCheckoutApiUrl)
+      : envServiceProvider.read('apiUrl');
+    // The api-url attribute may omit the protocol, so match request urls protocol-relatively
+    const cortexUrl = apiUrl.replace(/^https?:/, '') + '/cortex';
     const config = {
       applicationId: '3937053e-386b-4b5b-ab4a-c83217d2f953',
       clientToken,
       site: 'datadoghq.com',
       service: 'give-web',
       env: envServiceProvider.get(),
-      allowedTracingUrls: [envServiceProvider.read('apiUrl') + '/cortex'],
+      allowedTracingUrls: [
+        (url) => url.replace(/^https?:/, '').startsWith(cortexUrl),
+      ],
       version: process.env.GITHUB_SHA,
       sessionSampleRate: envServiceProvider.is('staging') ? 100 : 50,
       sessionReplaySampleRate: envServiceProvider.is('staging') ? 100 : 1,

--- a/src/common/datadog.config.spec.js
+++ b/src/common/datadog.config.spec.js
@@ -26,6 +26,109 @@ describe('dataDogConfig', () => {
     });
   });
 
+  describe('allowedTracingUrls', () => {
+    let initSpy;
+
+    // Replicates how DataDog evaluates allowedTracingUrls entries
+    // (string prefix match, RegExp test, or predicate function)
+    const wouldTrace = (entry, url) => {
+      if (typeof entry === 'function') {
+        return entry(url);
+      }
+      if (entry instanceof RegExp) {
+        return entry.test(url);
+      }
+      return url.startsWith(entry);
+    };
+
+    const initializeDataDog = () => {
+      angular
+        .module('testDataDogTracingConfig', [
+          'environment',
+          'pascalprecht.translate',
+        ])
+        .config(appConfig)
+        .config(module.default);
+      angular.mock.module('testDataDogTracingConfig');
+      inject(() => {});
+
+      expect(initSpy).toHaveBeenCalled();
+      const allowedTracingUrls = initSpy.mock.calls[0][0].allowedTracingUrls;
+      expect(allowedTracingUrls.length).toEqual(1);
+      return allowedTracingUrls[0];
+    };
+
+    beforeEach(() => {
+      initSpy = jest.spyOn(datadogRum, 'init').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      initSpy.mockRestore();
+      document
+        .querySelectorAll('branded-checkout')
+        .forEach((element) => element.remove());
+    });
+
+    it('should trace the environment apiUrl cortex requests when no branded-checkout element exists', () => {
+      const entry = initializeDataDog();
+
+      // development environment apiUrl from app.config.js
+      expect(
+        wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
+      ).toEqual(true);
+      expect(
+        wouldTrace(entry, 'https://example.com/cortex/carts/default'),
+      ).toEqual(false);
+    });
+
+    it('should trace the branded-checkout api-url cortex requests when the attribute includes a protocol', () => {
+      const element = document.createElement('branded-checkout');
+      element.setAttribute('api-url', 'https://brandedcheckout.jesusfilm.org');
+      document.body.appendChild(element);
+
+      const entry = initializeDataDog();
+
+      expect(
+        wouldTrace(
+          entry,
+          'https://brandedcheckout.jesusfilm.org/cortex/carts/default',
+        ),
+      ).toEqual(true);
+      expect(
+        wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
+      ).toEqual(false);
+    });
+
+    it('should trace the branded-checkout api-url cortex requests when the attribute omits the protocol', () => {
+      const element = document.createElement('branded-checkout');
+      element.setAttribute('api-url', 'brandedcheckout.jesusfilm.org/');
+      document.body.appendChild(element);
+
+      const entry = initializeDataDog();
+
+      expect(
+        wouldTrace(
+          entry,
+          'https://brandedcheckout.jesusfilm.org/cortex/carts/default',
+        ),
+      ).toEqual(true);
+      expect(
+        wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
+      ).toEqual(false);
+    });
+
+    it('should fall back to the environment apiUrl when the branded-checkout element has no api-url attribute', () => {
+      const element = document.createElement('branded-checkout');
+      document.body.appendChild(element);
+
+      const entry = initializeDataDog();
+
+      expect(
+        wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
+      ).toEqual(true);
+    });
+  });
+
   describe('updateDatadogUser', () => {
     let setUserSpy, clearUserSpy;
 

--- a/src/common/datadog.config.spec.js
+++ b/src/common/datadog.config.spec.js
@@ -96,6 +96,9 @@ describe('dataDogConfig', () => {
       ).toEqual(true);
       expect(
         wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
+      ).toEqual(true);
+      expect(
+        wouldTrace(entry, 'https://example.com/cortex/carts/default'),
       ).toEqual(false);
     });
 
@@ -114,7 +117,7 @@ describe('dataDogConfig', () => {
       ).toEqual(true);
       expect(
         wouldTrace(entry, 'https://give-stage2.cru.org/cortex/carts/default'),
-      ).toEqual(false);
+      ).toEqual(true);
     });
 
     it('should fall back to the environment apiUrl when the branded-checkout element has no api-url attribute', () => {

--- a/src/common/lib/normalizeApiUrl.js
+++ b/src/common/lib/normalizeApiUrl.js
@@ -1,0 +1,18 @@
+// Normalizes an API URL into a protocol-relative URL without trailing slashes,
+// e.g. 'https://give.domain.com/' or 'give.domain.com' -> '//give.domain.com'
+export default function normalizeApiUrl(url) {
+  if (!url) {
+    return url;
+  }
+
+  // Remove trailing slashes
+  url = url.replace(/\/+$/, '');
+
+  // Remove protocol if present
+  url = url.replace(/^https?:/, '');
+
+  // Remove slash before query parameters if present
+  url = url.replace(/\/\?/, '?');
+
+  return url.startsWith('//') ? url : '//' + url;
+}


### PR DESCRIPTION
## Jira
[EP-2480](https://jira.cru.org/browse/EP-2480)

## Problem
`datadog.config.js` built `allowedTracingUrls` from the environment `apiUrl` inside an Angular `.config()` block — which runs at bootstrap, **before** the `<branded-checkout api-url="...">` override is applied in the component's `$onInit`. So on third-party sites DataDog watched `give.cru.org/cortex` while all the real requests went to e.g. `brandedcheckout.jesusfilm.org/cortex` — branded checkout network requests were never instrumented.

## Fix
- At config time, read the `api-url` attribute straight from the DOM (`document.querySelector('branded-checkout')`) — safe because the loader bootstraps after the page is loaded.
- The attribute may omit the protocol (per README), so `normalizeApiUrl` was extracted from `branded-checkout.component.js` into a shared `common/lib/normalizeApiUrl.js` (verbatim; the component delegates to it) and matching is done protocol-relatively via a DataDog match **function** (supported by the installed @datadog/browser-rum v5.16 — `MatchOption` accepts `(url) => boolean`).
- The branded URL is **added alongside** the environment cortex URL rather than replacing it, so a stray branded element can never silently disable main-site tracing.
- Main give site behavior unchanged (no element → env apiUrl only; the appended `/cortex` also enforces the host boundary against prefix collisions).

## Tests
4 new specs written red-first, with a `wouldTrace` helper that mirrors DataDog's actual `matchList` semantics (verified against the installed v5.16 source). 87/87 green across the datadog and branded suites.