### PR TITLE
EP-1933 - Stack one-time gift modal buttons on small screens

### DIFF
--- a/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.tpl.html
+++ b/src/app/profile/yourGiving/giveOneTimeGift/giveOneTimeGift.modal.tpl.html
@@ -53,20 +53,25 @@
     </div>
   </div>
   <div class="modal-footer" ng-switch-when="errorLoadingRecentRecipients">
-    <div class="col-xs-6">
-      <a class="btn btn-default" ng-click="$ctrl.dismiss()" translate>
-        Cancel
-      </a>
-    </div>
-    <div class="col-xs-6 text-right">
-      <a
-        class="btn btn-primary"
-        ng-click="$ctrl.loadRecentRecipients()"
-        translate
-        >Retry</a
-      >
-      <a class="btn btn-default" ng-click="$ctrl.next()" translate>Continue</a>
-    </div>
+    <a
+      class="btn btn-default btn-block-xs pull-right"
+      ng-click="$ctrl.next()"
+      translate
+      >Continue</a
+    >
+    <a
+      class="btn btn-primary btn-block-xs pull-right"
+      ng-click="$ctrl.loadRecentRecipients()"
+      translate
+      >Retry</a
+    >
+    <a
+      class="btn btn-default btn-block-xs pull-left"
+      ng-click="$ctrl.dismiss()"
+      translate
+    >
+      Cancel
+    </a>
   </div>
 
   <step-1-select-recent-recipients

--- a/src/app/profile/yourGiving/giveOneTimeGift/step1/searchRecipients.tpl.html
+++ b/src/app/profile/yourGiving/giveOneTimeGift/step1/searchRecipients.tpl.html
@@ -35,18 +35,18 @@
 </div>
 
 <div class="modal-footer">
-  <div class="col-xs-6">
-    <button class="btn btn-default" ng-click="$ctrl.previous()" translate>
-      Back
-    </button>
-  </div>
-  <div class="col-xs-6 text-right">
-    <button
-      class="btn btn-primary"
-      ng-click="$ctrl.gatherSelections()"
-      translate
-    >
-      Continue
-    </button>
-  </div>
+  <button
+    class="btn btn-primary btn-block-xs pull-right"
+    ng-click="$ctrl.gatherSelections()"
+    translate
+  >
+    Continue
+  </button>
+  <button
+    class="btn btn-default btn-block-xs pull-left"
+    ng-click="$ctrl.previous()"
+    translate
+  >
+    Back
+  </button>
 </div>

--- a/src/app/profile/yourGiving/giveOneTimeGift/step1/selectRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/giveOneTimeGift/step1/selectRecentRecipients.tpl.html
@@ -53,18 +53,18 @@
 </div>
 
 <div class="modal-footer">
-  <div class="col-xs-6">
-    <button class="btn btn-default" ng-click="$ctrl.dismiss()" translate>
-      Cancel
-    </button>
-  </div>
-  <div class="col-xs-6 text-right">
-    <button
-      class="btn btn-primary"
-      ng-click="$ctrl.gatherSelections()"
-      translate
-    >
-      Continue
-    </button>
-  </div>
+  <button
+    class="btn btn-primary btn-block-xs pull-right"
+    ng-click="$ctrl.gatherSelections()"
+    translate
+  >
+    Continue
+  </button>
+  <button
+    class="btn btn-default btn-block-xs pull-left"
+    ng-click="$ctrl.dismiss()"
+    translate
+  >
+    Cancel
+  </button>
 </div>

--- a/src/app/profile/yourGiving/giveOneTimeGift/step2/enterAmounts.tpl.html
+++ b/src/app/profile/yourGiving/giveOneTimeGift/step2/enterAmounts.tpl.html
@@ -57,26 +57,26 @@
 </div>
 
 <div class="modal-footer">
-  <div class="col-xs-6">
-    <button class="btn btn-default" ng-click="$ctrl.previous()" translate>
-      Back
-    </button>
-  </div>
-  <div class="col-xs-6 text-right">
-    <button
-      class="btn btn-primary"
-      ng-click="$ctrl.addToCart()"
-      ng-disabled="!$ctrl.hasSelectedRecipients || $ctrl.addingToCart"
+  <button
+    class="btn btn-primary btn-block-xs pull-right"
+    ng-click="$ctrl.addToCart()"
+    ng-disabled="!$ctrl.hasSelectedRecipients || $ctrl.addingToCart"
+  >
+    <span ng-if="$ctrl.addingToCart" translate>Adding to Cart...</span>
+    <span ng-if="!$ctrl.addingToCart" translate>Add to Cart</span>
+    <span
+      class="sr-only"
+      aria-live="polite"
+      aria-atomic="true"
+      ng-bind="$ctrl.addingToCart ? ('Adding to Cart...' | translate) : ''"
     >
-      <span ng-if="$ctrl.addingToCart" translate>Adding to Cart...</span>
-      <span ng-if="!$ctrl.addingToCart" translate>Add to Cart</span>
-      <span
-        class="sr-only"
-        aria-live="polite"
-        aria-atomic="true"
-        ng-bind="$ctrl.addingToCart ? ('Adding to Cart...' | translate) : ''"
-      >
-      </span>
-    </button>
-  </div>
+    </span>
+  </button>
+  <button
+    class="btn btn-default btn-block-xs pull-left"
+    ng-click="$ctrl.previous()"
+    translate
+  >
+    Back
+  </button>
 </div>

--- a/src/assets/scss/_cart.scss
+++ b/src/assets/scss/_cart.scss
@@ -223,3 +223,11 @@ product-config-modal .modal-footer {
   }
 }
 
+@media screen and (min-width: 550px) {
+  // Two adjacent right-floated footer buttons: the float places them
+  // flush against each other, so restore Bootstrap's 5px button gap.
+  .modal-footer .btn-block-xs.pull-right + .btn-block-xs.pull-right {
+    margin-right: 5px;
+  }
+}
+

--- a/src/assets/scss/_cart.scss
+++ b/src/assets/scss/_cart.scss
@@ -214,7 +214,7 @@ product-config-modal .modal-footer {
   .btn-block-xs {
     display: block;
     width: 100%;
-    &.pull-right {float: none !important;}
+    &.pull-right, &.pull-left {float: none !important;}
     + .btn-block-xs {margin-top: 10px;}
   }
 


### PR DESCRIPTION
## Jira
[EP-1933](https://jira.cru.org/browse/EP-1933)

## Problem
On iOS, the bottom-of-screen Safari menu target area hides the side-by-side (`col-xs-6`) CTA buttons in the 1-Time Bulk Gift modal, making it hard to continue. The gift configuration modal was already fixed years ago by stacking full-width buttons (`btn-block-xs` pattern in `_cart.scss`), but this modal never got it.

## Fix
Applied the existing stacked pattern to **all four** footers of the giveOneTimeGift modal (step 1 select/search, step 2 amounts, and the error-state footer):
- < 550px: buttons stack full-width with the primary action on top (above Safari's bar) and Cancel at the bottom, with the existing 10px sibling spacing.
- ≥ 550px: visual layout unchanged (secondary left, primary right; the error footer keeps Cancel | Retry, Continue).
- SCSS: widened the float reset to cover `pull-left` (was `pull-right` only — safely additive, no other co-occurrence in the codebase) and restored Bootstrap's 5px gap between two floated right-side buttons in the error footer.
- All `ng-click`/`ng-disabled`/`translate`/aria attributes preserved verbatim.

## Notes for QA / follow-up
- Final verification on an actual iOS device/simulator recommended (specs are controller-only; layout verified against the compiled CSS rules).
- Tab order now puts the primary CTA first while desktop shows it on the right — a deliberate trade-off so the primary stacks on top on mobile (mild WCAG 2.4.3 note).
- The review inventoried ~16 other yourGiving modal footers (editRecurringGifts, stopStartRecurringGifts) with the same `col-xs-6` pattern — same iOS issue, candidates for a follow-up ticket.

## Tests
30/30 across the giveOneTimeGift suites (controller specs; templates aren't rendered by existing specs).

<img width="791" height="495" alt="Screenshot 2026-06-12 at 9 35 21 AM" src="https://github.com/user-attachments/assets/b3607e65-c723-46d1-aa05-ffc6244b8e1a" />

<img width="760" height="520" alt="Screenshot 2026-06-12 at 9 35 16 AM" src="https://github.com/user-attachments/assets/b2b5d9f7-12e0-4667-b0c8-fd1489f358a3" />




