### PR TITLE
EP-2118 - Make the Other amount option visible and labeled

### DIFF
--- a/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.component.spec.js
+++ b/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.component.spec.js
@@ -35,8 +35,9 @@ describe('suggestedGiftAmounts', () => {
       $rootScope = _$rootScope_;
     }));
 
+    let scope;
     const compileComponent = (scopeValues) => {
-      const scope = $rootScope.$new();
+      scope = $rootScope.$new();
       Object.assign(
         scope,
         {
@@ -108,6 +109,22 @@ describe('suggestedGiftAmounts', () => {
         'customAmountLabelRadio',
       );
       expect(input.getAttribute('placeholder')).toBeNull();
+    });
+
+    it('activates the custom input when the radio-variant amount input gains focus', () => {
+      const element = compileComponent({
+        useSuggestedAmounts: true,
+        useV3: false,
+        suggestedAmounts: [{ amount: 50, label: 'Suggested', order: 1 }],
+      });
+      const input = element.querySelector('#customAmountInput');
+
+      expect(scope.customInputActive).toEqual(false);
+
+      angular.element(input).triggerHandler('focus');
+      $rootScope.$digest();
+
+      expect(scope.customInputActive).toEqual(true);
     });
   });
 });

--- a/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.component.spec.js
+++ b/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.component.spec.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
+import 'angular-translate';
 import suggestedGiftAmounts from './suggestedGiftAmounts.component';
 
 describe('suggestedGiftAmounts', () => {
@@ -7,7 +8,7 @@ describe('suggestedGiftAmounts', () => {
   let $componentController;
 
   beforeEach(() => {
-    angular.mock.module(suggestedGiftAmounts.name);
+    angular.mock.module(suggestedGiftAmounts.name, 'pascalprecht.translate');
 
     angular.mock.inject((_$componentController_) => {
       $componentController = _$componentController_;
@@ -23,6 +24,90 @@ describe('suggestedGiftAmounts', () => {
       expect($ctrl.suggestedAmount(123.4)).toEqual('$123.40');
       expect($ctrl.suggestedAmount(123)).toEqual('$123');
       expect($ctrl.suggestedAmount(1234)).toEqual('$1,234');
+    });
+  });
+
+  describe('template', () => {
+    let $compile, $rootScope;
+
+    beforeEach(inject((_$compile_, _$rootScope_) => {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    }));
+
+    const compileComponent = (scopeValues) => {
+      const scope = $rootScope.$new();
+      Object.assign(
+        scope,
+        {
+          itemConfig: {},
+          customInputActive: false,
+          customAmount: undefined,
+          suggestedAmounts: [],
+          selectableAmounts: [50, 100, 250, 500, 1000, 5000],
+        },
+        scopeValues,
+      );
+      const element = $compile(
+        '<suggested-gift-amounts ' +
+          'use-v3="useV3" ' +
+          'use-suggested-amounts="useSuggestedAmounts" ' +
+          'suggested-amounts="suggestedAmounts" ' +
+          'selectable-amounts="selectableAmounts" ' +
+          'custom-input-active="customInputActive" ' +
+          'item-config="itemConfig" ' +
+          'custom-amount="customAmount">' +
+          '</suggested-gift-amounts>',
+      )(scope);
+      $rootScope.$digest();
+      return element[0];
+    };
+
+    it('shows a visible "Other amount" label tied to the custom input in the default variant', () => {
+      const element = compileComponent({ useSuggestedAmounts: false });
+      const label = element.querySelector('#customAmountLabel');
+      const input = element.querySelector('input[name="amount"]');
+
+      expect(label).not.toBeNull();
+      expect(label.textContent.trim()).toEqual('OTHER_AMOUNT');
+      expect(input.getAttribute('aria-labelledby')).toEqual(
+        'customAmountLabel',
+      );
+      expect(input.getAttribute('placeholder')).toBeNull();
+    });
+
+    it('shows a visible "Other amount" label tied to the custom input in the v3 variant', () => {
+      const element = compileComponent({
+        useSuggestedAmounts: true,
+        useV3: true,
+        suggestedAmounts: [{ amount: 50, label: 'Suggested', order: 1 }],
+      });
+      const label = element.querySelector('#customAmountLabelV3');
+      const input = element.querySelector('input[name="amount"]');
+
+      expect(label).not.toBeNull();
+      expect(label.textContent.trim()).toEqual('OTHER_AMOUNT');
+      expect(input.getAttribute('aria-labelledby')).toEqual(
+        'customAmountLabelV3',
+      );
+      expect(input.getAttribute('placeholder')).toBeNull();
+    });
+
+    it('shows a visible "Other amount" label tied to the custom input in the non-v3 suggested amounts variant', () => {
+      const element = compileComponent({
+        useSuggestedAmounts: true,
+        useV3: false,
+        suggestedAmounts: [{ amount: 50, label: 'Suggested', order: 1 }],
+      });
+      const label = element.querySelector('#customAmountLabelRadio');
+      const input = element.querySelector('input[name="amount"]');
+
+      expect(label).not.toBeNull();
+      expect(label.textContent.trim()).toEqual('OTHER_AMOUNT');
+      expect(input.getAttribute('aria-labelledby')).toEqual(
+        'customAmountLabelRadio',
+      );
+      expect(input.getAttribute('placeholder')).toBeNull();
     });
   });
 });

--- a/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.tpl.html
+++ b/src/app/productConfig/giftPanels/suggestedGiftAmounts/suggestedGiftAmounts.tpl.html
@@ -68,17 +68,19 @@
               type="radio"
               ng-checked="$ctrl.customInputActive"
             />
+            <span id="customAmountLabelV3" class="custom-amount-label" translate
+              >{{'OTHER_AMOUNT'}}</span
+            >
             <input
               name="amount"
               type="text"
               id="customAmount"
               step="1"
-              aria-label="{{'CUSTOM_AMOUNT' | translate}}"
+              aria-labelledby="customAmountLabelV3"
               ng-model="$ctrl.customAmount"
               ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
               ng-focus="$ctrl.customInputActive = true;"
               ng-required="$ctrl.customInputActive"
-              placeholder="{{'OTHER_PLACEHOLDER' | translate}}"
             />
           </label>
         </div>
@@ -134,22 +136,29 @@
         ng-class="{'has-error': ($ctrl.itemConfigForm.amount | showErrors)}"
       >
         <div class="form-group">
-          <label>
+          <label for="customAmountInput">
             <input
               name="suggestedAmount"
               type="radio"
               ng-checked="$ctrl.customInputActive"
             />
+            <span
+              id="customAmountLabelRadio"
+              class="custom-amount-label"
+              translate
+              >{{'OTHER_AMOUNT'}}</span
+            >
             <input
               class="form-control form-control-subtle"
               name="amount"
               type="text"
+              id="customAmountInput"
               step="1"
+              aria-labelledby="customAmountLabelRadio"
               ng-model="$ctrl.customAmount"
               ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
               ng-focus="$ctrl.customInputActive = true"
               ng-required="$ctrl.customInputActive"
-              placeholder="{{'OTHER_PLACEHOLDER' | translate}}"
             />
           </label>
           <div
@@ -213,6 +222,9 @@
         ng-class="{active: $ctrl.customInputActive}"
         class="btn btn-default-form u-textLeft custom-amount"
       >
+        <span id="customAmountLabel" class="custom-amount-label" translate
+          >{{'OTHER_AMOUNT'}}</span
+        >
         <div class="form-group form-group-default u-inline">
           <input
             class="form-control form-control-subtle number"
@@ -221,10 +233,9 @@
             step="1"
             ng-required="$ctrl.customInputActive"
             ng-model="$ctrl.customAmount"
-            aria-label="{{'CUSTOM_AMOUNT' | translate}}"
+            aria-labelledby="customAmountLabel"
             ng-change="$ctrl.changeCustomAmount($ctrl.customAmount)"
             ng-focus="$ctrl.customInputActive = true;"
-            placeholder="{{'Other' | translate}}"
             ng-attr-aria-invalid="{{$ctrl.itemConfigForm.amount | showErrors}}"
             ng-attr-aria-errormessage="{{ ($ctrl.itemConfigForm.amount | showErrors) ? 'amountErrors' : undefined }}"
             required

--- a/src/assets/scss/_gift-config.scss
+++ b/src/assets/scss/_gift-config.scss
@@ -40,6 +40,11 @@ div[data-toggle="buttons"] input[type="radio"] {
 
 label.custom-amount {
   width: auto;
+
+  .custom-amount-label {
+    margin-right: 8px;
+    white-space: nowrap;
+  }
 }
 
 .radio,
@@ -305,7 +310,7 @@ label.btn.btn-default-form.active {
   }
 
   .custom-amount {
-    width: 125px;
+    min-width: 125px;
     &:hover, .number:hover {cursor: pointer;}
 
     ::placeholder {
@@ -314,10 +319,23 @@ label.btn.btn-default-form.active {
       transition-duration: 100ms;
     }
 
+    .custom-amount-label {
+      color: $colorGrayscale-text;
+    }
+
+    input.number {
+      width: 6em;
+      text-align: left;
+    }
+
     &.active {
       background-color: $colorGrayscale-text !important;
 
       ::placeholder {
+        color: $colorCru-white;
+      }
+
+      .custom-amount-label {
         color: $colorCru-white;
       }
     }

--- a/src/assets/scss/_gift-config.scss
+++ b/src/assets/scss/_gift-config.scss
@@ -172,6 +172,25 @@ label.btn.btn-default-form.active {
   background: none;
 }
 
+.suggested-gift-amounts .custom-amount {
+  min-width: 125px;
+
+  .custom-amount-label {
+    color: $colorGrayscale-text;
+  }
+
+  input.number {
+    width: 6em;
+    text-align: left;
+  }
+
+  // The live active state (gold border, light background from the rules
+  // above) keeps the input text dark, so the label goes dark to match.
+  &.active .custom-amount-label {
+    color: $colorGrayscale-black;
+  }
+}
+
 .modal {
   position: fixed;
   z-index: 1040;
@@ -307,38 +326,6 @@ label.btn.btn-default-form.active {
   &:last-child {
     padding-bottom: 0;
     margin-bottom: 0;
-  }
-
-  .custom-amount {
-    min-width: 125px;
-    &:hover, .number:hover {cursor: pointer;}
-
-    ::placeholder {
-      color: $colorGrayscale-text;
-      transition-delay: 100ms;
-      transition-duration: 100ms;
-    }
-
-    .custom-amount-label {
-      color: $colorGrayscale-text;
-    }
-
-    input.number {
-      width: 6em;
-      text-align: left;
-    }
-
-    &.active {
-      background-color: $colorGrayscale-text !important;
-
-      ::placeholder {
-        color: $colorCru-white;
-      }
-
-      .custom-amount-label {
-        color: $colorCru-white;
-      }
-    }
   }
 }
 

--- a/src/assets/scss/_give.scss
+++ b/src/assets/scss/_give.scss
@@ -531,6 +531,10 @@ hr.horizontal-divider {
     float: none;
     vertical-align: 0%;
   }
+
+  .custom-amount-label {
+    margin-right: $gutter * 0.5;
+  }
 }
 
 .btn-xs,
@@ -633,17 +637,27 @@ hr.horizontal-divider {
 
   label {
     all: unset;
+    display: flex;
     width: 100%;
     height: 100%;
+    align-items: center;
+    cursor: pointer;
 
     input[type="radio"] {
       position: absolute;
       opacity: 0;
     }
 
+    .custom-amount-label {
+      padding: 0 5px 0 10px;
+      font-weight: normal;
+      white-space: nowrap;
+    }
+
     input[type="text"] {
-      width: 100%;
+      min-width: 0;
       height: 100%;
+      flex: 1;
       padding: 0 7px;
       border: none;
       transition: all 0.3s ease;

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -200,6 +200,7 @@ export const appConfig = /* @ngInject */ function (
       'There was an error adding this item to your account due to session data. Please re-add the item to your cart.',
     GIFT_AMOUNT: 'Gift Amount',
     OTHER_PLACEHOLDER: 'Other',
+    OTHER_AMOUNT: 'Other amount',
     GIFT_FREQUENCY: 'Gift Frequency',
     VALID_DOLLAR_AMOUNT_ERROR: 'Your gift must be a valid dollar amount',
     AMOUNT_EMPTY_ERROR: 'Amount must be not empty',
@@ -496,6 +497,7 @@ export const appConfig = /* @ngInject */ function (
       'There was an error adding this item to your account due to session data. Please re-add the item to your cart.',
     GIFT_AMOUNT: 'Selecciona Una Cantidad',
     OTHER_PLACEHOLDER: 'Otro regalo generoso',
+    OTHER_AMOUNT: 'Otra cantidad',
     GIFT_FREQUENCY: 'Frecuencia de la donación',
     VALID_DOLLAR_AMOUNT_ERROR:
       'Su regalo debe ser una cantidad válida en dólares',

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -199,7 +199,6 @@ export const appConfig = /* @ngInject */ function (
     FORCED_USER_TO_LOGOUT:
       'There was an error adding this item to your account due to session data. Please re-add the item to your cart.',
     GIFT_AMOUNT: 'Gift Amount',
-    OTHER_PLACEHOLDER: 'Other',
     OTHER_AMOUNT: 'Other amount',
     GIFT_FREQUENCY: 'Gift Frequency',
     VALID_DOLLAR_AMOUNT_ERROR: 'Your gift must be a valid dollar amount',
@@ -476,7 +475,6 @@ export const appConfig = /* @ngInject */ function (
     ADD_SPOUSE: 'Add Spouse',
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
-    CUSTOM_AMOUNT: 'Custom Amount',
   });
 
   $translateProvider.translations('es', {
@@ -496,7 +494,6 @@ export const appConfig = /* @ngInject */ function (
     FORCED_USER_TO_LOGOUT:
       'There was an error adding this item to your account due to session data. Please re-add the item to your cart.',
     GIFT_AMOUNT: 'Selecciona Una Cantidad',
-    OTHER_PLACEHOLDER: 'Otro regalo generoso',
     OTHER_AMOUNT: 'Otra cantidad',
     GIFT_FREQUENCY: 'Frecuencia de la donación',
     VALID_DOLLAR_AMOUNT_ERROR:
@@ -777,7 +774,6 @@ export const appConfig = /* @ngInject */ function (
     ADD_SPOUSE: 'Add Spouse',
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
-    CUSTOM_AMOUNT: 'Custom Amount',
   });
   $translateProvider.preferredLanguage('en');
 };


### PR DESCRIPTION
## Jira
[EP-2118](https://jira.cru.org/browse/EP-2118)

## Problem
Per the ticket, 30–50% of new donors couldn't find the "Other" amount option: it was a bare text input whose only label was a `placeholder` — which vanishes on focus, is low-contrast, and doesn't read as a peer of the suggested-amount buttons.

## Fix
All **three** template variants in `suggestedGiftAmounts.tpl.html` (default button-style, v3 $-prefixed, non-v3 radio list) now have a visible, persistent **"Other amount"** label styled consistently with the amount options:
- New `OTHER_AMOUNT` translate key in both en and es tables ("Otra cantidad"); the old placeholder relied on an `'Other'` key that never existed in either table, so this also fixes a latent untranslated-in-Spanish bug.
- Accessibility: `aria-labelledby` replaces the placeholder/aria-label as the accessible name everywhere.
- Radio variant: the label's `for` now targets the amount input (was implicitly targeting the decorative radio), so clicking the label text focuses the input and correctly drives the existing `customInputActive` wiring — fixing a latent visual-desync bug.
- Orphaned `OTHER_PLACEHOLDER`/`CUSTOM_AMOUNT` keys removed (zero remaining references).
- SCSS scoped to the live `.suggested-gift-amounts` selector (review caught that the pre-existing `.give-modal-panel .custom-amount` block was dead CSS — deleted); active-state label color matches the existing gold-border/light-background active treatment.
- Behavior/controller untouched — existing focus/radio wiring reused.

## QA note
A quick visual smoke test of the gift-config modal (default variant) at desktop and <768px is recommended, especially with the longer Spanish label.

## Tests
108/108 across `src/app/productConfig` (4 new template-render specs: label presence + aria wiring + placeholder removal per variant, plus a behavioral spec for focus → customInputActive).