### PR TITLE
EP-2114 - Warn when adding a designation already in recurring gifts

### DIFF
--- a/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/editRecurringGifts.modal.tpl.html
@@ -101,6 +101,7 @@
   <step-2-add-recent-recipients
     ng-switch-when="step2AddRecentRecipients"
     recent-recipients="$ctrl.recentRecipients"
+    recurring-gifts="$ctrl.recurringGifts"
     has-recent-recipients="$ctrl.hasRecentRecipients"
     loading-recent-recipients="$ctrl.loadingRecentRecipients"
     has-recurring-gift-changes="$ctrl.hasRecurringGiftChanges"
@@ -113,6 +114,7 @@
 
   <step-2-search-recipients
     ng-switch-when="step2SearchRecipients"
+    recurring-gifts="$ctrl.recurringGifts"
     dismiss="$ctrl.dismiss()"
     previous="$ctrl.previous()"
     next="$ctrl.next(null, null, additions)"

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import filter from 'lodash/filter';
+import some from 'lodash/some';
 
 import giftListItem from 'common/components/giftViews/giftListItem/giftListItem.component';
 
@@ -26,6 +27,15 @@ class AddRecentRecipientsController {
       additions: filter(this.recentRecipients, { _selectedGift: true }),
     });
   }
+
+  // The backend is authoritative for duplicate handling; this is only a non-blocking warning
+  isExistingRecurringGift(gift) {
+    return some(
+      this.recurringGifts,
+      (recurringGift) =>
+        recurringGift.designationNumber === gift.designationNumber,
+    );
+  }
 }
 
 export default angular
@@ -35,6 +45,7 @@ export default angular
     templateUrl: template,
     bindings: {
       recentRecipients: '<',
+      recurringGifts: '<',
       hasRecentRecipients: '<',
       loadingRecentRecipients: '<',
       hasRecurringGiftChanges: '<',

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.component.spec.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import 'angular-mocks';
 
+import RecurringGiftModel from 'common/models/recurringGift.model';
+
 import module from './addRecentRecipients.component';
 
 describe('editRecurringGiftsModal', () => {
@@ -73,6 +75,50 @@ describe('editRecurringGiftsModal', () => {
           additions: [{ _selectedGift: true }],
         });
       });
+    });
+
+    describe('isExistingRecurringGift', () => {
+      it('should return true when the recipient designation is already in the recurring gifts', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({ 'designation-number': '0123456' }),
+        ];
+
+        expect(
+          self.controller.isExistingRecurringGift({
+            designationNumber: '0123456',
+          }),
+        ).toEqual(true);
+      });
+
+      it('should return false when the recipient designation is not in the recurring gifts', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({ 'designation-number': '0123456' }),
+        ];
+
+        expect(
+          self.controller.isExistingRecurringGift({
+            designationNumber: '1234567',
+          }),
+        ).toEqual(false);
+      });
+
+      it('should return false when recurring gifts have not been loaded', () => {
+        self.controller.recurringGifts = undefined;
+
+        expect(
+          self.controller.isExistingRecurringGift({
+            designationNumber: '0123456',
+          }),
+        ).toEqual(false);
+      });
+    });
+
+    describe('component bindings', () => {
+      it('should accept the recurringGifts binding', inject(($injector) => {
+        const directive = $injector.get(`${module.name}Directive`)[0];
+
+        expect(directive.bindToController.recurringGifts).toEqual('<');
+      }));
     });
   });
 });

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/addRecentRecipients.tpl.html
@@ -47,7 +47,13 @@
           ng-repeat="gift in $ctrl.recentRecipients"
           class="row repeating-row user-profile"
         >
-          <gift-list-item gift="gift" selectable="checkbox"></gift-list-item>
+          <gift-list-item gift="gift" selectable="checkbox">
+            <span
+              class="label label-warning"
+              ng-if="$ctrl.isExistingRecurringGift(gift)"
+              >{{'ALREADY_IN_RECURRING_GIFTS' | translate}}</span
+            >
+          </gift-list-item>
         </div>
       </div>
     </div>

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.component.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.component.js
@@ -1,5 +1,7 @@
 import angular from 'angular';
+import filter from 'lodash/filter';
 import map from 'lodash/map';
+import some from 'lodash/some';
 
 import giftSearchView from 'common/components/giftViews/giftSearchView/giftSearchView.component';
 
@@ -15,6 +17,14 @@ class SearchRecipientsController {
 
   onChange(selectedRecipients) {
     this.additionalRecipients = selectedRecipients;
+    // The backend is authoritative for duplicate handling; this is only a non-blocking warning
+    this.duplicatedRecipients = filter(selectedRecipients, (gift) =>
+      some(
+        this.recurringGifts,
+        (recurringGift) =>
+          recurringGift.designationNumber === gift.designationNumber,
+      ),
+    );
   }
 
   gatherSelections() {
@@ -37,6 +47,7 @@ export default angular
     controller: SearchRecipientsController,
     templateUrl: template,
     bindings: {
+      recurringGifts: '<',
       dismiss: '&',
       previous: '&',
       next: '&',

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.component.spec.js
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.component.spec.js
@@ -29,6 +29,48 @@ describe('editRecurringGiftsModal', () => {
           'newly selected recipients',
         );
       });
+
+      it('should flag selections that are already in the recurring gifts', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({ 'designation-number': '0123456' }),
+        ];
+        self.controller.onChange([
+          { designationName: 'Name', designationNumber: '0123456' },
+          { designationName: 'Name 2', designationNumber: '1234567' },
+        ]);
+
+        expect(self.controller.duplicatedRecipients).toEqual([
+          { designationName: 'Name', designationNumber: '0123456' },
+        ]);
+      });
+
+      it('should not flag selections when none are in the recurring gifts', () => {
+        self.controller.recurringGifts = [
+          new RecurringGiftModel({ 'designation-number': '7654321' }),
+        ];
+        self.controller.onChange([
+          { designationName: 'Name', designationNumber: '0123456' },
+        ]);
+
+        expect(self.controller.duplicatedRecipients).toEqual([]);
+      });
+
+      it('should not flag selections when recurring gifts have not been loaded', () => {
+        self.controller.recurringGifts = undefined;
+        self.controller.onChange([
+          { designationName: 'Name', designationNumber: '0123456' },
+        ]);
+
+        expect(self.controller.duplicatedRecipients).toEqual([]);
+      });
+    });
+
+    describe('component bindings', () => {
+      it('should accept the recurringGifts binding', inject(($injector) => {
+        const directive = $injector.get(`${module.name}Directive`)[0];
+
+        expect(directive.bindToController.recurringGifts).toEqual('<');
+      }));
     });
 
     describe('gatherSelections', () => {

--- a/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.tpl.html
+++ b/src/app/profile/yourGiving/editRecurringGifts/step2/searchRecipients.tpl.html
@@ -29,6 +29,16 @@
           select-label="{{'Add' | translate}}"
         >
         </gift-search-view>
+        <div
+          class="alert alert-warning"
+          role="alert"
+          ng-if="$ctrl.duplicatedRecipients.length > 0"
+        >
+          <p ng-repeat="gift in $ctrl.duplicatedRecipients">
+            {{gift.designationName}} &mdash; {{'ALREADY_IN_RECURRING_GIFTS' |
+            translate}}
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/src/common/app.config.js
+++ b/src/common/app.config.js
@@ -476,6 +476,7 @@ export const appConfig = /* @ngInject */ function (
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
     CUSTOM_AMOUNT: 'Custom Amount',
+    ALREADY_IN_RECURRING_GIFTS: 'Already in your recurring gifts',
   });
 
   $translateProvider.translations('es', {
@@ -776,6 +777,7 @@ export const appConfig = /* @ngInject */ function (
     REMOVE_SPOUSE: 'Remove',
     SUGGESTED_AMOUNT_HELP: 'Suggested Gift Amounts. Tab for Custom Amount',
     CUSTOM_AMOUNT: 'Custom Amount',
+    ALREADY_IN_RECURRING_GIFTS: 'Ya está en sus donaciones recurrentes',
   });
   $translateProvider.preferredLanguage('en');
 };


### PR DESCRIPTION
## Jira
[EP-2114](https://jira.cru.org/browse/EP-2114)

## Problem
Donors can add a designation to a new recurring donation when they already give to that designation in another recurring gift. Siebel stops these by placing the gift on Hold, but the frontend gave no hint — the donor finds out via a held gift.

## Fix (non-blocking warning — backend remains authoritative)
In the "Edit my recurring donations" step 2 pickers, using a `designationNumber` intersection with the donor's existing recurring gifts (already in memory from step 1):
- **Recent recipients picker:** a per-row `label-warning` badge — "Already in your recurring gifts" — visible before selection, transcluded into `gift-list-item` (same pattern steps 1/3 already use; no shared-component changes).
- **Search picker:** results render in the shared `giftSearchView`, so instead of touching the shared component, selecting a duplicate shows an `alert-warning` listing the duplicated recipients; it clears on deselection.
- Continue is untouched — purely informational, no flow changes.
- New `ALREADY_IN_RECURRING_GIFTS` translate key in en + es.
- Handles the no-existing-gifts path safely (no badge, no errors).

## Open question for backend folks (from review)
The warning checks **active** recurring gifts only (step 1's `managerecurringdonations` list). If Siebel's duplicate/Hold logic also counts held/suspended/future gifts, the warning should be fed a wider gift-type list — easy follow-up once confirmed.

## Tests
8 new controller specs written red-first (detection logic both pickers, undefined-gifts safety, binding config). 70/70 green across the editRecurringGifts suites.